### PR TITLE
setRegenModel for BM Hunter

### DIFF
--- a/Classes/Hunter.lua
+++ b/Classes/Hunter.lua
@@ -94,110 +94,66 @@ if select( 2, UnitClass( 'player' ) ) == 'HUNTER' then
                 value = 33,
             },
             
-            dire_regen_0 = {
+            dire_frenzy_1 = {
                 resource = "focus",
 
                 spec = "beast_mastery",
-                aura = "dire_regen_0",
+                talent = "dire_frenzy",
+                aura = "dire_frenzy_1",
 
                 last = function()
-                    local app = state.buff.dire_regen_0.applied
+                    local app = state.buff.dire_frenzy_1.applied
                     local t = state.query_time
 
-                    return app + floor( t- app )
+                    return app + floor( t - app )
                 end,
 
                 interval = 2,
                 value = function()
-                    if state.talent.dire_frenzy.enabled then
-                        if state.talent.dire_stable.enabled then
-                            return 9
-                        else
-                            return 6
-                        end
+                    if state.talent.dire_stable.enabled then
+                        return 9
                     else
-                        if state.talent.dire_stable.enabled then
-                            return 6
-                        else
-                            return 3
-                        end
+                        return 6
                     end
                 end
             },
 
-            dire_regen_1 = {
+            dire_frenzy_2 = {
                 resource = "focus",
 
                 spec = "beast_mastery",
-                aura = "dire_regen_1",
+                talent = "dire_frenzy",
+                aura = "dire_frenzy_2",
 
                 last = function()
-                    local app = state.buff.dire_regen_1.applied
+                    local app = state.buff.dire_frenzy_2.applied
                     local t = state.query_time
 
-                    return app + floor( t- app )
+                    return app + floor( t - app )
                 end,
 
                 interval = 2,
                 value = function()
-                    if state.talent.dire_frenzy.enabled then
-                        if state.talent.dire_stable.enabled then
-                            return 9
-                        else
-                            return 6
-                        end
+                    if state.talent.dire_stable.enabled then
+                        return 9
                     else
-                        if state.talent.dire_stable.enabled then
-                            return 6
-                        else
-                            return 3
-                        end
+                        return 6
                     end
                 end
             },
             
-            dire_regen_2 = {
+            dire_frenzy_3 = {
                 resource = "focus",
 
                 spec = "beast_mastery",
-                aura = "dire_regen_2",
+                talent = "dire_frenzy",
+                aura = "dire_frenzy_3",
 
                 last = function()
-                    local app = state.buff.dire_regen_2.applied
+                    local app = state.buff.dire_frenzy_3.applied
                     local t = state.query_time
 
-                    return app + floor( t- app )
-                end,
-
-                interval = 2,
-                value = function()
-                    if state.talent.dire_frenzy.enabled then
-                        if state.talent.dire_stable.enabled then
-                            return 9
-                        else
-                            return 6
-                        end
-                    else
-                        if state.talent.dire_stable.enabled then
-                            return 6
-                        else
-                            return 3
-                        end
-                    end
-                end
-            },
-
-            dire_regen_3 = {
-                resource = "focus",
-
-                spec = "beast_mastery",
-                aura = "dire_regen_3",
-
-                last = function()
-                    local app = state.buff.dire_regen_3.applied
-                    local t = state.query_time
-
-                    return app + floor( t- app )
+                    return app + floor( t - app )
                 end,
 
                 interval = 2,
@@ -399,13 +355,10 @@ if select( 2, UnitClass( 'player' ) ) == 'HUNTER' then
             buff.dire_frenzy.applied = up and ( expires - duration ) or 0
             buff.dire_frenzy.caster = up and caster or "player"
         end )
-        -- fake auras for regen assumption (should we track the real auras otherwise?)
-        -- 246152 dire_frenzy regen buff (player)
-        -- 120694 dire_beast regen buff (player)
-        addAura( 'dire_regen_0', -103, 'duration', 8 )
-        addAura( 'dire_regen_1', -104, 'duration', 8 )
-        addAura( 'dire_regen_2', -105, 'duration', 8 )
-        addAura( 'dire_regen_3', -106, 'duration', 8 )
+        -- regen auras applied to player
+        addAura( 'dire_frenzy_1', 246152, 'duration', 8 )
+        addAura( 'dire_frenzy_2', 246851, 'duration', 8 )
+        addAura( 'dire_frenzy_3', 246852, 'duration', 8 )
 
         -- Gear Sets
         addGearSet( 'tier19', 138342, 138347, 138368, 138339, 138340, 138344 )
@@ -662,24 +615,6 @@ if select( 2, UnitClass( 'player' ) ) == 'HUNTER' then
 
             applyBuff( 'dire_beast' )
 
-            if buff.dire_regen_0.up then
-                if buff.dire_regen_1.up then
-                    if buff.dire_regen_2.up then
-                        if buff.dire_regen_3.up then
-                            -- should not come to this much applications
-                        else
-                            applyBuff( 'dire_regen_3' )
-                        end
-                    else
-                        applyBuff( 'dire_regen_2' )
-                    end
-                else
-                    applyBuff( 'dire_regen_1' )
-                end
-            else
-                applyBuff( 'dire_regen_0' )
-            end
-
         end )
         
     	addAbility( 'dire_frenzy', {
@@ -709,22 +644,18 @@ if select( 2, UnitClass( 'player' ) ) == 'HUNTER' then
             end
             addStack( 'dire_frenzy', 8, 1 )
 
-            if buff.dire_regen_0.up then
-                if buff.dire_regen_1.up then
-                    if buff.dire_regen_2.up then
-                        if buff.dire_regen_3.up then
-                            -- should not come to this much applications
-                        else
-                            applyBuff( 'dire_regen_3' )
-                        end
+            if buff.dire_frenzy_1.up then
+                if buff.dire_frenzy_2.up then
+                    if buff.dire_frenzy_3.up then
+                        -- don't  have more IDs
                     else
-                        applyBuff( 'dire_regen_2' )
+                        applyBuff( 'dire_frenzy_3' )
                     end
                 else
-                    applyBuff( 'dire_regen_1' )
+                    applyBuff( 'dire_frenzy_2' )
                 end
             else
-                applyBuff( 'dire_regen_0' )
+                applyBuff( 'dire_frenzy_1' )
             end
 
         end )

--- a/Classes/Hunter.lua
+++ b/Classes/Hunter.lua
@@ -93,14 +93,130 @@ if select( 2, UnitClass( 'player' ) ) == 'HUNTER' then
                 interval = 1,
                 value = 33,
             },
+            
+            dire_regen_0 = {
+                resource = "focus",
 
-            --[[ dire_frenzy_1 = {
-                resource = 'focus',
+                spec = "beast_mastery",
+                aura = "dire_regen_0",
 
-                spec = 'beast_mastery',
-                talent = 'dire_frenzy',
-                aura = 'dire_frenzy', 
-            } ]]
+                last = function()
+                    local app = state.buff.dire_regen_0.applied
+                    local t = state.query_time
+
+                    return app + floor( t- app )
+                end,
+
+                interval = 2,
+                value = function()
+                    if state.talent.dire_frenzy.enabled then
+                        if state.talent.dire_stable.enabled then
+                            return 9
+                        else
+                            return 6
+                        end
+                    else
+                        if state.talent.dire_stable.enabled then
+                            return 6
+                        else
+                            return 3
+                        end
+                    end
+                end
+            },
+
+            dire_regen_1 = {
+                resource = "focus",
+
+                spec = "beast_mastery",
+                aura = "dire_regen_1",
+
+                last = function()
+                    local app = state.buff.dire_regen_1.applied
+                    local t = state.query_time
+
+                    return app + floor( t- app )
+                end,
+
+                interval = 2,
+                value = function()
+                    if state.talent.dire_frenzy.enabled then
+                        if state.talent.dire_stable.enabled then
+                            return 9
+                        else
+                            return 6
+                        end
+                    else
+                        if state.talent.dire_stable.enabled then
+                            return 6
+                        else
+                            return 3
+                        end
+                    end
+                end
+            },
+            
+            dire_regen_2 = {
+                resource = "focus",
+
+                spec = "beast_mastery",
+                aura = "dire_regen_2",
+
+                last = function()
+                    local app = state.buff.dire_regen_2.applied
+                    local t = state.query_time
+
+                    return app + floor( t- app )
+                end,
+
+                interval = 2,
+                value = function()
+                    if state.talent.dire_frenzy.enabled then
+                        if state.talent.dire_stable.enabled then
+                            return 9
+                        else
+                            return 6
+                        end
+                    else
+                        if state.talent.dire_stable.enabled then
+                            return 6
+                        else
+                            return 3
+                        end
+                    end
+                end
+            },
+
+            dire_regen_3 = {
+                resource = "focus",
+
+                spec = "beast_mastery",
+                aura = "dire_regen_3",
+
+                last = function()
+                    local app = state.buff.dire_regen_3.applied
+                    local t = state.query_time
+
+                    return app + floor( t- app )
+                end,
+
+                interval = 2,
+                value = function()
+                    if state.talent.dire_frenzy.enabled then
+                        if state.talent.dire_stable.enabled then
+                            return 9
+                        else
+                            return 6
+                        end
+                    else
+                        if state.talent.dire_stable.enabled then
+                            return 6
+                        else
+                            return 3
+                        end
+                    end
+                end
+            }
         } )
 
 
@@ -283,6 +399,13 @@ if select( 2, UnitClass( 'player' ) ) == 'HUNTER' then
             buff.dire_frenzy.applied = up and ( expires - duration ) or 0
             buff.dire_frenzy.caster = up and caster or "player"
         end )
+        -- fake auras for regen assumption (should we track the real auras otherwise?)
+        -- 246152 dire_frenzy regen buff (player)
+        -- 120694 dire_beast regen buff (player)
+        addAura( 'dire_regen_0', -103, 'duration', 8 )
+        addAura( 'dire_regen_1', -104, 'duration', 8 )
+        addAura( 'dire_regen_2', -105, 'duration', 8 )
+        addAura( 'dire_regen_3', -106, 'duration', 8 )
 
         -- Gear Sets
         addGearSet( 'tier19', 138342, 138347, 138368, 138339, 138340, 138344 )
@@ -532,11 +655,32 @@ if select( 2, UnitClass( 'player' ) ) == 'HUNTER' then
         end)
         
         addHandler( 'dire_beast', function()
-                cooldown.bestial_wrath.expires = max( state.time, cooldown.bestial_wrath.expires - 12 )
-                if equipped.qapla_eredun_war_order then
-                    cooldown.kill_command.expires = max( state.time, cooldown.kill_command.expires - 3 )
+            cooldown.bestial_wrath.expires = max( state.time, cooldown.bestial_wrath.expires - 12 )
+            if equipped.qapla_eredun_war_order then
+                cooldown.kill_command.expires = max( state.time, cooldown.kill_command.expires - 3 )
+            end
+
+            applyBuff( 'dire_beast' )
+
+            if buff.dire_regen_0.up then
+                if buff.dire_regen_1.up then
+                    if buff.dire_regen_2.up then
+                        if buff.dire_regen_3.up then
+                            -- should not come to this much applications
+                        else
+                            applyBuff( 'dire_regen_3' )
+                        end
+                    else
+                        applyBuff( 'dire_regen_2' )
+                    end
+                else
+                    applyBuff( 'dire_regen_1' )
                 end
-            end )
+            else
+                applyBuff( 'dire_regen_0' )
+            end
+
+        end )
         
     	addAbility( 'dire_frenzy', {
             id = 217200,
@@ -564,6 +708,25 @@ if select( 2, UnitClass( 'player' ) ) == 'HUNTER' then
                 cooldown.kill_command.expires = max( state.time, cooldown.kill_command.expires - 3 )
             end
             addStack( 'dire_frenzy', 8, 1 )
+
+            if buff.dire_regen_0.up then
+                if buff.dire_regen_1.up then
+                    if buff.dire_regen_2.up then
+                        if buff.dire_regen_3.up then
+                            -- should not come to this much applications
+                        else
+                            applyBuff( 'dire_regen_3' )
+                        end
+                    else
+                        applyBuff( 'dire_regen_2' )
+                    end
+                else
+                    applyBuff( 'dire_regen_1' )
+                end
+            else
+                applyBuff( 'dire_regen_0' )
+            end
+
         end )
         
         addAbility( 'kill_command', {


### PR DESCRIPTION
Hi,

I thought I give a code example of what we discussed in the issue thread.

This is the same approach like SimC is doing that. They compressed it to a dire_regen aura and they have 10 versions of it. I capped it here to 4 versions, as it is very seldom you have more buffs there.

I tested this but this doesn't seem to work correctly, maybe you find  the mistake I'm doing? The auras seem not to apply correctly.

Additionally the IDs of the buffs you get as a player are the following:
- 246152 dire_frenzy regen buff
- 120694 dire_beast regen buff
Maybe we can use them and not the fake ID..