### PR TITLE
Fixed syntaxis typo in use_items

### DIFF
--- a/Classes.lua
+++ b/Classes.lua
@@ -2615,7 +2615,7 @@ do
         name = "|cff00ccff[Use Items]|r",
         cast = 0,
         cooldown = 120,
-        gcd = 'off',
+        gcd = "off",
     } )
 
 
@@ -2623,7 +2623,7 @@ do
         name = "|cff00ccff[Heart Essence]|r",
         cast = 0,
         cooldown = 0,
-        gcd = 'off',
+        gcd = "off",
 
         item = 158075,
         essence = true,


### PR DESCRIPTION
I believe this is the reason behind cache_of_acquired_treasures trinket still has GCD recommendation despite it should be used off GCD.
EDIT: No. It did not fix that issue but still i believe there is a typo that should be fixed for probable future interactions