### PR TITLE
[APL Tweak] Outlaw

### DIFF
--- a/Dragonflight/APLs/RogueOutlaw.simc
+++ b/Dragonflight/APLs/RogueOutlaw.simc
@@ -12,11 +12,11 @@ actions=stealth
 # Interrupt on cooldown to allow simming interactions with that
 actions+=/kick,if=!stealthed.all
 # Reroll BT + GM or single buffs early other than Broadside, TB with Shadowdust, or SnC with Blunderbuss
-actions+=/variable,name=rtb_reroll,value=rtb_buffs<2&(!buff.broadside.up&(!runeforge.concealed_blunderbuss&!talent.fan_the_hammer|!buff.skull_and_crossbones.up)&(!runeforge.invigorating_shadowdust|!buff.true_bearing.up))|rtb_buffs=2&buff.buried_treasure.up&buff.grand_melee.up
+actions+=/variable,name=rtb_reroll,value=rtb_buffs<2&(!buff.broadside.up&(!runeforge.concealed_blunderbuss&!talent.fan_the_hammer|!buff.skull_and_crossbones.up)&(!runeforge.invigorating_shadowdust|!buff.true_bearing.up))|rtb_buffs=2&(buff.buried_treasure.up&buff.grand_melee.up|!buff.broadside.up&!buff.true_bearing.up&buff.loaded_dice.up)
 # Ensure we get full Ambush CP gains and aren't rerolling Count the Odds buffs away
 actions+=/variable,name=ambush_condition,value=combo_points.deficit>=2+buff.broadside.up&energy>=50&(!conduit.count_the_odds&!talent.count_the_odds|buff.roll_the_bones.remains>=10)
 # Finish at max possible CP without overflowing bonus combo points, unless for BtE which always should be 5+ CP
-actions+=/variable,name=finish_condition,value=combo_points>=cp_max_spend-buff.broadside.up-(buff.opportunity.up*(talent.quick_draw|talent.fan_the_hammer)|buff.concealed_blunderbuss.up)|effective_combo_points>=cp_max_spend
+actions+=/variable,name=finish_condition,value=combo_points>=cp_max_spend-buff.broadside.up-(buff.opportunity.up&(talent.quick_draw|talent.fan_the_hammer)|buff.concealed_blunderbuss.up)|effective_combo_points>=cp_max_spend
 # Always attempt to use BtE at 5+ CP, regardless of CP gen waste
 actions+=/variable,name=finish_condition,op=reset,if=cooldown.between_the_eyes.ready&effective_combo_points<5
 # Finish at 2+ in the last GCD of Flagellation
@@ -36,8 +36,9 @@ actions+=/bag_of_tricks
 actions.build=sepsis,cycle_targets=1,if=target.time_to_die>11&debuff.between_the_eyes.up|fight_remains<11
 actions.build+=/ghostly_strike,if=debuff.ghostly_strike.remains<=3
 actions.build+=/shiv,if=runeforge.tiny_toxic_blade
-actions.build+=/echoing_reprimand,if=!soulbind.effusive_anima_accelerator|variable.blade_flurry_sync
-actions.build+=/ambush
+actions.build+=/echoing_reprimand,if=(!soulbind.effusive_anima_accelerator|variable.blade_flurry_sync)&!debuff.dreadblades.up
+# High priority Ambush line to apply Find Weakness or consume HO+Audacity buff before Pistol Shot
+actions.build+=/ambush,if=talent.hidden_opportunity&buff.audacity.up|talent.find_weakness&debuff.find_weakness.down
 # Use Pistol Shot when buffed by bonuses as a priority
 actions.build+=/cold_blood,if=buff.opportunity.up&buff.greenskins_wickers.up|buff.greenskins_wickers.up&buff.greenskins_wickers.remains<1.5
 actions.build+=/pistol_shot,if=buff.opportunity.up&(buff.greenskins_wickers.up&!talent.fan_the_hammer|buff.concealed_blunderbuss.up)|buff.greenskins_wickers.up&buff.greenskins_wickers.remains<1.5
@@ -45,7 +46,7 @@ actions.build+=/pistol_shot,if=buff.opportunity.up&(buff.greenskins_wickers.up&!
 actions.build+=/pistol_shot,if=talent.fan_the_hammer&buff.opportunity.up&(buff.opportunity.stack>=buff.opportunity.max_stack|buff.opportunity.remains<2)
 actions.build+=/pistol_shot,if=talent.fan_the_hammer&buff.opportunity.up&combo_points.deficit>4&!debuff.dreadblades.up
 actions.build+=/pool_resource,for_next=1
-actions.build+=/ambush
+actions.build+=/ambush,if=talent.hidden_opportunity|talent.find_weakness&debuff.find_weakness.down
 # Apply SBS to all targets without a debuff as priority, preferring targets dying sooner after the primary target
 actions.build+=/serrated_bone_spike,if=!dot.serrated_bone_spike_dot.ticking
 actions.build+=/serrated_bone_spike,cycle_targets=1,if=!dot.serrated_bone_spike_dot.ticking
@@ -73,6 +74,8 @@ actions.cds+=/vanish,if=variable.vanish_ma_condition&master_assassin_remains=0&v
 actions.cds+=/adrenaline_rush,if=!buff.adrenaline_rush.up&(!talent.improved_adrenaline_rush|combo_points<=2)
 # Fleshcraft for Pustule Eruption if not stealthed and not with Blade Flurry
 actions.cds+=/fleshcraft,if=(soulbind.pustule_eruption|soulbind.volatile_solvent)&!stealthed.all&(!buff.blade_flurry.up|spell_targets.blade_flurry<2)&(!buff.adrenaline_rush.up|energy.base_time_to_max>2)
+# Pool resource for dreadblades as it costs 50 energy
+actions.cds+=/pool_resource,for_next=1,if=talent.dreadblades.enabled
 actions.cds+=/dreadblades,if=!stealthed.all&combo_points<=2&(!action.flagellation.known|buff.flagellation_buff.up)&(!talent.marked_for_death|!cooldown.marked_for_death.ready)
 # If adds are up, snipe the one with lowest TTD. Use when dying faster than CP deficit or without any CP.
 actions.cds+=/marked_for_death,line_cd=1.5,cycle_targets=1,if=raid_event.adds.up&(target.time_to_die<combo_points.deficit|!stealthed.rogue&combo_points.deficit>=cp_max_spend-1)
@@ -85,7 +88,7 @@ actions.cds+=/killing_spree,if=variable.blade_flurry_sync&variable.killing_spree
 actions.cds+=/blade_rush,if=variable.blade_flurry_sync&(energy.base_time_to_max>2&!buff.dreadblades.up&!buff.flagellation_buff.up|energy<=30|spell_targets>2)
 # If using Invigorating Shadowdust, use normal logic in addition to checking major CDs.
 actions.cds+=/vanish,if=runeforge.invigorating_shadowdust&action.flagellation.known&!stealthed.all&variable.finish_condition&(!cooldown.flagellation.ready&(!talent.dreadblades|!cooldown.dreadblades.ready|!buff.flagellation_buff.up))
-actions.cds+=/vanish,if=runeforge.invigorating_shadowdust&!action.flagellation.known&!stealthed.all&variable.finish_condition&(cooldown.echoing_reprimand.remains>6|!cooldown.sepsis.ready|cooldown.serrated_bone_spike.full_recharge_time>20)
+actions.cds+=/vanish,if=runeforge.invigorating_shadowdust&!action.flagellation.known&!stealthed.all&variable.finish_condition&(((action.echoing_reprimand.known&cooldown.echoing_reprimand.remains>6)|(action.sepsis.known&!cooldown.sepsis.ready)|(action.serrated_bone_spike.known&cooldown.serrated_bone_spike.full_recharge_time>20))|!cooldown.adrenaline_rush.ready)
 actions.cds+=/shadowmeld,if=!stealthed.all&((conduit.count_the_odds|talent.count_the_odds)&variable.finish_condition|!talent.weaponmaster.enabled&variable.ambush_condition)
 actions.cds+=/thistle_tea,if=energy.deficit>=100&!buff.thistle_tea.up&(charges=3|buff.adrenaline_rush.up|fight_remains<charges*6)
 actions.cds+=/potion,if=buff.bloodlust.react|fight_remains<30|buff.adrenaline_rush.up

--- a/Dragonflight/APLs/RogueOutlaw.simc
+++ b/Dragonflight/APLs/RogueOutlaw.simc
@@ -1,4 +1,5 @@
 actions.precombat+=/bottled_flayedwing_toxin
+actions.precombat=apply_poison
 actions.precombat+=/marked_for_death,precombat_seconds=10,if=raid_event.adds.in>25
 actions.precombat+=/fleshcraft,if=soulbind.pustule_eruption|soulbind.volatile_solvent
 actions.precombat+=/stealth

--- a/Dragonflight/APLs/RogueOutlaw.simc
+++ b/Dragonflight/APLs/RogueOutlaw.simc
@@ -84,8 +84,8 @@ actions.cds+=/marked_for_death,if=raid_event.adds.in>30-raid_event.adds.duration
 # Attempt to sync Killing Spree with Vanish for Master Assassin
 actions.cds+=/variable,name=killing_spree_vanish_sync,value=!runeforge.mark_of_the_master_assassin|cooldown.vanish.remains>10|master_assassin_remains>2
 # Use in 1-2T if BtE is up and won't cap Energy, or at 3T+ (2T+ with Deathly Shadows) or when Master Assassin is up.
-actions.cds+=/killing_spree,if=variable.blade_flurry_sync&variable.killing_spree_vanish_sync&!stealthed.rogue&(debuff.between_the_eyes.up&buff.dreadblades.down&energy.base_deficit>(energy.regen*2+15)|spell_targets.blade_flurry>(2-buff.deathly_shadows.up)|master_assassin_remains>0)
-actions.cds+=/blade_rush,if=variable.blade_flurry_sync&(energy.base_time_to_max>2&!buff.dreadblades.up&!buff.flagellation_buff.up|energy<=30|spell_targets>2)
+actions.cds+=/killing_spree,if=variable.blade_flurry_sync&variable.killing_spree_vanish_sync&!stealthed.rogue&(debuff.between_the_eyes.up&debuff.dreadblades.down&energy.base_deficit>(energy.regen*2+15)|spell_targets.blade_flurry>(2-buff.deathly_shadows.up)|master_assassin_remains>0)
+actions.cds+=/blade_rush,if=variable.blade_flurry_sync&(energy.base_time_to_max>2&!debuff.dreadblades.up&!buff.flagellation_buff.up|energy<=30|spell_targets>2)
 # If using Invigorating Shadowdust, use normal logic in addition to checking major CDs.
 actions.cds+=/vanish,if=runeforge.invigorating_shadowdust&action.flagellation.known&!stealthed.all&variable.finish_condition&(!cooldown.flagellation.ready&(!talent.dreadblades|!cooldown.dreadblades.ready|!buff.flagellation_buff.up))
 actions.cds+=/vanish,if=runeforge.invigorating_shadowdust&!action.flagellation.known&!stealthed.all&variable.finish_condition&(((action.echoing_reprimand.known&cooldown.echoing_reprimand.remains>6)|(action.sepsis.known&!cooldown.sepsis.ready)|(action.serrated_bone_spike.known&cooldown.serrated_bone_spike.full_recharge_time>20))|!cooldown.adrenaline_rush.ready)


### PR DESCRIPTION
As Simcraft did not make any adjustments into prepatch version of the APL and only improved DF version of it. I want to suggest implementing some changes to represent both prepatch and future DF changes of the APL considering legendaries, talents, etc. Link to the simc APL https://github.com/simulationcraft/simc/blob/dragonflight/engine/class_modules/apl/rogue/outlaw_df.simc

Adjusted RTB reroll logic to actually not reroll Broadside and True bearing during Loaded Dice buff (line 21 of the DF APL)

Finish condition typo fix

Echoing Reprimand should not be used during dreadblades window. (Line 44 of the DF APL)

Ambush adjustment (Line 45 and line 53 of the DF APL)

Pool resources for Dreadblades as it costs 50 energy which is more than Sinister Strike and ofter i came up in a situation that i have no CD on dreadblade (and it should be cast on CD) but not enough energy to cast it and addon suggested me to just cast a filler (Sinister Strike) instead of waiting for an energy tick.

Vansich adjustments with Invigorating Shadowdust legendary and not a Venthyr covenant. This is needed or else in the non-SL related content no conditions for vanish are met and it will not be used at all.



Also a few questions:

1. Is it fine to use talent.name instead of talent.name.enabled?
2. That typo in finish condition (*), does it affect the calculations of the simcraft? How should I report it to the simcraft?
3. The same question goes for buff.dreadblades instead of debuff.dreadblades. Is it crucial in terms of dps calculation in simcraft or they have another syntaxis for it?