### PR TITLE
Remove talent condition for Mirror Image

### DIFF
--- a/Classes/MageFrost.lua
+++ b/Classes/MageFrost.lua
@@ -1017,8 +1017,6 @@ if UnitClassBase( 'player' ) == 'MAGE' then
             startsCombat = false,
             texture = 135994,
 
-            talent = "mirror_image",
-
             handler = function ()
                 applyBuff( "mirror_image", nil, 3 )
             end,


### PR DESCRIPTION
Was just testing out frost mage and noticed Mirror Image wasn't showing up in rotation.  Frost was already updated so my guess is this might have been missed.  We're only human!