### PR TITLE
Fixed Shield Block overlap

### DIFF
--- a/Dragonflight/WarriorProtection.lua
+++ b/Dragonflight/WarriorProtection.lua
@@ -1334,7 +1334,7 @@ spec:RegisterAbilities( {
         texture = 132110,
 
         nobuff = function()
-            if not settings.stack_shield_block or not legendary.reprisal.enabled then return "shield_block" end
+            if not settings.stack_shield_block then return "shield_block" end
         end,
 
         handler = function ()


### PR DESCRIPTION
Removed the condition for reprisal. With the new talents, you will hit full charges regardless of reprisal. Also checking for reprisal does not really make sense anymore anyway.