### PR TITLE
Add empowered spell level support to the HEKILI_RECOMMENDATION_UPDATE event and the Hekili_GetRecommendedAbility function

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -2031,7 +2031,7 @@ function Hekili.Update()
 
             if WeakAuras and WeakAuras.ScanEvents then
                 -- Hekili:Yield( "Post-ScanEvents for " .. dispName )
-                WeakAuras.ScanEvents( "HEKILI_RECOMMENDATION_UPDATE", dispName, Queue[ 1 ].actionID, Queue[ 1 ].indicator )
+                WeakAuras.ScanEvents( "HEKILI_RECOMMENDATION_UPDATE", dispName, Queue[ 1 ].actionID, Queue[ 1 ].indicator, Queue[ 1 ].empower_to )
                 -- Hekili:Yield( "Post-ScanEvents for " .. dispName )
             end
 

--- a/Core.lua
+++ b/Core.lua
@@ -2087,7 +2087,7 @@ function Hekili_GetRecommendedAbility( display, entry )
         return nil, "No entry #" .. entry .. " for that display."
     end
 
-    return slot.actionID
+    return slot.actionID, slot.empower_to
 end
 
 


### PR DESCRIPTION
Small edit to add the ability to get the recommended empower level of a recommended spell via WeakAuras since this does not seem to be possibly currently.