### PR TITLE
Updated packager so this isn't marked as 1.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
 
       # once cloned, we just run the GitHub Action for the packager project
       - name: Package and Release
-        uses: BigWigsMods/packager@v1
+        uses: BigWigsMods/packager@v2
 
       # another example where we supply additional arguments, this example is specifically to release
       # for the Classic version of the game


### PR DESCRIPTION
As some people are running into this, make sure that you're using the "@v2" version specifier for the packager if you're seeing assets get uploaded to CF as supporting game version 1.0.0.

https://github.com/BigWigsMods/packager#example-using-options

- From Meo on Discord