### PR TITLE
Rushed_setup conduit fix for Rogues

### DIFF
--- a/Classes/RogueAssassination.lua
+++ b/Classes/RogueAssassination.lua
@@ -972,7 +972,7 @@ if UnitClassBase( 'player' ) == 'ROGUE' then
             cooldown = 0,
             gcd = "spell",
 
-            spend = function () return 40 * ( 1 - conduit.rushed_setup.mod * 0.01 ) end,
+            spend = function () return 40 * ( 1 + conduit.rushed_setup.mod * 0.01 ) end,
             spendType = "energy",
 
             startsCombat = true,
@@ -1114,7 +1114,7 @@ if UnitClassBase( 'player' ) == 'ROGUE' then
             cooldown = 30,
             gcd = "spell",
 
-            spend = function () return 30 * ( 1 - conduit.rushed_setup.mod * 0.01 ) end,
+            spend = function () return 30 * ( 1 + conduit.rushed_setup.mod * 0.01 ) end,
             spendType = "energy",
 
             startsCombat = false,
@@ -1328,7 +1328,7 @@ if UnitClassBase( 'player' ) == 'ROGUE' then
             cooldown = 20,
             gcd = "spell",
 
-            spend = function () return 25 * ( 1 - conduit.rushed_setup.mod * 0.01 ) end,
+            spend = function () return 25 * ( 1 + conduit.rushed_setup.mod * 0.01 ) end,
             spendType = "energy",
 
             startsCombat = true,
@@ -1503,7 +1503,7 @@ if UnitClassBase( 'player' ) == 'ROGUE' then
             cooldown = 0,
             gcd = "spell",
 
-            spend = function () return 35 * ( 1 - conduit.rushed_setup.mod * 0.01 ) end,
+            spend = function () return 35 * ( 1 + conduit.rushed_setup.mod * 0.01 ) end,
             spendType = "energy",
 
             startsCombat = true,

--- a/Classes/RogueOutlaw.lua
+++ b/Classes/RogueOutlaw.lua
@@ -717,7 +717,7 @@ if UnitClassBase( "player" ) == "ROGUE" then
             cooldown = 0,
             gcd = "spell",
 
-            spend = function () return ( talent.dirty_tricks.enabled and 0 or 40 ) * ( 1 - conduit.rushed_setup.mod * 0.01 ) end,
+            spend = function () return ( talent.dirty_tricks.enabled and 0 or 40 ) * ( 1 + conduit.rushed_setup.mod * 0.01 ) end,
             spendType = "energy",
 
             startsCombat = true,
@@ -838,7 +838,7 @@ if UnitClassBase( "player" ) == "ROGUE" then
             cooldown = 30,
             gcd = "spell",
 
-            spend = function () return 30 * ( 1 - conduit.rushed_setup.mod * 0.01 ) end,
+            spend = function () return 30 * ( 1 + conduit.rushed_setup.mod * 0.01 ) end,
             spendType = "energy",
 
             startsCombat = false,
@@ -1018,7 +1018,7 @@ if UnitClassBase( "player" ) == "ROGUE" then
             cooldown = 20,
             gcd = "spell",
             
-            spend = function () return 25 * ( 1 - conduit.rushed_setup.mod * 0.01 ) end,
+            spend = function () return 25 * ( 1 + conduit.rushed_setup.mod * 0.01 ) end,
             spendType = "energy",
             
             startsCombat = true,
@@ -1206,7 +1206,7 @@ if UnitClassBase( "player" ) == "ROGUE" then
             cooldown = 0,
             gcd = "spell",
 
-            spend = function () return ( talent.dirty_tricks.enabled and 0 or 35 ) * ( 1 - conduit.rushed_setup.mod * 0.01 ) end,
+            spend = function () return ( talent.dirty_tricks.enabled and 0 or 35 ) * ( 1 + conduit.rushed_setup.mod * 0.01 ) end,
             spendType = "energy",
 
             startsCombat = false,

--- a/Classes/RogueSubtlety.lua
+++ b/Classes/RogueSubtlety.lua
@@ -724,7 +724,7 @@ if UnitClassBase( "player" ) == "ROGUE" then
 
             spend = function () 
                 if buff.shot_in_the_dark.up then return 0 end
-                return 40 * ( ( talent.shadow_focus.enabled and ( buff.shadow_dance.up or buff.stealth.up ) ) and 0.8 or 1 ) * ( 1 - conduit.rushed_setup.mod * 0.01 )
+                return 40 * ( ( talent.shadow_focus.enabled and ( buff.shadow_dance.up or buff.stealth.up ) ) and 0.8 or 1 ) * ( 1 + conduit.rushed_setup.mod * 0.01 )
             end,
             spendType = "energy",
 
@@ -826,7 +826,7 @@ if UnitClassBase( "player" ) == "ROGUE" then
             cooldown = 30,
             gcd = "spell",
 
-            spend = function () return 30 * ( ( talent.shadow_focus.enabled and ( buff.shadow_dance.up or buff.stealth.up ) ) and 0.8 or 1 ) * ( 1 - conduit.rushed_setup.mod * 0.01 ) end,
+            spend = function () return 30 * ( ( talent.shadow_focus.enabled and ( buff.shadow_dance.up or buff.stealth.up ) ) and 0.8 or 1 ) * ( 1 + conduit.rushed_setup.mod * 0.01 ) end,
             spendType = "energy",
 
             startsCombat = false,
@@ -992,7 +992,7 @@ if UnitClassBase( "player" ) == "ROGUE" then
             cooldown = 20,
             gcd = "spell",
 
-            spend = function () return 25 * ( ( talent.shadow_focus.enabled and ( buff.shadow_dance.up or buff.stealth.up ) ) and 0.8 or 1 ) * ( 1 - conduit.rushed_setup.mod * 0.01 ) end,
+            spend = function () return 25 * ( ( talent.shadow_focus.enabled and ( buff.shadow_dance.up or buff.stealth.up ) ) and 0.8 or 1 ) * ( 1 + conduit.rushed_setup.mod * 0.01 ) end,
             spendType = "energy",
 
             toggle = "cooldowns",
@@ -1124,7 +1124,7 @@ if UnitClassBase( "player" ) == "ROGUE" then
             cooldown = 0,
             gcd = "spell",
 
-            spend = function () return 35 * ( ( talent.shadow_focus.enabled and ( buff.shadow_dance.up or buff.stealth.up ) ) and 0.8 or 1 ) * ( 1 - conduit.rushed_setup.mod * 0.01 ) end,
+            spend = function () return 35 * ( ( talent.shadow_focus.enabled and ( buff.shadow_dance.up or buff.stealth.up ) ) and 0.8 or 1 ) * ( 1 + conduit.rushed_setup.mod * 0.01 ) end,
             spendType = "energy",
 
             startsCombat = false,


### PR DESCRIPTION
The logic behind "conduit.rushed_setup" is to decrease the value (https://github.com/Hekili/hekili/blob/shadowlands/Shadowlands/SoulbindConduits.lua Line 252) so we get less energy spent. But here if we substract the already negative value we actually increase the energy cost of the spell. Here is a fix.