### PR TITLE
"Reserve Rage" changes

### DIFF
--- a/Dragonflight/WarriorProtection.lua
+++ b/Dragonflight/WarriorProtection.lua
@@ -894,7 +894,7 @@ spec:RegisterAbilities( {
         timeToReady = function()
             if buff.sudden_death.up then return 0 end
             local threshold = settings.reserve_rage + 40
-            if rage.current >= threshold then return 0 end
+            if rage.current >= threshold or ( buff.shield_block.remains > 3 and buff.ignore_pain.remains > 3 ) or not tanking then return 0 end
             return rage[ "time_to_" .. ( settings.reserve_rage + 40 ) ]
         end,
 
@@ -1265,7 +1265,7 @@ spec:RegisterAbilities( {
         readyTime = function()
             if buff.revenge.up then return 0 end
             local threshold = action.revenge.cost + settings.reserve_rage
-            if rage.current >= threshold then return 0 end
+            if rage.current >= threshold or ( buff.shield_block.remains > 3 and buff.ignore_pain.remains > 3 ) or not tanking then return 0 end
             return rage[ "time_to_" .. threshold ]
         end,
 


### PR DESCRIPTION
Changed the reserve_rage setting to only kick in once either ignore pain or shield block have only  3 sec or less time left and only if you are actively tanking. No need to reserve rage otherwise, since it will hurt you in the long run, since you will have less Shield Slam resets and thus less rage gen.