### PR TITLE
Fixed "nobuff" condition for stances - Arms

### DIFF
--- a/Dragonflight/WarriorArms.lua
+++ b/Dragonflight/WarriorArms.lua
@@ -658,7 +658,7 @@ spec:RegisterAbilities( {
         startsCombat = false,
         texture = 132349,
         essential = true,
-        nobuff = "stance",
+        nobuff = "battle_stance",
 
         handler = function ()
             applyBuff( "battle_stance" )
@@ -834,7 +834,7 @@ spec:RegisterAbilities( {
         talent = "defensive_stance",
         startsCombat = false,
         texture = 132341,
-        nobuff = "stance",
+        nobuff = "defensive_stance",
 
         handler = function ()
             applyBuff( "defensive_stance" )


### PR DESCRIPTION
Setting "nobuff" to simply "stance" caused the issue that a stance would only be ever recommended if you were not in a stance. So if the APL had an entry to switch to defensive stance if you are below 80% HP for example, it would simply be ignored since you were already in a stance (battle stance / berserker stance).