### PR TITLE
Change LDB type to "data source"

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -87,7 +87,7 @@ function Hekili:OnInitialize()
     local LDBIcon = LDB and LibStub( "LibDBIcon-1.0", true )
     if LDB then
         ns.UI.Minimap = ns.UI.Minimap or LDB:NewDataObject( "Hekili", {
-            type = "launcher",
+            type = "data source",
             text = "Hekili",
             icon = "Interface\\ICONS\\spell_nature_bloodlust",
             OnClick = function( f, button )


### PR DESCRIPTION
As per the docs at https://github.com/tekkub/libdatabroker-1-1/wiki/data-specifications
LDB addons which provide data display should use "data source",
this fixes StatBlockCore (and possibly other LDB displays) not
giving updates when turning Hekili features on/off.

Tested with Bazooka and StatBlockCore.