### PR TITLE
SP - Add a condition for the dispel in pvp

### DIFF
--- a/Classes/Notes/90_Priest_Shadow.simc
+++ b/Classes/Notes/90_Priest_Shadow.simc
@@ -63,7 +63,7 @@ actions.dmg_trinkets+=/use_item,name=dreadfire_vessel
 
 ## Main APL, should cover all ranges of targets and scenarios
 actions.main+=/call_action_list,name=boon,strict=1,if=buff.boon_of_the_ascended.up
-actions.main+=/dispel_magic
+actions.main+=/dispel_magic,if=!target.is_player
 # Use Void Eruption on cooldown pooling at least 40 insanity but not if you will overcap insanity in VF. Make sure shadowfiend/mindbender and Mind Blast is on cooldown before VE. Ignore pooling restrictions if using Shadowflame Prism and Bender is out.
 actions.main=void_eruption,if=variable.pool_for_cds&(insanity>=40|pet.fiend.active&runeforge.shadowflame_prism.equipped&!cooldown.mind_blast.up&!cooldown.shadow_word_death.up)&(insanity<=85|talent.searing_nightmare.enabled&variable.searing_nightmare_cutoff)&!cooldown.fiend.up&(!cooldown.mind_blast.up|spell_targets.mind_sear>2)
 # Make sure you put up SW:P ASAP on the target if Wrathful Faerie isn't active when fighting 1-3 targets.


### PR DESCRIPTION
I was playing some BG and i saw that dispel was "spam" in the rotation.
In PVP it's better to be able to choose when to dispel and if it is appropriate to use it rather than having to spam it (when ennemies have multiples buff to dispel) without casting any offensive spell.