### PR TITLE
fix stopScreenMovement bug when dragging UI elements

### DIFF
--- a/UI.lua
+++ b/UI.lua
@@ -47,9 +47,9 @@ end
 
 local function stopScreenMovement(frame)
     local monitor = (tonumber(GetCVar("gxMonitor")) or 0) + 1
-    local resolutions = {GetScreenResolutions()}
-    local resolution = resolutions[GetCurrentResolution()] or GetCVar("gxWindowedResolution") or "1024x768"
-    local scrW, scrH = resolution:match("(%d+)x(%d+)")
+    --local resolutions = {GetScreenResolutions()}
+    local resolution = C_VideoOptions.GetCurrentGameWindowSize()
+    local scrW, scrH = resolution.x, resolution.y
 
     local scale, pScale = Hekili:GetScale(), UIParent:GetScale()
 


### PR DESCRIPTION
Fixes error: `global 'GetScreenResolutions' (a nil value)` in Dragonflight branch.
The UI locks up so I can't copy and paste it; but here's a screenshot of the error in-game: https://imgur.com/e1SYdCg
![image](https://user-images.githubusercontent.com/5103286/193189698-8ec52491-b8a9-4426-8982-fc4c868d598c.png)

GetCurrentResolution() and GetCurrentResolution() API's are being **removed** in DragonFlight (10.0). This PR is a quick fix to allow dragging/dropping UI elements again using C_VideoOptions.GetCurrentGameWindowSize()

My Ingame Dump Value of C_VideoOptions.GetCurrentGameWindowSize() :  (I use a 2560x1440 resolution monitor and in-game setting)
```
[1]={
 RotateDirection=<function>,
 GetLength=<function>,
 Normalize=<function>,
 Dot=<function>,
 GetLengthSquared=<function>,
 GetXY=<function>,
 OnLoad=<function>,
 IsZero=<function>,
 DivideBy=<function>,
 x=2560,
 y=1440,
 Subtract=<function>,
 Clone=<function>,
 Cross=<function>,
 ScaleBy=<function>,
 SetXY=<function>,
 IsEqualTo=<function>,
 Add=<function>
}
```
 