### PR TITLE
fix: bartender button name change

### DIFF
--- a/Events.lua
+++ b/Events.lua
@@ -2078,7 +2078,7 @@ do
 
                     -- If bar is disabled assume paging / stance switching on bar 1
                     if actionBarNumber > 1 and bar and not bar.disabled then
-                        bindingKeyName = "CLICK BT4Button" .. actionBarButtonId .. ":LeftButton"
+                        bindingKeyName = "CLICK BT4Button" .. actionBarButtonId .. ":Keybind"
                     end
 
                     StoreKeybindInfo( actionBarNumber, GetBindingKey( bindingKeyName ), GetActionInfo( actionBarButtonId ) )
@@ -2233,7 +2233,7 @@ local function ReadOneKeybinding( event, slot )
 
         -- If bar is disabled assume paging / stance switching on bar 1
         if actionBarNumber > 1 and bar and not bar.disabled then
-            bindingKeyName = "CLICK BT4Button" .. slot .. ":LeftButton"
+            bindingKeyName = "CLICK BT4Button" .. slot .. ":Keybind"
         end
 
         ability = StoreKeybindInfo( actionBarNumber, GetBindingKey( bindingKeyName ), GetActionInfo( slot ) )


### PR DESCRIPTION
I think I fixed the name change to the bartender4 bars.  I referenced https://github.com/Hekili/hekili/issues/1706#issuecomment-1292902135

Testing locally seems to work fine with my bartender4