### PR TITLE
Primal Wrath Ticks Gained Improvement

### DIFF
--- a/Events.lua
+++ b/Events.lua
@@ -1578,6 +1578,7 @@ RegisterEvent( "PLAYER_TARGET_CHANGED", function( event )
     Hekili.ScrapeUnitAuras( "target", true )
     state.target.updated = false
 
+    ns.getNumberTargets( true )
     Hekili:ForceUpdate( event, true )
 end )
 

--- a/Targets.lua
+++ b/Targets.lua
@@ -245,10 +245,10 @@ do
     end
 
     -- New Nameplate Proximity System
-    function ns.getNumberTargets()
+    function ns.getNumberTargets( targetChanged )
         local now = GetTime()
 
-        if now - lastCycle < 0.2 then return lastCount end
+        if now - lastCycle < 0.2 and not targetChanged then return lastCount end
         lastCycle = now
 
         if now - Hekili.lastAudit > 1 then


### PR DESCRIPTION
Calculate ticks_gained_on_refresh based on actual TTD of all targets.

Limitations:
Auras are not tracked by GUID so assumptions have to be made
- Assumes X number of dots out using active_dot (same as current)
- Assumes remaining time for active dots based on previous cast or current target's remains if >0

Should be more accurate.  Especially when the primary target is about to die or otherwise mismatched TTDs.