### PR TITLE
Improving Bartender 4 Support

### DIFF
--- a/Events.lua
+++ b/Events.lua
@@ -1604,40 +1604,21 @@ local function ReadKeybindings()
         wipe( v.lower )
     end
 
-    -- Bartender4 support (Originally from tanichan, improved by konstantinkoeppe)
+    -- Bartender4 support (Original from tanichan, rewritten for action bar paging by konstantinkoeppe).
     if _G["Bartender4"] then
-        local playerIsRogue = select( 2, UnitClass( "player" ) ) == "ROGUE"
+        for actionBarNumber = 1, 10 do
+            for keyNumber = 1, 12 do
+                local actionBarButtonId = (actionBarNumber - 1) * 12 + keyNumber
+                local bindingKeyName = "ACTIONBUTTON" .. keyNumber
 
-		-- Action Bar 1
-        for keyNumber = 1, 12 do
-            StoreKeybindInfo( 1, GetBindingKey( "ACTIONBUTTON" .. keyNumber ), GetActionInfo( keyNumber ) )
+                -- Action bar 1 and 7+ use bindings of action bar 1
+                if actionBarNumber > 1 and actionBarNumber <= 6 then
+                    bindingKeyName = "CLICK BT4Button" .. actionBarButtonId .. ":LeftButton"
+                end
+
+                StoreKeybindInfo( actionBarNumber, GetBindingKey( bindingKeyName ), GetActionInfo( actionBarButtonId ) )
+            end
         end
-
-		-- Action Bar 2 to 10
-		for actionBarNumber = 2, 10 do
-		
-			-- Keys 1 to 12
-			for keyNumber = 1, 12 do
-			
-				-- Calculate action bar button id
-				local actionBarButtonId = (actionBarNumber - 1) * 12 + keyNumber
-				
-				if playerIsRogue and actionBarNumber == 7 then
-					-- Rogue Stealth (Page 7 uses keybinds of bar 1)
-					StoreKeybindInfo( 7, GetBindingKey( "ACTIONBUTTON" .. keyNumber ), GetActionInfo( actionBarButtonId ) )
-				else
-					-- Default (previous logic)
-					local bt4Key = GetBindingKey( "CLICK BT4Button" .. actionBarButtonId .. ":LeftButton" )
-					local bt4Button = _G[ "BT4Button" .. actionBarButtonId ]
-
-					if bt4Button then
-						local buttonActionType, buttonActionId = GetActionInfo( actionBarButtonId )
-						StoreKeybindInfo( actionBarNumber, bt4Key, buttonActionType, buttonActionId )
-					end
-				end
-			end
-		end
-        
     else
         for i = 1, 12 do
             StoreKeybindInfo( 1, GetBindingKey( "ACTIONBUTTON" .. i ), GetActionInfo( i ) )

--- a/Events.lua
+++ b/Events.lua
@@ -1604,29 +1604,40 @@ local function ReadKeybindings()
         wipe( v.lower )
     end
 
-    -- Bartender4 support from tanichan.
+    -- Bartender4 support (Originally from tanichan, improved by konstantinkoeppe)
     if _G["Bartender4"] then
-        -- Bartender
-        local bt4Button
-        local bt4Key
-        local bt4Page
+        local playerIsRogue = select( 2, UnitClass( "player" ) ) == "ROGUE"
 
-        for i = 1, 12 do
-            StoreKeybindInfo( 1, GetBindingKey( "ACTIONBUTTON" .. i ), GetActionInfo( i ) )
+		-- Action Bar 1
+        for keyNumber = 1, 12 do
+            StoreKeybindInfo( 1, GetBindingKey( "ACTIONBUTTON" .. keyNumber ), GetActionInfo( keyNumber ) )
         end
 
-        for i = 13, 120 do 
-            bt4Key = GetBindingKey( "CLICK BT4Button" .. i .. ":LeftButton" )
-            bt4Button = _G[ "BT4Button" .. i ]
+		-- Action Bar 2 to 10
+		for actionBarNumber = 2, 10 do
+		
+			-- Keys 1 to 12
+			for keyNumber = 1, 12 do
+			
+				-- Calculate action bar button id
+				local actionBarButtonId = (actionBarNumber - 1) * 12 + keyNumber
+				
+				if playerIsRogue and actionBarNumber == 7 then
+					-- Rogue Stealth (Page 7 uses keybinds of bar 1)
+					StoreKeybindInfo( 7, GetBindingKey( "ACTIONBUTTON" .. keyNumber ), GetActionInfo( actionBarButtonId ) )
+				else
+					-- Default (previous logic)
+					local bt4Key = GetBindingKey( "CLICK BT4Button" .. actionBarButtonId .. ":LeftButton" )
+					local bt4Button = _G[ "BT4Button" .. actionBarButtonId ]
 
-            local bt4Page = 1 + math.floor( ( i - 1 ) / 12 )
-
-            if bt4Button then
-                local buttonActionType, buttonActionId = GetActionInfo( i )
-                StoreKeybindInfo( bt4Page, bt4Key, buttonActionType, buttonActionId )
-            end
-        end
-
+					if bt4Button then
+						local buttonActionType, buttonActionId = GetActionInfo( actionBarButtonId )
+						StoreKeybindInfo( actionBarNumber, bt4Key, buttonActionType, buttonActionId )
+					end
+				end
+			end
+		end
+        
     else
         for i = 1, 12 do
             StoreKeybindInfo( 1, GetBindingKey( "ACTIONBUTTON" .. i ), GetActionInfo( i ) )


### PR DESCRIPTION
Hello!

The current Bartender support doesn't handle action bar paging. This makes rogue rather strange to play because Hekili either suggests the wrong keybinds (eg. for "Garrote" when having it on different keys on the default action bar and the page it switches over to on stealth) or none at all (eg. when an ability is only on the stealth page). 

Page switching seems to be fully customizable in Bartender which unfortunately makes this rather complicated to implement properly.

I've taken a simpler approach:

By default WoW switches action bar 1 over to page 7 when going stealth. I've rewritten the portion that reads Bartenders keybinds to read keybinds from action bar 1 whenever action bar 7 is scanned. 

This appears to work fine ingame and Hekili properly switches keybinds when going stealth / leaving stealth. The downside to this approach is that it basically makes action bar 7 unavailable for normal use with Hekili.

Currently this only affects rogues. All other classes (and action bars on rogue) fall back to the previous behavior.

Please let me know what you think. I rarely work with Lua so any feedback would be appreciated! 

If desired I could try to adapt this to work with druid as well (with the same downsides of making the bars it pages to unavailable to normal use). 