### PR TITLE
Updated EvokerPreservation.lua for 10.0.5

### DIFF
--- a/Dragonflight/EvokerPreservation.lua
+++ b/Dragonflight/EvokerPreservation.lua
@@ -768,7 +768,7 @@ spec:RegisterAbilities( {
 
         handler = function ()
             applyBuff( "reversion")
-            if talent.temporal_compression.enabled then addStack("temporal_compression") end
+            if talent.temporal_compression.enabled then addStack( "temporal_compression" ) end
         end,
     },
     rewind = {
@@ -787,7 +787,7 @@ spec:RegisterAbilities( {
         toggle = "cooldowns",
 
         handler = function ()
-            if talent.temporal_compression.enabled then addStack("temporal_compression") end
+            if talent.temporal_compression.enabled then addStack( "temporal_compression" ) end
         end,
     },
     spiritbloom = {
@@ -809,7 +809,7 @@ spec:RegisterAbilities( {
                 removeBuff( "tip_the_scales" )
                 setCooldown( "tip_the_scales", action.tip_the_scales.cooldown )
             end
-            removeBuff("temporal_compression")
+            removeBuff( "temporal_compression" )
         end,
 
         copy = { 382731, 367226 }
@@ -828,7 +828,7 @@ spec:RegisterAbilities( {
         toggle = "cooldowns",
 
         handler = function ()
-            if talent.temporal_compression.enabled then addStack("temporal_compression") end
+            if talent.temporal_compression.enabled then addStack( "temporal_compression" ) end
         end,
     },
     temporal_anomaly = {
@@ -843,12 +843,12 @@ spec:RegisterAbilities( {
         startsCombat = false,
 
         handler = function ()
-            if talent.temporal_compression.enabled then addStack("temporal_compression") end
-            if talent.resonating_sphere.enabled then applyBuff("echo") end
+            if talent.temporal_compression.enabled then addStack( "temporal_compression" ) end
+            if talent.resonating_sphere.enabled then applyBuff( "echo" ) end
             if talent.nozdormus_teachings.enabled then
-                reduceCooldown ("dream_breath",5)
-                reduceCooldown ("fire_breath",5)
-                reduceCooldown ("spiritbloom",5)
+                reduceCooldown( "dream_breath", 5 )
+                reduceCooldown( "fire_breath", 5 )
+                reduceCooldown( "spiritbloom", 5 )
             end
         end,
     },

--- a/Dragonflight/EvokerPreservation.lua
+++ b/Dragonflight/EvokerPreservation.lua
@@ -436,7 +436,7 @@ spec:RegisterAbilities( {
 
         toggle = "cooldowns",
 
-        min_range = 20,
+        min_range = 15,
         max_range = 50,
 
         damage = function () return 2.30 * stat.spell_power end,
@@ -527,6 +527,9 @@ spec:RegisterAbilities( {
         cast = 0.5,
         cooldown = 90,
         gcd = "spell",
+
+        spend = 0.04,
+        spendType = "mana",
 
         startsCombat = false,
 
@@ -831,7 +834,7 @@ spec:RegisterAbilities( {
     temporal_anomaly = {
         id = 373861,
         cast = 1.5,
-        cooldown = 6,
+        cooldown = 15,
         gcd = "spell",
 
         spend = 0.08,
@@ -842,6 +845,11 @@ spec:RegisterAbilities( {
         handler = function ()
             if talent.temporal_compression.enabled then addStack("temporal_compression") end
             if talent.resonating_sphere.enabled then applyBuff("echo") end
+            if talent.nozdormus_teachings.enabled then
+                reduceCooldown ("dream_breath",5)
+                reduceCooldown ("fire_breath",5)
+                reduceCooldown ("spiritbloom",5)
+            end
         end,
     },
     time_dilation = {


### PR DESCRIPTION
- Changed minimum range on Deep Breath
- Added Mana Spend for Dream Projection
- Changed cooldown for Temporal Anomaly
- Added cooldown reduction for Empowered Spells with Nozdormu's Teachings talented, when casting Temporal Anomaly

Confirmed via patch notes and tested in-game.

https://worldofwarcraft.com/en-gb/news/23892227/dragonflight-1005-content-update-notes