### PR TITLE
Wyste df/warriorfury_1_build_45570

### DIFF
--- a/Dragonflight/WarriorFury.lua
+++ b/Dragonflight/WarriorFury.lua
@@ -9,7 +9,62 @@ local class, state = Hekili.Class, Hekili.State
 
 local spec = Hekili:NewSpecialization( 72 )
 
-spec:RegisterResource( Enum.PowerType.Rage )
+local base_rage_gen, fury_rage_mult = 1.75, 1.00
+local offhand_mod = 0.50
+
+spec:RegisterResource( Enum.PowerType.Rage, {
+    mainhand_fury = {
+        swing = "mainhand",
+
+        last = function ()
+            local swing = state.swings.mainhand
+            local t = state.query_time
+
+            return swing + floor( ( t - swing ) / state.swings.mainhand_speed ) * state.swings.mainhand_speed
+        end,
+
+        interval = "mainhand_speed",
+
+        stop = function () return state.time == 0 or state.swings.mainhand == 0 end,
+        value = function ()
+            return ( state.talent.war_machine.enabled and 1.2 or 1 ) * base_rage_gen * fury_rage_mult * state.swings.mainhand_speed / state.haste
+        end
+    },
+
+    offhand_fury = {
+        swing = "offhand",
+
+        last = function ()
+            local swing = state.swings.offhand
+            local t = state.query_time
+
+            return swing + floor( ( t - swing ) / state.swings.offhand_speed ) * state.swings.offhand_speed
+        end,
+
+        interval = "offhand_speed",
+
+        stop = function () return state.time == 0 or state.swings.offhand == 0 end,
+        value = function ()
+            return ( state.talent.war_machine.enabled and 1.2 or 1 ) * base_rage_gen * fury_rage_mult * state.swings.offhand_speed * offhand_mod / state.haste
+        end,
+    },
+
+    battle_trance = {
+        aura = "battle_trance",  -- PVP Talent
+
+        last = function ()
+            local app = state.buff.battle_trance.applied
+            local t = state.query_time
+
+            return app + floor( ( t - app ) / 3 ) * 3
+        end,
+
+        interval = 3,
+
+        value = 5,
+    },
+
+} )
 
 -- Talents
 spec:RegisterTalents( {
@@ -139,23 +194,79 @@ spec:RegisterPvpTalents( {
 
 -- Auras
 spec:RegisterAuras( {
+    annihilator = {
+        id = 383915,
+        duration = 12,
+        max_stack = 5,
+    },
+    ashen_juggernaut = {
+        id = 392537,
+        duration = 12,
+        max_stack = 5,
+    },
     avatar = {
         id = 107574,
+        duration = 20,
+        max_stack = 1,
+    },
+	battle_shout = {
+        id = 6673,
+        duration = 3600,
+        max_stack = 1,
+        shared = "player", -- check for anyone's buff on the player.
     },
     berserker_rage = {
         id = 18499,
+        duration = 6,
+        type = "",
+        max_stack = 1,
+    },
+    berserker_stance = {
+ 		id = 386196,
     },
     berserker_shout = {
         id = 384100,
+        duration = 6,
+        type = "",
+        max_stack = 1,
+    },
+    bloodcraze = {
+        id = 23881,
+        duration = 20,
+        max_stack = 3,
     },
     bloodrage = {
         id = 329038,
+        duration = 4,
+        max_stack = 1
     },
     bloodthirst = {
         id = 23881,
     },
+    bounding_stride = {
+        id = 202164,
+        duration = 3,
+        max_stack = 1,
+    },
+    charge = {
+        id = 105771,
+        duration = 1,
+        max_stack = 1,
+    },
+    concussive_blows = {
+        id = 383116,
+        duration = 10,
+        max_stack = 1,
+    },
+	dancing_blades = {
+	    id = 391683,
+	    duration = 10,
+	    max_stack = 1,
+    },
     death_wish = {
         id = 199261,
+        duration = 15,
+        max_stack = 10,
     },
     defensive_stance = {
         id = 386208,
@@ -164,13 +275,52 @@ spec:RegisterAuras( {
         id = 231842,
     },
     enrage = {
-        id = 184361,
+        id = 184362,
+        duration = function () return 4 + ( talent.pulverize.enabled and 1 or 0 ) end,
+        max_stack = 1,
     },
     enraged_regeneration = {
         id = 184364,
+        duration = function () return 8 + ( 8 * (talent.invigorating_fury.enabled and 0.25 or 0 ) ) end,
+        max_stack = 1,
+    },
+    frenzy = {
+        id = 335082,
+        duration = 12,
+        max_stack = 4,
+    },
+    gushing_wound = {
+        id = 385042,
+        duration = 6,
+        max_stack = 1,
+    },
+    hamstring= {
+        id = 1715,
+        duration = 15,
+        max_stack = 1,
+    },
+    hurricane = {
+        id = 390581,
+        duration = 6,
+        max_stack = 6,
+    },
+	intimidating_shout = {
+        id = 5246,
+        duration = 8,
+        max_stack = 1,
     },
     mastery_unshackled_fury = {
         id = 76856,
+    },
+    odyns_fury = {
+        id = 385060,
+        duration = 4,
+        max_stack = 1,
+    },
+    piercing_howl = {
+        id = 12323,
+        duration = 8,
+        max_stack = 1,
     },
     raging_blow = {
         id = 85288,
@@ -178,16 +328,168 @@ spec:RegisterAuras( {
     ravager = {
         id = 228920,
     },
+    rallying_cry = {
+        id = 97463,
+        duration = function () return 10 * ( 10 * (talent.inspiring_presence.enabled and 0.25 or 0 ) ) end,
+        max_stack = 1,
+    },
     recklessness = {
         id = 1719,
+	    duration = function () return 12 + ( talent.depths_of_insanity.enabled and 4 or 0 ) end,
+        max_stack = 1,
+    },
+    shockwave = {
+        id = 46968,
+        duration = 2,
+        max_stack = 1,
+    },
+    slaughtering_strikes = { 
+        id = 85288, -- Labeled as Raging blow in WowHead, but Slaughtering Strikes talent triggers this
+        duration = 12,
+        max_stack = 5,
     },
     spell_reflection = {
         id = 23920,
+        duration = 5,
+        max_stack = 1,
+    },
+    storm_bolt = {
+        id = 107570,
+        duration = 4,
+        max_stack = 1,
+    },
+    sudden_death = {
+        id = 280776,
+        duration = 10,
+        max_stack = 1,
+    },
+    taunt = {
+        id = 355,
+        duration = 3,
+        max_stack = 1,
+    },
+    thunder_clap = {
+        id = 6343,
+        duration = 10,
+        max_stack = 1,
+    },
+    thunderous_roar = {
+        id = 384318,
+        duration = function () return 8 + ( talent.thunderous_words.enabled and 2 or 0 ) end,
+        max_stack = 1,
     },
     titans_grip = {
         id = 46917,
     },
+    victorious = {
+        id = 32216,
+        duration = 20,
+        max_stack = 1,
+    },
+    whirlwind = {
+        id = 85739,
+        duration = 20,
+        max_stack = function () return talent.meat_cleaver.enabled and 4 or 2 end,
+    },
 } )
+
+local whirlwind_consumers = {
+    bloodthirst       = 1, -- talent
+    impending_victory = 1, -- talent
+    onslaught         = 1, -- talent
+    raging_blow       = 1, -- talent
+    rampage           = 1, -- talent
+    execute           = 1, -- baseline
+    hamstring         = 1, -- baseline
+    slam              = 1, -- baseline
+    victory_rush      = 1, -- baseline
+}
+
+local whirlwind_gained = 0
+local whirlwind_stacks = 0
+
+local rageSpent = 0
+-- local gloryRage = 0 -- Shadowlands Covenant ability
+
+local fresh_meat_actual = {}
+local fresh_meat_virtual = {}
+
+spec:RegisterCombatLogEvent( function(  _, subtype, _, sourceGUID, sourceName, _, _, destGUID, destName, destFlags, _, spellID, spellName ) --#TODO: DF CHECK
+
+    if sourceGUID == state.GUID then
+        if subtype == "SPELL_CAST_SUCCESS" then
+            local ability = class.abilities[ spellID ]
+
+            if not ability then return end
+
+            -- Whirlwind Stack tracking
+            if ability.key == "whirlwind" then
+                whirlwind_gained = GetTime()
+                whirlwind_stacks = state.talent.meat_cleaver.enabled and 4 or 2 -- #TODO: DF CHECK
+            elseif whirlwind_consumers[ ability.key ] and whirlwind_stacks > 0 then
+                whirlwind_stacks = whirlwind_stacks - 1
+            end
+
+        -- FRESH MEAT Talent tracking 
+        elseif state.talent.fresh_meat.enabled and spellID == 23881 and subtype == "SPELL_DAMAGE" and not fresh_meat_actual[ destGUID ] and UnitGUID( "target" ) == destGUID then
+            fresh_meat_actual[ destGUID ] = true
+        end
+    end
+end )
+
+spec:RegisterStateExpr( "rage_spent", function()
+    return rageSpent
+end )
+
+local wipe = table.wipe
+
+spec:RegisterHook( "spend", function( amt, resource )
+    if resource == "rage" then
+        if talent.recklessness.enabled then
+            rage_spent = rage_spent + amt
+            cooldown.recklessness.expires = cooldown.recklessness.expires - floor( rage_spent / 20 )
+            rage_spent = rage_spent % 20
+        end
+
+        if legendary.glory.enabled and buff.conquerors_banner.up then
+            glory_rage = glory_rage + amt
+            local reduction = floor( glory_rage / 20 ) * 0.5
+            glory_rage = glory_rage % 20
+
+            buff.conquerors_banner.expires = buff.conquerors_banner.expires + reduction
+        end
+    end
+end )
+
+
+spec:RegisterHook( "reset_precast", function ()
+    rage_spent = nil
+
+    -- BladeStorm doesn't exist for fury anymore in DF.
+    --if buff.bladestorm.up and buff.gathering_storm.up then
+    --    applyBuff( "gathering_storm", buff.bladestorm.remains + 6, 5 )
+    --end
+
+    if buff.whirlwind.up then
+        if whirlwind_stacks == 0 then removeBuff( "whirlwind" )
+        elseif whirlwind_stacks < buff.whirlwind.stack then
+            applyBuff( "whirlwind", buff.whirlwind.remains, whirlwind_stacks )
+        end
+    end
+
+    wipe( fresh_meat_virtual )
+    active_dot.hit_by_fresh_meat = 0
+
+    for k, v in pairs( fresh_meat_actual ) do
+        fresh_meat_virtual[ k ] = v
+
+        if k == target.unit then
+            applyDebuff( "target", "hit_by_fresh_meat" )
+        else
+            active_dot.hit_by_fresh_meat = active_dot.hit_by_fresh_meat + 1
+        end
+    end
+end )
 
 
 -- Abilities
@@ -199,12 +501,15 @@ spec:RegisterAbilities( {
         gcd = "off",
 
         talent = "avatar",
+        spend = -20,
+        spendType = "rage",        
         startsCombat = false,
         texture = 613534,
 
         toggle = "cooldowns",
 
         handler = function ()
+            applyBuff( "avatar" )
         end,
     },
 
@@ -218,7 +523,11 @@ spec:RegisterAbilities( {
         startsCombat = false,
         texture = 132333,
 
+        essential = true,
+        nobuff = "battle_shout",
+
         handler = function ()
+            applyBuff( "battle_shout" )
         end,
     },
 
@@ -236,6 +545,7 @@ spec:RegisterAbilities( {
         toggle = "cooldowns",
 
         handler = function ()
+            applyBuff( "berserker_rage" )
         end,
     },
 
@@ -253,6 +563,7 @@ spec:RegisterAbilities( {
         toggle = "cooldowns",
 
         handler = function ()
+            applyBuff( "berserker_shout" )
         end,
     },
 
@@ -268,6 +579,8 @@ spec:RegisterAbilities( {
         texture = 132275,
 
         handler = function ()
+            applyBuff( "berzerker_stance" )
+            removeBuff( "defensive_stance" )
         end,
     },
 
@@ -285,10 +598,48 @@ spec:RegisterAbilities( {
         toggle = "cooldowns",
 
         handler = function ()
+            gain( health.max * 0.20 , "health" )
         end,
     },
+    bloodbath = {
+        id = 335096,
+        known = 23881,
+        cast = 0,
+        cooldown = 3,
+        gcd = "spell",
+        hasteCD = true,
 
+        spend = function () return ( (talent.cold_steel_hot_blood.enabled and stat.crit >= 100) and -4 or 0 ) - 8 end,
+        spendType = "rage",
 
+        cycle = function () return talent.fresh_meat.enabled and "hit_by_fresh_meat" or nil end,
+
+        startsCombat = true,
+        texture = 236304,
+
+        bind = "bloodthirst",
+        talent = "reckless_abandon",
+        buff = "recklessness",
+               
+        
+        handler = function ()
+            gain( health.max * ( buff.enraged_regeneration.up and 0.23 or 0.03 ), "health" )
+
+            --removeBuff( "bloody_rage" ) --#TODO: Verify if DF removed bloody_rage ?? 
+            removeStack( "whirlwind" )
+
+            if talent.cold_steel_hot_blood.enabled and stat.crit >= 100 then
+                -- Gain 4 rage when talented in cold steel, hot blood and critical strike occurs
+                applyDebuff( "target", "gushing_wound" )
+                gain( 4, "rage" )
+            end
+
+            if talent.fresh_meat.enabled and debuff.hit_by_fresh_meat.down then
+                applyBuff( "enrage" )
+                applyDebuff( "target", "hit_by_fresh_meat" )
+            end
+        end,
+    },
     bloodrage = {
         id = 329038,
         cast = 0,
@@ -303,6 +654,7 @@ spec:RegisterAbilities( {
         texture = 132277,
 
         handler = function ()
+            applyBuff( "bloodrage" )
         end,
     },
 
@@ -310,34 +662,94 @@ spec:RegisterAbilities( {
     bloodthirst = {
         id = 23881,
         cast = 0,
-        cooldown = 4.5,
+        cooldown = function() return (4.5 - (talent.deft_experience.rank * 0.75 ) ) end,
+        hasteCD = true,
         gcd = "spell",
 
+        spend = function () return ( (talent.cold_steel_hot_blood.enabled and stat.crit >= 100) and -4 or 0 ) - 8 end,
+        spendType = "rage",
+
+        cycle = function () return talent.fresh_meat.enabled and "hit_by_fresh_meat" or nil end,
+
         talent = "bloodthirst",
-        startsCombat = false,
+        startsCombat = true,
         texture = 136012,
 
+        bind = "bloodthirst",
+        
         handler = function ()
+            gain( health.max * ( buff.enraged_regeneration.up and 0.23 or 0.03 ), "health" )
+
+            removeStack( "whirlwind" )
+
+            if talent.cold_steel_hot_blood.enabled and stat.crit >= 100 then
+                -- Gain 4 rage when talented in cold steel, hot blood and critical strike occurs
+                applyDebuff( "target", "gushing_wound" )
+                gain( 4, "rage" )
+            end
+
+            if talent.fresh_meat.enabled and debuff.hit_by_fresh_meat.down then
+                applyBuff( "enrage" )
+                applyDebuff( "target", "hit_by_fresh_meat" )
+            end
+
         end,
+
+        auras = {
+            hit_by_fresh_meat = {
+                duration = 3600,
+                max_stack = 1,
+            }
+        },
     },
-
-
     charge = {
         id = 100,
         cast = 0,
-        charges = 1,
-        cooldown = 20,
-        recharge = 20,
+        charges = function () return talent.double_time.enabled and 2 or nil end,
+        cooldown = function () return talent.double_time.enabled and 17 or 20 end,
+        recharge = function () return talent.double_time.enabled and 17 or 20 end,
         gcd = "spell",
 
         startsCombat = true,
         texture = 132337,
 
+        usable = function () return target.distance > 10 and ( query_time - action.charge.lastCast > gcd.execute ) end,
         handler = function ()
+            applyDebuff( "target", "charge" )
+            setDistance( 5 )
         end,
     },
+    crushing_blow = {
+        id = 335097,
+        cast = 0,
+        charges = function () 
+            return (
+                (talent.raging_blow.enabled and 1 or 0)
+                +
+                (talent.improved_raging_blow.enabled and 1 or 0)
+                +
+                (talent.raging_armaments.enabled and 1 or 0)
+            ) end,
+        cooldown = 8,
+        recharge = 8,
+        gcd = "spell",
+        hasteCD = true,
 
+        spend = -12,
+        spendType = "rage",
 
+        startsCombat = true,
+        texture = 132215,
+
+        bind = "raging_blow",
+        talent = "reckless_abandon",
+        buff = "recklessness",
+
+        handler = function ()
+            removeStack( "whirlwind" )
+            if talent.reckless_abandon.enabled then spendCharges( "raging_blow", 1 ) end
+        end,
+    },
     death_wish = {
         id = 199261,
         cast = 0,
@@ -352,6 +764,7 @@ spec:RegisterAbilities( {
         texture = 136146,
 
         handler = function ()
+            addStack( "death_wish", nil, 1 )
         end,
     },
 
@@ -367,6 +780,8 @@ spec:RegisterAbilities( {
         texture = 132341,
 
         handler = function ()
+            apllyBuff( "defensive_stance" )
+            removeBuff( "berserker_stance" )
         end,
     },
 
@@ -396,9 +811,10 @@ spec:RegisterAbilities( {
         startsCombat = false,
         texture = 132345,
 
-        toggle = "cooldowns",
+        toggle = "defensives",
 
         handler = function ()
+            applyBuff( "enraged_regeneration" )
         end,
     },
 
@@ -408,11 +824,18 @@ spec:RegisterAbilities( {
         cast = 0,
         cooldown = 6,
         gcd = "spell",
-
-        startsCombat = false,
+        hasteCD = true,
+        
+        spend = function() return talent.improved_execute.enabled and -20 or 0 end,
+        spendType = "rage",
+        
+        startsCombat = true,
         texture = 135358,
 
+        usable = function () return buff.sudden_death.up or target.health.pct < (talent.massacre.enabled and 35 or 20 ) end,
         handler = function ()
+            if buff.sudden_death.up then removeBuff( "sudden_death" ) end
+            removeStack( "whirlwind" )
         end,
     },
 
@@ -430,6 +853,7 @@ spec:RegisterAbilities( {
         texture = 132316,
 
         handler = function ()
+            applyDebuff( "hamstring" )
         end,
     },
 
@@ -438,15 +862,18 @@ spec:RegisterAbilities( {
         id = 6544,
         cast = 0,
         charges = 1,
-        cooldown = 45,
-        recharge = 45,
+        cooldown = function () return 45 - ( talent.bounding_stride.enabled and 15 or 0 ) + ( talent.wrenching_impact.enabled and 45 or 0 ) end,
+        recharge = function () return 45 - ( talent.bounding_stride.enabled and 15 or 0 ) + ( talent.wrenching_impact.enabled and 45 or 0 ) end,
         gcd = "spell",
 
         talent = "heroic_leap",
-        startsCombat = false,
+        startsCombat = true,
         texture = 236171,
 
+        usable = function () return ( query_time - action.heroic_leap.lastCast > gcd.execute ) end,
         handler = function ()
+            setDistance( 15 ) -- probably heroic_leap + charge combo.
+            if talent.bounding_stride.enabled then applyBuff( "bounding_stride" ) end
         end,
     },
 
@@ -475,10 +902,12 @@ spec:RegisterAbilities( {
         spendType = "rage",
 
         talent = "impending_victory",
-        startsCombat = false,
+        startsCombat = true,
         texture = 589768,
 
         handler = function ()
+            gain( health.max * 0.3, "health" )
+            removeStack( "whirlwind" )
         end,
     },
 
@@ -505,12 +934,13 @@ spec:RegisterAbilities( {
         gcd = "spell",
 
         talent = "intimidating_shout",
-        startsCombat = false,
+        startsCombat = true,
         texture = 132154,
 
         toggle = "cooldowns",
 
         handler = function ()
+            applyDebuff( "target", "intimidating_shout" )
         end,
     },
 
@@ -522,10 +952,13 @@ spec:RegisterAbilities( {
         gcd = "spell",
 
         talent = "odyns_fury",
-        startsCombat = false,
+        startsCombat = true,
         texture = 1278409,
 
         handler = function ()
+            applyDebuff( "target", "odyns_fury" )
+            active_dot.odyns_fury = max( active_dot.odyns_fury, active_enemies )
+            applyBuff( "dancing_blades" )
         end,
     },
 
@@ -534,27 +967,20 @@ spec:RegisterAbilities( {
         id = 315720,
         cast = 0,
         cooldown = 18,
+        hasteCD = true,
         gcd = "spell",
 
+        spend = -20,
+        spendType = "rage",
+        
         talent = "onslaught",
-        startsCombat = false,
+        startsCombat = true,
         texture = 132364,
 
+        buff = "enrage",
+        
         handler = function ()
-        end,
-    },
-
-
-    ph_pocopoc_zone_ability_skill = {
-        id = 363942,
-        cast = 0,
-        cooldown = 0,
-        gcd = "off",
-
-        startsCombat = false,
-        texture = 4239318,
-
-        handler = function ()
+            removeStack( "whirlwind" )
         end,
     },
 
@@ -570,6 +996,7 @@ spec:RegisterAbilities( {
         texture = 136147,
 
         handler = function ()
+            applyDebuff( "target", "piercing_howl" )
         end,
     },
 
@@ -577,13 +1004,20 @@ spec:RegisterAbilities( {
     pummel = {
         id = 6552,
         cast = 0,
-        cooldown = 15,
+        cooldown = function() return 15 - ( talent.concussive_blows.enabled and 1 or 0 ) end,
         gcd = "off",
 
         startsCombat = true,
         texture = 132938,
 
+        toggle = "interrupts",
+        
+        debuff = "casting",
+        readyTime = state.timeToInterrupt,
+
         handler = function ()
+            interrupt()
+            if talent.concussive_blows.enabled then applyDebuff( "concussive_blows" ) end
         end,
     },
 
@@ -591,16 +1025,34 @@ spec:RegisterAbilities( {
     raging_blow = {
         id = 85288,
         cast = 0,
-        charges = 1,
-        cooldown = 7.557,
-        recharge = 7.557,
+        charges = function () 
+            return (
+                (talent.raging_blow.enabled and 1 or 0)
+                +
+                (talent.improved_raging_blow.enabled and 1 or 0)
+                +
+                (talent.raging_armaments.enabled and 1 or 0)
+            ) end,
+        cooldown = 8,
+        recharge = 8,
         gcd = "spell",
+        bind = "crushing_blow",
 
+        notalent = "annihilator",
         talent = "raging_blow",
-        startsCombat = false,
+        startsCombat = true,
         texture = 589119,
 
+        readyTime = function ()
+            if talent.reckless_abandon.enabled then return buff.recklessness.remains end
+            return 0
+        end,
+        
         handler = function ()
+            removeStack( "whirlwind" )
+            if talent.swift_strikes.enabled then gain( 1 * talent.swift_strikes.rank, "rage" ) end
+            if talent.reckless_abandon.enabled then spendCharges( "crushing_blow", 1 ) end
+            if talent.slaughtering_strikes.enabled then addStack( "slaughtering_strikes" , nil, 1) end
         end,
     },
 
@@ -615,9 +1067,10 @@ spec:RegisterAbilities( {
         startsCombat = false,
         texture = 132351,
 
-        toggle = "cooldowns",
+        toggle = "defensives",
 
         handler = function ()
+            applyBuff( "rallying_cry" )
         end,
     },
 
@@ -632,10 +1085,14 @@ spec:RegisterAbilities( {
         spendType = "rage",
 
         talent = "rampage",
-        startsCombat = false,
+        startsCombat = true,
         texture = 132352,
 
         handler = function ()
+            if talent.frenzy.enabled then addStack( "frenzy", nil, 1 ) end
+            applyBuff( "enrage" )
+            removeStack( "whirlwind" )
+            removeBuff( "slaughtering_strikes" )
         end,
     },
 
@@ -643,13 +1100,13 @@ spec:RegisterAbilities( {
     ravager = {
         id = 228920,
         cast = 0,
-        charges = 1,
+        charges = function() return 1 + (talent.storm_of_steel and 1 or 0) end,
         cooldown = 90,
         recharge = 90,
         gcd = "spell",
 
         talent = "ravager",
-        startsCombat = false,
+        startsCombat = true,
         texture = 970854,
 
         toggle = "cooldowns",
@@ -672,6 +1129,10 @@ spec:RegisterAbilities( {
         toggle = "cooldowns",
 
         handler = function ()
+            applyBuff( "recklessness" )
+            if talent.reckless_abandon.enabled then
+                gain( 50, "rage" )
+            end
         end,
     },
 
@@ -679,11 +1140,11 @@ spec:RegisterAbilities( {
     shattering_throw = {
         id = 64382,
         cast = 1.5,
-        cooldown = 180,
+        cooldown = function() return (pvptalent.demolition.enabled and 60 or 180) end,
         gcd = "spell",
 
         talent = "shattering_throw",
-        startsCombat = false,
+        startsCombat = true,
         texture = 311430,
 
         toggle = "cooldowns",
@@ -700,6 +1161,7 @@ spec:RegisterAbilities( {
         cooldown = 15.115,
         recharge = 15.115,
         gcd = "spell",
+        hasteCD = true,
 
         spend = 30,
         spendType = "rage",
@@ -717,6 +1179,7 @@ spec:RegisterAbilities( {
         cast = 0,
         cooldown = 9,
         gcd = "spell",
+        hasteCD = true,
 
         startsCombat = true,
         texture = 134951,
@@ -729,14 +1192,21 @@ spec:RegisterAbilities( {
     shockwave = {
         id = 46968,
         cast = 0,
-        cooldown = 40,
+        cooldown = function () return ( ( talent.rumbling_earth.enabled and active_enemies >= 3 ) and 25 or 40 ) end,
         gcd = "spell",
 
         talent = "shockwave",
-        startsCombat = false,
+        startsCombat = true,
         texture = 236312,
 
+        toggle = "interrupts",
+        debuff = function () return settings.shockwave_interrupt and "casting" or nil end,
+        readyTime = function () return settings.shockwave_interrupt and timeToInterrupt() or nil end,
+        usable = function () return not target.is_boss end,
         handler = function ()
+            applyDebuff( "target", "shockwave" )
+            active_dot.shockwave = max( active_dot.shockwave, active_enemies ) -- This isn't quite proper considering Shockwave is a cone, but close enough.
+            if not target.is_boss then interrupt() end
         end,
     },
 
@@ -744,16 +1214,18 @@ spec:RegisterAbilities( {
     slam = {
         id = 1464,
         cast = 0,
-        cooldown = 0,
+        cooldown = function() return ( talent.storm_of_swords.enabled and 12 or 0 ) end, 
         gcd = "spell",
+        hasteCD = true,
 
-        spend = 20,
+        spend = function() return ( talent.storm_of_swords.enabled and -10 or 20 ) end,
         spendType = "rage",
 
         startsCombat = true,
         texture = 132340,
 
         handler = function ()
+            removeStack( "whirlwind" )
         end,
     },
 
@@ -765,16 +1237,32 @@ spec:RegisterAbilities( {
         gcd = "spell",
 
         talent = "spear_of_bastion",
-        startsCombat = false,
+        startsCombat = true,
+        spend = function () return -25 + ( talent.piercing_verdict.enabled and -7.5 or 0 ) end,
+        spendType = "rage",
         texture = 3565453,
 
         toggle = "cooldowns",
+        velocity = 30,
 
         handler = function ()
+            applyDebuff( "target", "spear_of_bastion" )
+            if talent.elysian_might.enabled then applyBuff( "elysian_might" ) end
         end,
+
+        auras = {
+            spear_of_bastion = {
+                id = 376079,
+                duration = function () return talent.elysian_might.enabled and 8 or 4 end,
+                max_stack = 1
+            },
+            elysian_might = {
+                id = 386285,
+                duration = 8,
+                max_stack = 1,
+            },
+        }
     },
-
-
     spell_reflection = {
         id = 23920,
         cast = 0,
@@ -799,10 +1287,11 @@ spec:RegisterAbilities( {
         gcd = "spell",
 
         talent = "storm_bolt",
-        startsCombat = false,
+        startsCombat = true,
         texture = 613535,
 
         handler = function ()
+            applyDebuff ("target", storm_bolt)
         end,
     },
 
@@ -817,6 +1306,7 @@ spec:RegisterAbilities( {
         texture = 136080,
 
         handler = function ()
+            applyDebuff( "target", "taunt" )
         end,
     },
 
@@ -826,15 +1316,18 @@ spec:RegisterAbilities( {
         cast = 0,
         cooldown = 6,
         gcd = "spell",
+        hasteCD = true,
 
         spend = 30,
         spendType = "rage",
 
         talent = "thunder_clap",
-        startsCombat = false,
+        startsCombat = true,
         texture = 136105,
 
         handler = function ()
+            applyDebuff( "target", "thunder_clap" )
+            active_dot.thunder_clap = max( active_dot.thunder_clap, active_enemies )
         end,
     },
 
@@ -842,16 +1335,18 @@ spec:RegisterAbilities( {
     thunderous_roar = {
         id = 384318,
         cast = 0,
-        cooldown = 90,
+        cooldown = function() return 90 - (talent.uproar.enabled and 30 or 0) end,
         gcd = "spell",
 
         talent = "thunderous_roar",
-        startsCombat = false,
+        startsCombat = true,
         texture = 642418,
 
         toggle = "cooldowns",
 
         handler = function ()
+            applyDebuff( "target", "thunderous_roar" )
+            active_dot.thunderous_roar = max( active_dot.thunderous_roar, active_enemies )
         end,
     },
 
@@ -863,7 +1358,7 @@ spec:RegisterAbilities( {
         gcd = "spell",
 
         talent = "titanic_throw",
-        startsCombat = false,
+        startsCombat = true,
         texture = 132453,
 
         handler = function ()
@@ -880,7 +1375,11 @@ spec:RegisterAbilities( {
         startsCombat = true,
         texture = 132342,
 
+        notalent = "impending_victory",
+        buff = "victorious",
         handler = function ()
+            removeBuff( "victorious" )
+            removeStack( "whirlwind" )
         end,
     },
 
@@ -890,11 +1389,23 @@ spec:RegisterAbilities( {
         cast = 0,
         cooldown = 0,
         gcd = "spell",
+        hasteCD = true,
 
-        startsCombat = false,
+        startsCombat = true,
         texture = 132369,
 
+        usable = function ()
+            if settings.check_ww_range and target.outside7 then return false, "target is outside of whirlwind range" end
+            return true
+        end,
+
         handler = function ()
+            if level > 36 then
+                if talent.improved_whirlwind.enabled then
+                    gain( min(3 + active_enemies, 8), "rage" ) --Whirlwind generates 3 Rage, plus an additional 1 per target hit. Maximum 8 Rage
+                    applyBuff ( "whirlwind", nil, talent.meat_cleaver.enabled and 4 or 2 )
+                end
+            end
         end,
     },
 
@@ -906,12 +1417,32 @@ spec:RegisterAbilities( {
         gcd = "spell",
 
         talent = "wrecking_throw",
-        startsCombat = false,
+        startsCombat = true,
         texture = 311430,
-
-        handler = function ()
-        end,
     },
+} )
+
+
+spec:RegisterSetting( "shockwave_interrupt", true, {
+    name = "Only |T236312:0|t Shockwave as Interrupt",
+    desc = "If checked AND talented, |T236312:0|t Shockwave will only be recommended when your target is casting.",
+    type = "toggle",
+    width = "full"
+} )
+
+spec:RegisterSetting( "check_ww_range", false, {
+    name = "Check |T132369:0|t Whirlwind Range",
+    desc = "If checked, when your target is outside of |T132369:0|t Whirlwind's range, it will not be recommended.",
+    type = "toggle",
+    width = "full"
+} )
+
+spec:RegisterSetting( "heroic_charge", false, {
+    name = "Use Heroic Charge Combo",
+    desc = "If checked, the default priority will check |cFFFFD100settings.heroic_charge|r to determine whether to use Heroic Leap + Charge together.\n\n" ..
+        "This is generally a DPS increase but the erratic movement can be disruptive to smooth gameplay.",
+    type = "toggle",
+    width = "full",
 } )
 
 spec:RegisterPriority( "Fury", 20220915,

--- a/Dragonflight/WarriorFury.lua
+++ b/Dragonflight/WarriorFury.lua
@@ -271,6 +271,11 @@ spec:RegisterAuras( {
     defensive_stance = {
         id = 386208,
     },
+    disarm = {
+        id = 236077,
+        duration = 6,
+        max_stack = 1,
+    }, 
     dual_wield = {
         id = 231842,
     },
@@ -342,6 +347,11 @@ spec:RegisterAuras( {
         id = 46968,
         duration = 2,
         max_stack = 1,
+    },
+    slaughterhouse = {
+        id = 354788,
+        duration = 6,
+        max_stack = 5,
     },
     slaughtering_strikes = { 
         id = 85288, -- Labeled as Raging blow in WowHead, but Slaughtering Strikes talent triggers this
@@ -797,6 +807,7 @@ spec:RegisterAbilities( {
         texture = 132343,
 
         handler = function ()
+            applyDebuff( "target", "disarm" )
         end,
     },
 
@@ -853,7 +864,7 @@ spec:RegisterAbilities( {
         texture = 132316,
 
         handler = function ()
-            applyDebuff( "hamstring" )
+            applyDebuff(  "target", "hamstring" )
         end,
     },
 
@@ -1093,6 +1104,7 @@ spec:RegisterAbilities( {
             applyBuff( "enrage" )
             removeStack( "whirlwind" )
             removeBuff( "slaughtering_strikes" )
+            -- if pvptalent.slaughterhouse.enabled then addStack ( "slaughterhouse", nil, 1)
         end,
     },
 


### PR DESCRIPTION
First pass at DF Fury Warrior talents / abilities for Dragonflight.

I've tested it in-game and made a crude APL list that works. No errors generated by Hekili that I've found with my limited testing.

Note: 
- Not sure if the rage gen or fury_rage_mult is changed in DF, those are copied from Shadowlands branch.
- Removed unused covenant abilities from SL that aren't reused in DF (Fleshcraft / Conq Banner / Ancient Aftershock / Soulshape / Condemn / Door of Shadows
- Removed references SL legendaries.
- Removed references to SL Tier sets
- Removed references to pre-SL legendaries.
- I have not tested the PVP talents but researched all appropriate ID's and such via wowhead and the PTR itself.


If you'd like any changes please just let me know (Feel free to @Wyste#8631 in discord. 