### PR TITLE
Assassination bleed multiplier new fix

### DIFF
--- a/Dragonflight/RogueAssassination.lua
+++ b/Dragonflight/RogueAssassination.lua
@@ -512,11 +512,7 @@ spec:RegisterStateExpr( "persistent_multiplier", function ()
 
     if buff.stealth.up or buff.subterfuge.up then
         if talent.nightstalker.enabled then
-            mult = mult * 2
-        end
-
-        if talent.subterfuge.enabled and this_action == "garrote" then
-            mult = mult * 1.8
+            mult = mult * 1.08
         end
     end
 


### PR DESCRIPTION
Nightstalker only boosts damage by 8% now https://www.wowhead.com/spell=14062/nightstalker#changelog

Subterfuge does not boost Garrote damage anymore https://www.wowhead.com/spell=108208/subterfuge#changelog

Basically the same as #2083 . I did not notice there are several bleed multiplier functions before.