### PR TITLE
Remove Warrior's Charge and Intervene from GCD

### DIFF
--- a/Classes/WarriorArms.lua
+++ b/Classes/WarriorArms.lua
@@ -553,7 +553,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             charges = function () return talent.double_time.enabled and 2 or nil end,
             cooldown = function () return talent.double_time.enabled and 17 or 20 end,
             recharge = function () return talent.double_time.enabled and 17 or 20 end,
-            gcd = "spell",
+            gcd = "off",
 
             startsCombat = true,
             texture = 132337,
@@ -823,7 +823,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             id = 3411,
             cast = 0,
             cooldown = 30,
-            gcd = "spell",
+            gcd = "off",
             
             startsCombat = true,
             texture = 132365,

--- a/Classes/WarriorFury.lua
+++ b/Classes/WarriorFury.lua
@@ -553,7 +553,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             charges = function () return talent.double_time.enabled and 2 or nil end,
             cooldown = function () return talent.double_time.enabled and 17 or 20 end,
             recharge = function () return talent.double_time.enabled and 17 or 20 end,
-            gcd = "spell",
+            gcd = "off",
 
             startsCombat = true,
             texture = 132337,

--- a/Classes/WarriorProtection.lua
+++ b/Classes/WarriorProtection.lua
@@ -425,7 +425,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             id = 100,
             cast = 0,
             cooldown = 20,
-            gcd = "spell",
+            gcd = "off",
 
             spend = function () return -20 * ( 1 + conduit.unnerving_focus.mod * 0.01 ) end,
             spendType = "rage",
@@ -616,7 +616,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             id = 3411,
             cast = 0,
             cooldown = 30,
-            gcd = "spell",
+            gcd = "off",
             
             startsCombat = true,
             texture = 132365,


### PR DESCRIPTION
Tested both on beta and pre-patch, neither Intervene nor Charge are on GCD.