### PR TITLE
Fix visibility not updating after combat ends

### DIFF
--- a/Events.lua
+++ b/Events.lua
@@ -967,6 +967,7 @@ RegisterEvent( "PLAYER_REGEN_ENABLED", function ()
     C_Timer.After( 10, function () ns.Audit( "combatExit" ) end )
     Hekili:ReleaseHolds( true )
     Hekili:ExpireTTDs( true )
+    Hekili:UpdateDisplayVisibility()
 end )
 
 


### PR DESCRIPTION
When combat ends, the visibility of the Hekili frames is not correctly updated and can remain visible until another event triggers the visibility.

Technical details: `PLAYER_REGEN_ENABLED` event is triggered on combat end. Normally this would set `state.combat` to `0`, and would cause the `UpdateAlpha()` for individual frames to hide the frame (assuming the proper settings).

The problem is in the order of operations. In `UI.lua`, `d:OnEvent( event, ... )` for `PLAYER_REGEN_ENABLED` actually triggers before the registered handler in `Events.lua`. So the order currently looks like this:

1. `PLAYER_REGEN_ENABLED` is triggered.
2. `UI.lua` `d:OnEvent( event, ... )` is called.
3. `PLAYER_REGEN_ENABLED` is in `alphaUpdateEvents[]`, so `self:UpdateAlpha()` is called.
4. `CalculateAlpha()` is called.
5. `state.combat > 0`, so configured alpha setting is returned.
6. Alpha is set to configured alpha setting and remains visible.
7. `Events.lua` handler for `PLAYER_REGEN_ENABLED` is called.
8. `state.combat` is set to 0.

This is just a simple change to call `Hekili:UpdateDisplayVisibility()` after setting `state.combat = 0` so the appropriate alpha changes take effect immediately.