### PR TITLE
Assassination Exsanguinate nerf update

### DIFF
--- a/Dragonflight/RogueAssassination.lua
+++ b/Dragonflight/RogueAssassination.lua
@@ -1869,7 +1869,7 @@ spec:RegisterAbilities( {
     exsanguinate = {
         id = 200806,
         cast = 0,
-        cooldown = 45,
+        cooldown = 180,
         gcd = "totem",
         school = "physical",
 


### PR DESCRIPTION
Assassination Exsanguinate CD was nerfed to 3 minutes https://www.wowhead.com/spell=200806/exsanguinate