### PR TITLE
Bartender4: Map only disabled bars to bar 1 keys rather than all bars past bar 6

### DIFF
--- a/Events.lua
+++ b/Events.lua
@@ -2628,12 +2628,13 @@ local function ReadKeybindings()
     -- Bartender4 support (Original from tanichan, rewritten for action bar paging by konstantinkoeppe).
     if _G["Bartender4"] then
         for actionBarNumber = 1, 10 do
+            local bar = _G["BT4Bar" .. actionBarNumber]
             for keyNumber = 1, 12 do
                 local actionBarButtonId = (actionBarNumber - 1) * 12 + keyNumber
                 local bindingKeyName = "ACTIONBUTTON" .. keyNumber
 
-                -- Action bar 1 and 7+ use bindings of action bar 1
-                if actionBarNumber > 1 and actionBarNumber <= 6 then
+                -- If bar is disabled assume paging / stance switching on bar 1
+                if actionBarNumber > 1 and bar and not bar.disabled then
                     bindingKeyName = "CLICK BT4Button" .. actionBarButtonId .. ":LeftButton"
                 end
 


### PR DESCRIPTION
This still doesn't properly handle all BT4 state features, but covers unpaged configuration in addition to default UI style stance switching.

This fixes showing wrong keybinds for BT4 users who disable paging and use bars 7-10. [My friend ran into this problem.](https://cdn.discordapp.com/attachments/370246898990186497/774361680377020436/see.jpg)

This assumes that BT4 users who use stance-based page switching and want to use bar 1 keybinds for the stance bar don't also have the stance bar enabled separately - seems like a reasonable limitation to avoid having to parse BT4's state/paging configuration.