### PR TITLE
Add nameplate filtering cross applied to the aggro table

### DIFF
--- a/Options.lua
+++ b/Options.lua
@@ -4568,6 +4568,19 @@ do
                                     order = 1,
                                 },
 
+                                nameplatesOption = {
+                                    type = "toggle",
+                                    name = "Cross-Check Aggro Table",
+                                    desc = "If checked, the addon will only count enemies that exist on the tank aggro table. This feature should eliminate  " ..
+                                        "nameplates of other creatures that your character is not in combat with",
+                                    width = "full",
+                                    hidden = function()
+                                        return self.DB.profile.specs[ id ].nameplates == false
+                                    end,
+                                    order = 1.5,
+                                },
+
+
                                 nameplateRange = {
                                     type = "range",
                                     name = "Nameplate Detection Range",

--- a/Targets.lua
+++ b/Targets.lua
@@ -298,6 +298,11 @@ do
                         -- Always count your target.
                         if UnitIsUnit( unit, "target" ) then excluded = false end
 
+                        
+                        if spec.nameplatesOption and UnitThreatSituation('player', unit) == nil then
+                            excluded = true
+                        end
+
                         if not excluded then
                             local rate, n = Hekili:GetTTD(unit)
                             Hekili.TargetDebug = format( "%s%12s - %2d - %s - %.2f - %d\n", Hekili.TargetDebug, unit, range or 0, guid, rate or 0, n or 0 )


### PR DESCRIPTION
If a user selects the Nameplate targeting option inside of a spec, this adds another option to cross-check that unit with the threat table. This can be useful because you can have nameplates of targets which are not in combat with you.

I'm not honestly sure how accurate this is, or if it offers much benefit, but it seems intrinsically like it should.

Feel free to change the wording/labeling however you see fit.