### PR TITLE
Enable ConsolePort keybinds on queue display

### DIFF
--- a/UI.lua
+++ b/UI.lua
@@ -645,8 +645,6 @@ do
         local conf = Hekili.DB.profile.displays[ self.id ]
 
         if conf.keybindings and conf.keybindings.enabled then
-            local cPort = conf.keybindings.cPortOverride and ConsolePort ~= nil
-
             for i, b in ipairs( self.Buttons ) do
                 local r = self.Recommendations[i]
                 if r then
@@ -656,7 +654,7 @@ do
                         r.keybind = Hekili:GetBindingForAction( r.actionName, conf )
                     end
 
-                    if i == 1 or ( conf.keybindings.queued and not cPort ) then
+                    if i == 1 or conf.keybindings.queued then
                         b.Keybinding:SetText( r.keybind )
                     else
                         b.Keybinding:SetText( nil )
@@ -762,7 +760,7 @@ do
                         b.Caption:SetText(nil)
                     end
 
-                    if conf.keybindings.enabled and ( i == 1 or conf.keybindings.queued and not ( conf.keybindings.cPortOverride and ConsolePort ~= nil ) ) then
+                    if conf.keybindings.enabled and ( i == 1 or conf.keybindings.queued ) then
                         b.Keybinding:SetText( keybind )
                     else
                         b.Keybinding:SetText(nil)


### PR DESCRIPTION
This enables showing the ConsolePort keybinds on the queue display icons.  I'm not sure why this was disabled previously, but I've played many hours on a Demon Hunter using ConsolePort and this modification with no problems.