### PR TITLE
Adding refreshing_healing_potion

### DIFF
--- a/Classes.lua
+++ b/Classes.lua
@@ -2610,6 +2610,40 @@ all:RegisterAbilities( {
         end,
     },
 
+    refreshing_healing_potion = {
+        name = function () return ( GetItemInfo( 191380 ) ) or "Refreshing Healing Potion" end,
+        listName = function ()
+            local _, link, _, _, _, _, _, _, _, tex = GetItemInfo( 191380 )
+            if link and tex then return "|T" .. tex .. ":0|t " .. link end
+            return "|cff00ccff[Refreshing Healing Potion]|r"
+        end,
+        cast = 0,
+        cooldown = function () return time > 0 and 3600 or 60 end,
+        gcd = "off",
+
+        item = 191380,
+        bagItem = true,
+
+        startsCombat = false,
+        texture = 4497595,
+
+        usable = function ()
+            if GetItemCount( 191380 ) == 0 then return false, "requires Refreshing Healing Potion in bags"
+            elseif not IsUsableItem( 191380 ) then return false, "Refreshing Healing Potion on CD"
+            elseif health.current >= health.max then return false, "must be damaged" end
+            return true
+        end,
+
+        readyTime = function ()
+            local start, duration = GetItemCooldown( 191380 )
+            return max( 0, start + duration - query_time )
+        end,
+
+        handler = function ()
+            gain( 128250, "health" )
+        end,
+    },
+
     cancel_buff = {
         name = "Cancel Buff",
         listName = '|T136243:0|t |cff00ccff[Cancel Buff]|r',


### PR DESCRIPTION
Added healing potion to be suggested if added as custom apl entry akin to healthstone. 
Only checks for rank 3 Refreshing healing potion being present in bags, not lower ranks.