### PR TITLE
Warrior: Fix more abilities being off-GCD

### DIFF
--- a/Classes/WarriorArms.lua
+++ b/Classes/WarriorArms.lua
@@ -542,7 +542,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             id = 18499,
             cast = 0,
             cooldown = 60,
-            gcd = "spell",
+            gcd = "off",
 
             toggle = "cooldowns",
 
@@ -584,7 +584,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             id = 1161,
             cast = 0,
             cooldown = 240,
-            gcd = "spell",
+            gcd = "off",
 
             startsCombat = true,
             texture = 132091,
@@ -683,7 +683,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             id = 197690,
             cast = 0,
             cooldown = 6,
-            gcd = "spell",
+            gcd = "off",
 
             startsCombat = false,
             texture = 132349,
@@ -858,7 +858,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             id = 190456,
             cast = 0,
             cooldown = 12,
-            gcd = "spell",
+            gcd = "off",
 
             spend = 0,
             spendType = "rage",
@@ -1087,7 +1087,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             id = 198817,
             cast = 0,
             cooldown = 25,
-            gcd = "spell",
+            gcd = "off",
 
             startsCombat = false,
             pvptalent = "sharpen_blade",
@@ -1126,7 +1126,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             id = 2565,
             cast = 0,
             cooldown = 16,
-            gcd = "spell",
+            gcd = "off",
 
             spend = 30,
             spendType = "rage",
@@ -1251,7 +1251,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             id = 355,
             cast = 0,
             cooldown = 8,
-            gcd = "spell",
+            gcd = "off",
 
             startsCombat = true,
             texture = 136080,

--- a/Classes/WarriorFury.lua
+++ b/Classes/WarriorFury.lua
@@ -543,7 +543,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             id = 18499,
             cast = 0,
             cooldown = 60,
-            gcd = "spell",
+            gcd = "off",
 
             toggle = "cooldowns",
 
@@ -754,7 +754,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             id = 184364,
             cast = 0,
             cooldown = function () return 120 - conduit.stalwart_guardian.mod * 0.001 end,
-            gcd = "spell",
+            gcd = "off",
 
             toggle = "defensives",
 
@@ -817,7 +817,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             id = 190456,
             cast = 0,
             cooldown = 12,
-            gcd = "spell",
+            gcd = "off",
 
             toggle = "defensives",
 
@@ -912,7 +912,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             id = 6552,
             cast = 0,
             cooldown = 15,
-            gcd = "spell",
+            gcd = "off",
 
             startsCombat = true,
             texture = 132938,
@@ -1119,7 +1119,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             id = 355,
             cast = 0,
             cooldown = 8,
-            gcd = "spell",
+            gcd = "off",
 
             startsCombat = true,
             texture = 136080,

--- a/Classes/WarriorProtection.lua
+++ b/Classes/WarriorProtection.lua
@@ -448,7 +448,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             id = 18499,
             cast = 0,
             cooldown = 60,
-            gcd = "spell",
+            gcd = "off",
 
             defensive = true,
 
@@ -465,7 +465,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             id = 1161,
             cast = 0,
             cooldown = 240,
-            gcd = "spell",
+            gcd = "off",
 
             toggle = "cooldowns",
 
@@ -724,7 +724,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             id = 12975,
             cast = 0,
             cooldown = function () return talent.bolster.enabled and 120 or 180 end,
-            gcd = "spell",
+            gcd = "off",
 
             toggle = "defensives",
             defensive = true,
@@ -918,7 +918,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             charges = function () if legendary.unbreakable_will.enabled then return 2 end end,
             cooldown = function () return 240 - conduit.stalwart_guardian.mod * 0.002 end,
             recharge = function () return 240 - conduit.stalwart_guardian.mod * 0.002 end,
-            gcd = "spell",
+            gcd = "off",
 
             toggle = "defensives",
             defensive = true,
@@ -993,7 +993,7 @@ if UnitClassBase( 'player' ) == 'WARRIOR' then
             id = 355,
             cast = 0,
             cooldown = 8,
-            gcd = "spell",
+            gcd = "off",
 
             startsCombat = true,
             texture = 136080,


### PR DESCRIPTION
Tested on 9.2.5:
- Berserker Rage
- Challenging Shout
- Defensive Stance
- Enraged Regeneration
- Ignore Pain
- Last Stand
- Pummel
- Sharpen Blade
- Shield Block
- Shield Wall
- Taunt