### PR TITLE
Prevoker/Disc/HPal Ability Updates

### DIFF
--- a/Dragonflight/EvokerPreservation.lua
+++ b/Dragonflight/EvokerPreservation.lua
@@ -589,7 +589,7 @@ spec:RegisterAbilities( {
 
             if buff.tip_the_scales.up then
                 removeBuff( "tip_the_scales" )
-                setCooldown( "tip_the_scales" , action.tip_the_scales.cooldown )
+                setCooldown( "tip_the_scales", action.tip_the_scales.cooldown )
             end
 
             if talent.leaping_flames.enabled then applyBuff( "leaping_flames", nil, empowerment_level ) end
@@ -760,10 +760,10 @@ spec:RegisterAbilities( {
         handler = function ()
             if buff.stasis_ready.down then
                 if talent.temporal_compression.enabled then addStack( "temporal_compression" ) end
-                addStack( "stasis", 3)
+                addStack( "stasis", 3 )
             end
             if buff.stasis_ready.up then
-                setCooldown( "stasis" ,90)
+                setCooldown( "stasis", 90)
                 removeBuff( "stasis_ready" )
             end
         end,
@@ -785,9 +785,9 @@ spec:RegisterAbilities( {
             if talent.temporal_compression.enabled then addStack( "temporal_compression" ) end
             if talent.resonating_sphere.enabled then applyBuff( "echo" ) end
             if talent.nozdormus_teachings.enabled then
-                reduceCooldown( "dream_breath" , 5 )
-                reduceCooldown( "fire_breath" , 5 )
-                reduceCooldown( "spiritbloom" , 5 )
+                reduceCooldown( "dream_breath", 5 )
+                reduceCooldown( "fire_breath", 5 )
+                reduceCooldown( "spiritbloom", 5 )
             end
             if buff.stasis.stack == 1 then applyBuff( "stasis_ready" ) end
             removeStack( "stasis" )

--- a/Dragonflight/EvokerPreservation.lua
+++ b/Dragonflight/EvokerPreservation.lua
@@ -702,7 +702,7 @@ spec:RegisterAbilities( {
         cast = 0,
         charges = function() return talent.erasure.enabled and 2 or nil end,
         cooldown = function() return talent.temporal_artificer.enabled and 180 or 240 end,
-        recharge = 240,
+        recharge = function() return talent.temporal_artificer.enabled and 180 or 240 end,
         gcd = "spell",
 
         spend = 0.05,
@@ -758,13 +758,12 @@ spec:RegisterAbilities( {
         usable = function () return buff.stasis_ready.up or buff.stasis.stack < 1, "Stasis not ready" end,
 
         handler = function ()
-            if buff.stasis_ready.down then
+            if buff.stasis_ready.up then
+                setCooldown( "stasis", 90 )
+                removeBuff( "stasis_ready" )
+            else
                 if talent.temporal_compression.enabled then addStack( "temporal_compression" ) end
                 addStack( "stasis", 3 )
-            end
-            if buff.stasis_ready.up then
-                setCooldown( "stasis", 90)
-                removeBuff( "stasis_ready" )
             end
         end,
 

--- a/Dragonflight/EvokerPreservation.lua
+++ b/Dragonflight/EvokerPreservation.lua
@@ -417,7 +417,7 @@ spec:RegisterAbilities( {
         toggle = "cooldowns",
 
         handler = function ()
-            if talent.temporal_compression.enabled then addStack("temporal_compression") end
+            if talent.temporal_compression.enabled then addStack( "temporal_compression" ) end
         end,
     },
     disintegrate = {
@@ -457,13 +457,13 @@ spec:RegisterAbilities( {
         startsCombat = false,
 
         handler = function ()
-            applyBuff("dream_breath")
-            applyBuff("dream_breath_hot")
-            removeBuff("call_of_ysera")
-            removeBuff("temporal_compression")
+            applyBuff( "dream_breath" )
+            applyBuff( "dream_breath_hot" )
+            removeBuff( "call_of_ysera" )
+            removeBuff( "temporal_compression" )
             if buff.tip_the_scales.up then
                 removeBuff( "tip_the_scales" )
-                setCooldown( "tip_the_scales", action.tip_the_scales.cooldown )
+                setCooldown( "tip_the_scales" , action.tip_the_scales.cooldown )
             end
             if buff.stasis.stack == 1 then applyBuff( "stasis_ready" ) end
             removeStack( "stasis" )
@@ -516,7 +516,7 @@ spec:RegisterAbilities( {
 
         handler = function ()
             removeStack( "essence_burst" )
-            if talent.temporal_compression.enabled then addStack("temporal_compression") end
+            if talent.temporal_compression.enabled then addStack( "temporal_compression" ) end
             if buff.stasis.stack == 1 then applyBuff( "stasis_ready" ) end
             removeStack( "stasis" )
         end,
@@ -539,7 +539,7 @@ spec:RegisterAbilities( {
         --    - Count shows on action button.
 
         handler = function ()
-            removeStack("essence_burst")
+            removeStack( "essence_burst" )
             -- if talent.cycle_of_life.enabled then
             --     if cycle_of_life_count == 2 then
             --         cycle_of_life_count = 0
@@ -583,13 +583,13 @@ spec:RegisterAbilities( {
         damage = function () return 1.334 * stat.spell_power * ( 1 + 0.1 * talent.blast_furnace.rank ) end,
 
         handler = function()
-            removeBuff("temporal_compression")
+            removeBuff( "temporal_compression" )
 
             applyDebuff( "target", "fire_breath" )
 
             if buff.tip_the_scales.up then
                 removeBuff( "tip_the_scales" )
-                setCooldown( "tip_the_scales", action.tip_the_scales.cooldown )
+                setCooldown( "tip_the_scales" , action.tip_the_scales.cooldown )
             end
 
             if talent.leaping_flames.enabled then applyBuff( "leaping_flames", nil, empowerment_level ) end
@@ -691,7 +691,7 @@ spec:RegisterAbilities( {
         startsCombat = false,
 
         handler = function ()
-            applyBuff( "reversion")
+            applyBuff( "reversion" )
             if talent.temporal_compression.enabled then addStack( "temporal_compression" ) end
             if buff.stasis.stack == 1 then applyBuff( "stasis_ready" ) end
             removeStack( "stasis" )
@@ -759,12 +759,12 @@ spec:RegisterAbilities( {
 
         handler = function ()
             if buff.stasis_ready.down then
-                if talent.temporal_compression.enabled then addStack("temporal_compression") end
+                if talent.temporal_compression.enabled then addStack( "temporal_compression" ) end
                 addStack( "stasis", 3)
             end
             if buff.stasis_ready.up then
-                setCooldown("stasis",90)
-                removeBuff("stasis_ready")
+                setCooldown( "stasis" ,90)
+                removeBuff( "stasis_ready" )
             end
         end,
 
@@ -785,9 +785,9 @@ spec:RegisterAbilities( {
             if talent.temporal_compression.enabled then addStack( "temporal_compression" ) end
             if talent.resonating_sphere.enabled then applyBuff( "echo" ) end
             if talent.nozdormus_teachings.enabled then
-                reduceCooldown( "dream_breath", 5 )
-                reduceCooldown( "fire_breath", 5 )
-                reduceCooldown( "spiritbloom", 5 )
+                reduceCooldown( "dream_breath" , 5 )
+                reduceCooldown( "fire_breath" , 5 )
+                reduceCooldown( "spiritbloom" , 5 )
             end
             if buff.stasis.stack == 1 then applyBuff( "stasis_ready" ) end
             removeStack( "stasis" )
@@ -807,7 +807,7 @@ spec:RegisterAbilities( {
         toggle = "cooldowns",
 
         handler = function ()
-            if talent.temporal_compression.enabled then addStack("temporal_compression") end
+            if talent.temporal_compression.enabled then addStack( "temporal_compression" ) end
         end,
     },
         -- Talent: Fly to an ally and heal them for 4,557.
@@ -826,8 +826,8 @@ spec:RegisterAbilities( {
         startsCombat = false,
 
         handler = function ()
-            if talent.lifebind.enabled then applyBuff("lifebind") end
-            if talent.call_of_ysera.enabled then applyBuff("call_of_ysera") end
+            if talent.lifebind.enabled then applyBuff( "lifebind" ) end
+            if talent.call_of_ysera.enabled then applyBuff( "call_of_ysera" ) end
         end,
     },
 } )

--- a/Dragonflight/EvokerPreservation.lua
+++ b/Dragonflight/EvokerPreservation.lua
@@ -209,6 +209,11 @@ spec:RegisterAuras( {
         tick_time = 1,
         max_stack = 1
     },
+    lifebind = {
+        id = 373267,
+        duration = 5,
+        max_stack = 1
+    },
     mastery_lifebinder = {
         id = 363510,
     },
@@ -245,6 +250,11 @@ spec:RegisterAuras( {
         duration = 3600,
         max_stack = 3
     },
+    stasis_ready = {
+        id = 370562,
+        duration = 30,
+        max_stack = 1
+    },    
     temporal_anomaly = { -- TODO: Creates an absorb vortex effect.
         id = 373861,
         duration = 6,
@@ -389,6 +399,8 @@ spec:RegisterAbilities( {
             removeBuff( "dispellable_disease" )
             -- removeBuff( "dispellable_bleed" )
             health.current = min( health.max, health.current + action.cauterizing_flame.healing )
+            if buff.stasis.stack == 1 then applyBuff( "stasis_ready" ) end
+            removeStack( "stasis" )
         end,
     },
     chrono_loop = {
@@ -453,6 +465,8 @@ spec:RegisterAbilities( {
                 removeBuff( "tip_the_scales" )
                 setCooldown( "tip_the_scales", action.tip_the_scales.cooldown )
             end
+            if buff.stasis.stack == 1 then applyBuff( "stasis_ready" ) end
+            removeStack( "stasis" )
         end,
 
         copy = { 382614, 355936 }
@@ -503,6 +517,8 @@ spec:RegisterAbilities( {
         handler = function ()
             removeStack( "essence_burst" )
             if talent.temporal_compression.enabled then addStack("temporal_compression") end
+            if buff.stasis.stack == 1 then applyBuff( "stasis_ready" ) end
+            removeStack( "stasis" )
         end,
     },
     emerald_blossom = {
@@ -532,6 +548,8 @@ spec:RegisterAbilities( {
             --         cycle_of_life_count = cycle_of_life_count + 1
             --     end
             -- end
+            if buff.stasis.stack == 1 then applyBuff( "stasis_ready" ) end
+            removeStack( "stasis" )
         end,
     },
     emerald_communion = {
@@ -600,6 +618,8 @@ spec:RegisterAbilities( {
             removeBuff( "scarlet_adaptation" )
             removeBuff( "call_of_ysera" )
             removeStack( "lifespark" )
+            if buff.stasis.stack == 1 then applyBuff( "stasis_ready" ) end
+            removeStack( "stasis" )
         end,
     },
     naturalize = {
@@ -622,6 +642,8 @@ spec:RegisterAbilities( {
         handler = function ()
             removeBuff( "dispellable_poison" )
             removeBuff( "dispellable_magic" )
+            if buff.stasis.stack == 1 then applyBuff( "stasis_ready" ) end
+            removeStack( "stasis" )
         end,
     },
     nullifying_shroud = {
@@ -671,14 +693,16 @@ spec:RegisterAbilities( {
         handler = function ()
             applyBuff( "reversion")
             if talent.temporal_compression.enabled then addStack( "temporal_compression" ) end
+            if buff.stasis.stack == 1 then applyBuff( "stasis_ready" ) end
+            removeStack( "stasis" )
         end,
     },
     rewind = {
         id = 363534,
         cast = 0,
-        charges = 1,
-        cooldown = 180,
-        recharge = 180,
+        charges = function() return talent.erasure.enabled and 2 or nil end,
+        cooldown = function() return talent.temporal_artificer.enabled and 180 or 240 end,
+        recharge = 240,
         gcd = "spell",
 
         spend = 0.05,
@@ -712,26 +736,39 @@ spec:RegisterAbilities( {
                 setCooldown( "tip_the_scales", action.tip_the_scales.cooldown )
             end
             removeBuff( "temporal_compression" )
+            if buff.stasis.stack == 1 then applyBuff( "stasis_ready" ) end
+            removeStack( "stasis" )
         end,
 
         copy = { 382731, 367226 }
     },
     stasis = {
-        id = 370537,
+        id = function () return buff.stasis_ready.up and 370564 or 370537 end,
         cast = 0,
         cooldown = 90,
         gcd = "off",
 
-        spend = 0.04,
+        spend = function () return buff.stasis_ready.up and 0 or 0.04 end,
         spendType = "mana",
 
         startsCombat = false,
 
         toggle = "cooldowns",
 
+        usable = function () return buff.stasis_ready.up or buff.stasis.stack < 1, "Stasis not ready" end,
+
         handler = function ()
-            if talent.temporal_compression.enabled then addStack( "temporal_compression" ) end
+            if buff.stasis_ready.down then
+                if talent.temporal_compression.enabled then addStack("temporal_compression") end
+                addStack( "stasis", 3)
+            end
+            if buff.stasis_ready.up then
+                setCooldown("stasis",90)
+                removeBuff("stasis_ready")
+            end
         end,
+
+        copy = { 370564, 370537, "stasis" }
     },
     temporal_anomaly = {
         id = 373861,
@@ -752,6 +789,8 @@ spec:RegisterAbilities( {
                 reduceCooldown( "fire_breath", 5 )
                 reduceCooldown( "spiritbloom", 5 )
             end
+            if buff.stasis.stack == 1 then applyBuff( "stasis_ready" ) end
+            removeStack( "stasis" )
         end,
     },
     time_dilation = {
@@ -768,7 +807,27 @@ spec:RegisterAbilities( {
         toggle = "cooldowns",
 
         handler = function ()
-            if talent.temporal_compression.enabled then addStack( "temporal_compression" ) end
+            if talent.temporal_compression.enabled then addStack("temporal_compression") end
+        end,
+    },
+        -- Talent: Fly to an ally and heal them for 4,557.
+    verdant_embrace = {
+        id = 360995,
+        cast = 0,
+        cooldown = 24,
+        gcd = "spell",
+        school = "nature",
+        color = "green",
+
+        spend = 0.03,
+        spendType = "mana",
+
+        talent = "verdant_embrace",
+        startsCombat = false,
+
+        handler = function ()
+            if talent.lifebind.enabled then applyBuff("lifebind") end
+            if talent.call_of_ysera.enabled then applyBuff("call_of_ysera") end
         end,
     },
 } )

--- a/Dragonflight/EvokerPreservation.lua
+++ b/Dragonflight/EvokerPreservation.lua
@@ -463,7 +463,7 @@ spec:RegisterAbilities( {
             removeBuff( "temporal_compression" )
             if buff.tip_the_scales.up then
                 removeBuff( "tip_the_scales" )
-                setCooldown( "tip_the_scales" , action.tip_the_scales.cooldown )
+                setCooldown( "tip_the_scales", action.tip_the_scales.cooldown )
             end
             if buff.stasis.stack == 1 then applyBuff( "stasis_ready" ) end
             removeStack( "stasis" )

--- a/Dragonflight/PaladinHoly.lua
+++ b/Dragonflight/PaladinHoly.lua
@@ -321,6 +321,11 @@ spec:RegisterAuras( {
         duration = 5.113,
         max_stack = 1,
     },
+    maraads_dying_breath = {
+        id = 388019,
+        duration = 10,
+        max_stack = 5,
+    },
     mastery_lightbringer = {
         id = 183997,
     },

--- a/Dragonflight/PaladinHoly.lua
+++ b/Dragonflight/PaladinHoly.lua
@@ -1190,6 +1190,7 @@ spec:RegisterAbilities( {
 
         handler = function ()
             removeBuff( "divine_purpose" )
+            if talent.maraads_dying_breath.enabled then applyBuff( "maraads_dying_breath" ) end
         end,
     },
 

--- a/Dragonflight/PriestDiscipline.lua
+++ b/Dragonflight/PriestDiscipline.lua
@@ -155,6 +155,11 @@ spec:RegisterAuras( {
         duration = 15,
         max_stack = 1
     },
+    atonement = {
+        id = 194384,
+        duration = 15,
+        max_stack = 1
+    },
     body_and_soul = {
         id = 65081,
         duration = 3,
@@ -200,6 +205,16 @@ spec:RegisterAuras( {
         id = 45242,
         duration = 8,
         max_stack = 1
+    },
+    harsh_discipline = {
+        id = 373183,
+        duration = 30,
+        max_stack = 1
+    },
+    harsh_discipline_stack = {
+        id = 373181,
+        duration = 3600,
+        max_stack = 3
     },
     inspiration = {
         id = 390677,
@@ -495,6 +510,11 @@ spec:RegisterAbilities( {
         texture = 136224,
 
         handler = function ()
+            if buff.harsh_discipline_stack.stack == 3
+                then applyBuff("harsh_discipline")
+                    buff.harsh_discipline_stack.stack = 0
+                else addStack("harsh_discipline_stack")
+            end
         end,
     },
 
@@ -552,6 +572,7 @@ spec:RegisterAbilities( {
 
         start = function ()
             removeBuff( "power_of_the_dark_side" )
+            removeBuff("harsh_discipline")
             if debuff.purge_the_wicked.up then active_dot.purge_the_wicked = min( active_dot.purge_the_wicked + 1, true_active_enemies ) end
         end,
     },
@@ -580,9 +601,9 @@ spec:RegisterAbilities( {
     power_word_radiance = {
         id = 194509,
         cast = 2,
-        charges = 1,
+        charges = function() return talent.lights_promise.enabled and 2 or nil end,
         cooldown = 20,
-        recharge = 20,
+        recharge = function() return talent.lights_promise.enabled and 15 or nil end,
         gcd = "spell",
 
         spend = 0.06,
@@ -615,6 +636,11 @@ spec:RegisterAbilities( {
 
         handler = function ()
             gain( 0.01 * mana.max, "mana" )
+            if buff.harsh_discipline_stack.stack == 3
+                then applyBuff("harsh_discipline")
+                    buff.harsh_discipline_stack.stack = 0
+                else addStack("harsh_discipline_stack")
+            end
         end,
     },
 
@@ -772,6 +798,11 @@ spec:RegisterAbilities( {
         texture = 135924,
 
         handler = function ()
+            if buff.harsh_discipline_stack.stack == 3
+                then applyBuff("harsh_discipline")
+                    buff.harsh_discipline_stack.stack = 0
+                else addStack("harsh_discipline_stack")
+            end
         end,
     },
 

--- a/Dragonflight/PriestDiscipline.lua
+++ b/Dragonflight/PriestDiscipline.lua
@@ -511,9 +511,9 @@ spec:RegisterAbilities( {
 
         handler = function ()
             if buff.harsh_discipline_stack.stack == 3
-                then applyBuff("harsh_discipline")
-                    buff.harsh_discipline_stack.stack = 0
-                else addStack("harsh_discipline_stack")
+                then applyBuff( "harsh_discipline" )
+                    removeBuff( "harsh_discipline_stack" )
+                else addStack( "harsh_discipline_stack" )
             end
         end,
     },
@@ -572,7 +572,7 @@ spec:RegisterAbilities( {
 
         start = function ()
             removeBuff( "power_of_the_dark_side" )
-            removeBuff("harsh_discipline")
+            removeBuff( "harsh_discipline" )
             if debuff.purge_the_wicked.up then active_dot.purge_the_wicked = min( active_dot.purge_the_wicked + 1, true_active_enemies ) end
         end,
     },
@@ -637,9 +637,9 @@ spec:RegisterAbilities( {
         handler = function ()
             gain( 0.01 * mana.max, "mana" )
             if buff.harsh_discipline_stack.stack == 3
-                then applyBuff("harsh_discipline")
-                    buff.harsh_discipline_stack.stack = 0
-                else addStack("harsh_discipline_stack")
+                then applyBuff( "harsh_discipline" )
+                    removeBuff( "harsh_discipline_stack" )
+                else addStack( "harsh_discipline_stack" )
             end
         end,
     },
@@ -799,9 +799,9 @@ spec:RegisterAbilities( {
 
         handler = function ()
             if buff.harsh_discipline_stack.stack == 3
-                then applyBuff("harsh_discipline")
-                    buff.harsh_discipline_stack.stack = 0
-                else addStack("harsh_discipline_stack")
+                then applyBuff( "harsh_discipline" )
+                    removeBuff( "harsh_discipline_stack" )
+                else addStack( "harsh_discipline_stack" )
             end
         end,
     },

--- a/Dragonflight/PriestDiscipline.lua
+++ b/Dragonflight/PriestDiscipline.lua
@@ -207,14 +207,14 @@ spec:RegisterAuras( {
         max_stack = 1
     },
     harsh_discipline = {
+        id = 373181,
+        duration = 3600,
+        max_stack = 10
+    },
+    harsh_discipline_ready = {
         id = 373183,
         duration = 30,
         max_stack = 1
-    },
-    harsh_discipline_stack = {
-        id = 373181,
-        duration = 3600,
-        max_stack = 3
     },
     inspiration = {
         id = 390677,
@@ -510,10 +510,13 @@ spec:RegisterAbilities( {
         texture = 136224,
 
         handler = function ()
-            if buff.harsh_discipline_stack.stack == 3
-                then applyBuff( "harsh_discipline" )
-                    removeBuff( "harsh_discipline_stack" )
-                else addStack( "harsh_discipline_stack" )
+            if talent.harsh_discipline.enabled then
+                if buff.harsh_discipline.up and buff.harsh_discipline.stack == 9 then
+                    removeBuff( "harsh_discipline" )
+                    applyBuff( "harsh_discipline_ready" )
+                else
+                    addStack( "harsh_discipline" )
+                end
             end
         end,
     },
@@ -564,7 +567,7 @@ spec:RegisterAbilities( {
         cooldown = 9,
         gcd = "spell",
 
-        spend = 0.02,
+        spend = function() return buff.harsh_discipline_ready.up and 0 or 0.02 end,
         spendType = "mana",
 
         startsCombat = true,
@@ -572,7 +575,7 @@ spec:RegisterAbilities( {
 
         start = function ()
             removeBuff( "power_of_the_dark_side" )
-            removeBuff( "harsh_discipline" )
+            removeBuff( "harsh_discipline_ready" )
             if debuff.purge_the_wicked.up then active_dot.purge_the_wicked = min( active_dot.purge_the_wicked + 1, true_active_enemies ) end
         end,
     },
@@ -601,9 +604,9 @@ spec:RegisterAbilities( {
     power_word_radiance = {
         id = 194509,
         cast = 2,
-        charges = function() return talent.lights_promise.enabled and 2 or nil end,
+        charges = function() if talent.lights_promise.enabled then return 2 end end,
         cooldown = 20,
-        recharge = function() return talent.lights_promise.enabled and 15 or nil end,
+        recharge = function() if talent.lights_promise.enabled then return 20 end end,
         gcd = "spell",
 
         spend = 0.06,
@@ -636,11 +639,15 @@ spec:RegisterAbilities( {
 
         handler = function ()
             gain( 0.01 * mana.max, "mana" )
-            if buff.harsh_discipline_stack.stack == 3
-                then applyBuff( "harsh_discipline" )
-                    removeBuff( "harsh_discipline_stack" )
-                else addStack( "harsh_discipline_stack" )
-            end
+            
+            if talent.harsh_discipline.enabled then
+                if buff.harsh_discipline.up and buff.harsh_discipline.stack == 9 then
+                    removeBuff( "harsh_discipline" )
+                    applyBuff( "harsh_discipline_ready" )
+                else
+                    addStack( "harsh_discipline" )
+                end
+            end    
         end,
     },
 
@@ -798,10 +805,13 @@ spec:RegisterAbilities( {
         texture = 135924,
 
         handler = function ()
-            if buff.harsh_discipline_stack.stack == 3
-                then applyBuff( "harsh_discipline" )
-                    removeBuff( "harsh_discipline_stack" )
-                else addStack( "harsh_discipline_stack" )
+            if talent.harsh_discipline.enabled then
+                if buff.harsh_discipline.up and buff.harsh_discipline.stack == 9 then
+                    removeBuff( "harsh_discipline" )
+                    applyBuff( "harsh_discipline_ready" )
+                else
+                    addStack( "harsh_discipline" )
+                end
             end
         end,
     },


### PR DESCRIPTION
- **Discipline Priest:** added Atonement aura, Harsh Discipline & stacks,  and Power Word Radiance charges with talent.
- **Holy Paladin:** added Maraad's Dying Breath aura.
- **Preservation Evoker:** added better Stasis handling, Rewind talent updates, and updates to support interactions with Verdant Embrace, Lifebind, and Call of Ysera.