### PR TITLE
Add visibility option for "if in combat and has a target"

### DIFF
--- a/Options.lua
+++ b/Options.lua
@@ -507,6 +507,10 @@ function Hekili:GetDefaults()
                     value = "automatic",
                 },
 
+                combatdisplay = {
+                    value = false,
+                },
+
                 cooldowns = {
                     key = "ALT-SHIFT-R",
                     value = false,
@@ -6108,6 +6112,9 @@ do
 
         if option == 'value' then
             if bind == 'pause' then self:TogglePause()
+            elseif bind == 'combatdisplay' then
+                toggle.value = val
+                self:ToggleCombatDisplay()
             elseif bind == 'mode' then toggle.value = val
             else self:FireToggle( bind ) end
 
@@ -6415,6 +6422,35 @@ do
                             },
                             order = 2,
                         }, ]]
+                    },
+                },
+
+                combatdisplay_header = {
+                    type = "header",
+                    name = "Combat Display Mode",
+                    order = 15,
+                },
+
+                combatdisplay = {
+                    type = "group",
+                    inline = true,
+                    name = "",
+                    order = 15.1,
+                    args = {
+                        desc = {
+                            type = "description",
+                            name = "|cFFFFD100Combat Display Mode|r will force the addon to hide unless you are in combat.",
+                            fontSize = "medium",
+                            width = "full",
+                            order = 1
+                        },
+
+                        value = {
+                            type = "toggle",
+                            name = "Enabled",
+                            desc = "If checked, Hekili will not show until you are in combat with an attackable target.",
+                            order = 2,
+                        },
                     },
                 },
 
@@ -8937,6 +8973,13 @@ function Hekili:TogglePause( ... )
 
 end
 
+function Hekili:ToggleCombatDisplay( ... )
+    if not self.CombatDisplay then
+        self.CombatDisplay = true
+    else
+        self.CombatDisplay = false
+    end
+end
 
 -- Key Bindings
 function Hekili:MakeSnapshot( ... )

--- a/UI.lua
+++ b/UI.lua
@@ -582,7 +582,7 @@ do
 
     
     local function CalculateAlpha( id )
-        if IsInPetBattle() or Hekili.Barber or UnitHasVehicleUI("player") or HasVehicleActionBar() or HasOverrideActionBar() or UnitOnTaxi("player") or not Hekili:IsDisplayActive( id ) then
+        if IsInPetBattle() or Hekili.Barber or UnitHasVehicleUI("player") or HasVehicleActionBar() or HasOverrideActionBar() or UnitOnTaxi("player") or not Hekili:IsDisplayActive( id ) or ( not Hekili.CombatDisplay and (not UnitCanAttack("player", "target") and not InCombatLockdown()) ) then
             return 0
         end
 
@@ -590,7 +590,7 @@ do
         local conf, mode = prof.displays[ id ], prof.toggles.mode.value
 
         local _, zoneType = IsInInstance()
-    
+
         -- Switch Type:
         --   0 = Auto - AOE
         --   1 = ST - AOE


### PR DESCRIPTION
I've added the requested feature in the below pull request. It does little more than make Hekili function similar to most combat display items in WA when combot toggles are enabled. This prevents Hekili from floating on the screen all the time, especially in cases where it is not required (shell game, runes etc).

It's default off, and leaving it off retains the old display mode.