### PR TITLE
Fixed "nobuff" condition for stances - Fury

### DIFF
--- a/Dragonflight/WarriorFury.lua
+++ b/Dragonflight/WarriorFury.lua
@@ -821,7 +821,7 @@ spec:RegisterAbilities( {
         startsCombat = false,
         essential = true,
 
-        nobuff = "stance",
+        nobuff = "berserker_stance",
 
         handler = function ()
             applyBuff( "berserker_stance" )
@@ -1044,7 +1044,7 @@ spec:RegisterAbilities( {
 
         talent = "defensive_stance",
         startsCombat = false,
-        nobuff = "stance",
+        nobuff = "defensive_stance",
 
         handler = function ()
             applyBuff( "defensive_stance" )


### PR DESCRIPTION
Setting "nobuff" to simply "stance" caused the issue that a stance would only be ever recommended if you were not in a stance. So if the APL had an entry to switch to defensive stance if you are below 80% HP for example, it would simply be ignored since you were already in a stance (battle stance / berserker stance).