### PR TITLE
Prot Warrior free_revenge to reserve_rage setting

### DIFF
--- a/Dragonflight/WarriorProtection.lua
+++ b/Dragonflight/WarriorProtection.lua
@@ -891,9 +891,9 @@ spec:RegisterAbilities( {
 
         timeToReady = function()
             if buff.sudden_death.up then return 0 end
-            local threshold = settings.reserve_rage + 20
+            local threshold = settings.reserve_rage + 40
             if rage.current >= threshold then return 0 end
-            return rage[ "time_to_" .. ( settings.reserve_rage + 20 ) ]
+            return rage[ "time_to_" .. ( settings.reserve_rage + 40 ) ]
         end,
 
         handler = function ()
@@ -1223,7 +1223,7 @@ spec:RegisterAbilities( {
     },
 
 
-    revenge = {
+revenge = {
         id = 6572,
         cast = 0,
         cooldown = 0,

--- a/Dragonflight/WarriorProtection.lua
+++ b/Dragonflight/WarriorProtection.lua
@@ -881,6 +881,7 @@ spec:RegisterAbilities( {
 
         usable = function ()
             if buff.sudden_death.up then return true end
+            if rage.current < settings.reserve_rage then return false, "Reserving enough rage for rotational defensives" end
             if cycle_for_execute then return true end
             return target.health_pct < ( talent.massacre.enabled and 35 or 20 ), "requires < " .. ( talent.massacre.enabled and 35 or 20 ) .. "% health"
         end,
@@ -1240,7 +1241,7 @@ spec:RegisterAbilities( {
         usable = function ()
             if action.revenge.cost == 0 then return true end
             if toggle.defensives and buff.ignore_pain.down and incoming_damage_5s > 0.1 * health.max then return false, "don't spend on revenge if ignore_pain is down and there is incoming damage" end
-            if settings.free_revenge and action.revenge.cost ~= 0 then return false, "free_revenge is checked and revenge is not free" end
+            if rage.current < settings.reserve_rage then return false, "Reserving enough rage for rotational defensives" end
             return true
         end,
 
@@ -1650,11 +1651,16 @@ spec:RegisterAbilities( {
 } )
 
 
-spec:RegisterSetting( "free_revenge", true, {
-    name = "Only |T132353:0|t Revenge when Free",
-    desc = "If checked, the |T132353:0|t Revenge ability will only be recommended when it costs 0 Rage to use.",
-    type = "toggle",
-    width = "full"
+spec:RegisterSetting( "reserve_rage", 35, { -- Ignore Pain cost is 35, Shield Block is 30
+    name = "Reserved rage for rotational defensives |T1377132:0|t Ignore Pain and |T132110:0|t Shield Block",
+    desc = "The addon will only recommend |T132353:0|t Revenge and |T135358:0|t Execute if you have more than this much Rage.",
+    icon = 135726, -- Same as talent "Overwhelming Rage"
+    iconCoords = { 0.1, 0.9, 0.1, 0.9 },
+    type = "range",
+    min = 0,
+    max = 100,
+    step = 1,
+    width = 3
 } )
 
 spec:RegisterSetting( "shockwave_interrupt", true, {

--- a/Dragonflight/WarriorProtection.lua
+++ b/Dragonflight/WarriorProtection.lua
@@ -1223,7 +1223,7 @@ spec:RegisterAbilities( {
     },
 
 
-revenge = {
+    revenge = {
         id = 6572,
         cast = 0,
         cooldown = 0,

--- a/Dragonflight/WarriorProtection.lua
+++ b/Dragonflight/WarriorProtection.lua
@@ -891,9 +891,9 @@ spec:RegisterAbilities( {
 
         timeToReady = function()
             if buff.sudden_death.up then return 0 end
-            local threshold = settings.reserve_rage + 40
+            local threshold = settings.reserve_rage + 20
             if rage.current > threshold then return 0 end
-            return rage[ "time_to_" .. ( settings.reserve_rage + 40 ) ]
+            return rage[ "time_to_" .. ( settings.reserve_rage + 20 ) ]
         end,
 
         handler = function ()
@@ -1223,7 +1223,7 @@ spec:RegisterAbilities( {
     },
 
 
-revenge = {
+    revenge = {
         id = 6572,
         cast = 0,
         cooldown = 0,

--- a/Dragonflight/WarriorProtection.lua
+++ b/Dragonflight/WarriorProtection.lua
@@ -892,7 +892,7 @@ spec:RegisterAbilities( {
         timeToReady = function()
             if buff.sudden_death.up then return 0 end
             local threshold = settings.reserve_rage + 20
-            if rage.current > threshold then return 0 end
+            if rage.current >= threshold then return 0 end
             return rage[ "time_to_" .. ( settings.reserve_rage + 20 ) ]
         end,
 
@@ -1248,7 +1248,7 @@ spec:RegisterAbilities( {
         readyTime = function()
             if buff.revenge.up then return 0 end
             local threshold = action.revenge.cost + settings.reserve_rage
-            if rage.current > threshold then return 0 end
+            if rage.current >= threshold then return 0 end
             return rage[ "time_to_" .. threshold ]
         end,
 


### PR DESCRIPTION
Abilities affected: Revenge + Execute.  Simple enough change; remove the free_revenge toggle setting in favor of a setting that allows the user to reserve a set amount of rage to maintain for use on rotation defensives (Shield Block and Ignore Pain). 

35 is the default, due to Ignore Pain's cost being higher then Shield Block. For the UI, I decided a width of 3 was better looking due to the text's length and slider feeling easier to use, but feel free to change to suit your design intent.

I decided to leave Condemn out of the new setting due to it's upcoming scarcity with DF launch, and the ability has defensive value to it anyways.

This PR references Issue #1987 . In the issue you commented that any choice in changes here was going to result in more questions, but I feel as if this is a better solution then just gating Revenge behind it's proc. The user can change the setting down to 0 if they like to get the same effect as before, just like toggling the free_revenge off. 

Playing the phase2 primalist storm event with this new setting felt good and wasn't too greedy with how protection warrior plays currently.

The only future enhancement I can see to this setting would be to consider the current rolling rotation defensives as well, such as if IP is up and near cap, or SB is already rolling with a high duration, or the 2nd charge is ready. But that's a discussion for another day.