### PR TITLE
add rogue's gift of the naruu spellID, and priest's blood_fury spellID

### DIFF
--- a/Classes.lua
+++ b/Classes.lua
@@ -2253,7 +2253,8 @@ local gotn_classes = {
     HUNTER = 59543,
     PRIEST = 59544,
     MAGE = 59548,
-    PALADIN = 59542
+    PALADIN = 59542,
+    ROGUE = 370626
 }
 
 local baseClass = UnitClassBase( "player" ) or "WARRIOR"
@@ -2262,7 +2263,7 @@ all:RegisterAura( "gift_of_the_naaru", {
     id = gotn_classes[ baseClass ],
     duration = 5,
     max_stack = 1,
-    copy = { 28800, 121093, 59545, 59547, 59543, 59544, 59548, 59542 }
+    copy = { 28800, 121093, 59545, 59547, 59543, 59544, 59548, 59542, 370626 }
 } )
 
 all:RegisterAbility( "gift_of_the_naaru", {
@@ -2383,6 +2384,7 @@ local bf_classes = {
     SHAMAN = 33697,
     WARLOCK = 33702,
     WARRIOR = 20572,
+    PRIEST = 33702
 }
 
 all:RegisterAbilities( {


### PR DESCRIPTION
This would add in the new spellIDs to class mappings due to the new class combinations for DF, which are now possible due to Draenei Rogues and Orc Priests.