### PR TITLE
Melee Range is 2 yards

### DIFF
--- a/UI.lua
+++ b/UI.lua
@@ -815,7 +815,7 @@ do
 
                 if conf.range.enabled then
                     if conf.range.type == "melee" and UnitExists( "target" ) then
-                        outOfRange = ( LRC:GetRange( "target" ) or 50 ) > 7
+                        outOfRange = ( LRC:GetRange( "target" ) or 50 ) >= 2
                     elseif conf.range.type == "ability" then
                         if a.item then
                             outOfRange = UnitExists( "target" ) and UnitCanAttack( "player", "target" ) and IsItemInRange( a.item, "target" ) == false


### PR DESCRIPTION
Melee Range is actually `2` yards, not the `5` from in game tooltips (or the `7` that was in Hekili's code).

This is correct for all melee classes except Druids with Balance Affinity and Outlaw Rogues with Acrobatic Strikes.  For these, it doesn't seem to be as simple as adding 3 yards as `>= 5` yards is too short and `> 5` is too long so an ability will probably have to be checked in these circumstances.