### PR TITLE
Rogue Conduit.nimble_fingers fix

### DIFF
--- a/Classes/RogueAssassination.lua
+++ b/Classes/RogueAssassination.lua
@@ -1619,7 +1619,6 @@ if UnitClassBase( 'player' ) == 'ROGUE' then
                 end
 
                 applyDebuff( "target", "kidney_shot", 1 + combo_points.current )
-                end
                 spend( min( talent.deeper_stratagem.enabled and 6 or 5, combo_points.current ), "combo_points" )
 
                 if talent.elaborate_planning.enabled then applyBuff( "elaborate_planning" ) end

--- a/Classes/RogueAssassination.lua
+++ b/Classes/RogueAssassination.lua
@@ -1616,10 +1616,8 @@ if UnitClassBase( 'player' ) == 'ROGUE' then
                 end
 
                 applyDebuff( "target", "kidney_shot", 1 + combo_points.current )
-                if combo_points.current == animacharged_cp then
-                    removeBuff( "echoing_reprimand_" .. combo_points.current )
                 end
-                spend( combo_points.current, "combo_points" )
+                spend( min( talent.deeper_stratagem.enabled and 6 or 5, combo_points.current ), "combo_points" )
 
                 if talent.elaborate_planning.enabled then applyBuff( "elaborate_planning" ) end
             end,

--- a/Classes/RogueAssassination.lua
+++ b/Classes/RogueAssassination.lua
@@ -234,7 +234,7 @@ if UnitClassBase( 'player' ) == 'ROGUE' then
     spec:RegisterStateExpr( "animacharged_cp", function ()
         local n = buff.echoing_reprimand.stack
         if n > 0 then return n end
-        return combo_points.max
+        return 0
     end )
 
     spec:RegisterStateExpr( "effective_combo_points", function ()

--- a/Classes/RogueAssassination.lua
+++ b/Classes/RogueAssassination.lua
@@ -1507,7 +1507,7 @@ if UnitClassBase( 'player' ) == 'ROGUE' then
             cooldown = 15,
             gcd = "spell",
 
-            spend = function () return 35 - conduit.nimble_fingers.mod end,
+            spend = function () return 35 + conduit.nimble_fingers.mod end,
             spendType = "energy",
 
             startsCombat = false,

--- a/Classes/RogueAssassination.lua
+++ b/Classes/RogueAssassination.lua
@@ -1317,7 +1317,7 @@ if UnitClassBase( 'player' ) == 'ROGUE' then
             cooldown = 30,
             gcd = "spell",
 
-            spend = function () return 20 - conduit.nimble_fingers.mod end,
+            spend = function () return 20 + conduit.nimble_fingers.mod end,
             spendType = "energy",
 
             startsCombat = false,

--- a/Classes/RogueAssassination.lua
+++ b/Classes/RogueAssassination.lua
@@ -1603,6 +1603,9 @@ if UnitClassBase( 'player' ) == 'ROGUE' then
 
             usable = function () return combo_points.current > 0 end,
             handler = function ()
+                if talent.alacrity.enabled and combo_points.current > 4 then
+                    addStack( "alacrity", 20, 1 )
+                end
                 if talent.internal_bleeding.enabled then
                     applyDebuff( "target", "internal_bleeding" )
                     debuff.internal_bleeding.pmultiplier = persistent_multiplier

--- a/Classes/RogueOutlaw.lua
+++ b/Classes/RogueOutlaw.lua
@@ -1067,8 +1067,7 @@ if UnitClassBase( "player" ) == "ROGUE" then
                 if pvptalent.control_is_king.enabled then
                     gain( 15 * combo_points.current, "energy" )
                 end
-                if combo_points.current == animacharged_cp then removeBuff( "echoing_reprimand" ) end
-                spend( combo_points.current, "combo_points" )
+                spend( min( talent.deeper_stratagem.enabled and 6 or 5, combo_points.current ), "combo_points" )
             end,
         },
 

--- a/Classes/RogueOutlaw.lua
+++ b/Classes/RogueOutlaw.lua
@@ -813,7 +813,7 @@ if UnitClassBase( "player" ) == "ROGUE" then
             cooldown = 30,
             gcd = "spell",
 
-            spend = function () return 20 - conduit.nimble_fingers.mod end,
+            spend = function () return 20 + conduit.nimble_fingers.mod end,
             spendType = "energy",
 
             startsCombat = false,

--- a/Classes/RogueOutlaw.lua
+++ b/Classes/RogueOutlaw.lua
@@ -1061,11 +1061,15 @@ if UnitClassBase( "player" ) == "ROGUE" then
 
             startsCombat = true,
             texture = 132298,
-
+                
+            usable = function() return combo_points.current > 0 end,
             handler = function ()
                 applyDebuff( "kidney_shot", 1 + combo_points.current )
+                if talent.alacrity.enabled and combo_points.current > 4 then
+                    addStack( "alacrity", 20, 1 )
+                end
                 if pvptalent.control_is_king.enabled then
-                    gain( 15 * combo_points.current, "energy" )
+                    gain( 10 * combo_points.current, "energy" )
                 end
                 spend( min( talent.deeper_stratagem.enabled and 6 or 5, combo_points.current ), "combo_points" )
             end,

--- a/Classes/RogueOutlaw.lua
+++ b/Classes/RogueOutlaw.lua
@@ -934,7 +934,7 @@ if UnitClassBase( "player" ) == "ROGUE" then
             cooldown = 15,
             gcd = "spell",
 
-            spend = function () return 35 - conduit.nimble_fingers.mod end,
+            spend = function () return 35 + conduit.nimble_fingers.mod end,
             spendType = "energy",
 
             startsCombat = false,

--- a/Classes/RogueSubtlety.lua
+++ b/Classes/RogueSubtlety.lua
@@ -1074,7 +1074,6 @@ if UnitClassBase( "player" ) == "ROGUE" then
 
                 if talent.prey_on_the_weak.enabled then applyDebuff( "target", "prey_on_the_weak" ) end
 
-                if combo_points.current == animacharged_cp then removeBuff( "echoing_reprimand" ) end
                 spend( min( talent.deeper_stratagem.enabled and 6 or 5, combo_points.current ), "combo_points" )
             end,
         },

--- a/Classes/RogueSubtlety.lua
+++ b/Classes/RogueSubtlety.lua
@@ -848,7 +848,7 @@ if UnitClassBase( "player" ) == "ROGUE" then
 
             toggle = "cooldowns",
 
-            spend = function () return ( 20 - conduit.nimble_fingers.mod ) * ( ( talent.shadow_focus.enabled and ( buff.shadow_dance.up or buff.stealth.up ) ) and 0.8 or 1 ) end,
+            spend = function () return ( 20 + conduit.nimble_fingers.mod ) * ( ( talent.shadow_focus.enabled and ( buff.shadow_dance.up or buff.stealth.up ) ) and 0.8 or 1 ) end,
             spendType = "energy",
 
             startsCombat = false,
@@ -963,7 +963,7 @@ if UnitClassBase( "player" ) == "ROGUE" then
             cooldown = 15,
             gcd = "spell",
 
-            spend = function () return ( 35 - conduit.nimble_fingers.mod ) * ( ( talent.shadow_focus.enabled and ( buff.shadow_dance.up or buff.stealth.up ) ) and 0.8 or 1 ) end,
+            spend = function () return ( 35 + conduit.nimble_fingers.mod ) * ( ( talent.shadow_focus.enabled and ( buff.shadow_dance.up or buff.stealth.up ) ) and 0.8 or 1 ) end,
             spendType = "energy",
 
             startsCombat = false,


### PR DESCRIPTION
The logic behind "conduit.nimble_fingers" is to decrease the value (https://github.com/Hekili/hekili/blob/shadowlands/Shadowlands/SoulbindConduits.lua Line 247) so we get less energy spent. But here if we substract the already negative value we actually increase the energy cost of the spell. Here is a fix.