### PR TITLE
Fix WeakAuras Event Payload

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -1984,22 +1984,27 @@ function Hekili.Update( initial )
 
             UI:SetThreadLocked( false )
 
-            if UI.EventPayload then
-                wipe( UI.EventPayload )
-            else
-                UI.EventPayload = {}        
+            if not UI.EventPayload then
+                UI.EventPayload = {
+                    {}, -- [1]
+                }
+                setmetatable( UI.EventPayload, {
+                    __index = UI.EventPayload[ 1 ],
+                    __mode  = "kv"
+                } )
             end
 
             for i = 1, numRecs do
-                UI.EventPayload[ i ] = {}
+                if UI.EventPayload[ i ] then wipe( UI.EventPayload[ i ] )
+                else UI.EventPayload[ i ] = {} end
+
                 for k, v in pairs( Queue[ i ] ) do
                     UI.EventPayload[ i ][ k ] = v                   
                 end
             end
-            setmetatable(UI.EventPayload, {__index = UI.EventPayload[1], __mode="kv"})
 
             if WeakAuras and WeakAuras.ScanEvents then
-                WeakAuras.ScanEvents( "HEKILI_RECOMMENDATION_UPDATE", dispName, Queue[ 1 ].actionID, Queue[ 1 ].indicator, Queue[ 1 ].empower_to, UI.EventPayload)
+                WeakAuras.ScanEvents( "HEKILI_RECOMMENDATION_UPDATE", dispName, Queue[ 1 ].actionID, Queue[ 1 ].indicator, Queue[ 1 ].empower_to, UI.EventPayload )
             end
 
             if debug then

--- a/Core.lua
+++ b/Core.lua
@@ -1987,7 +1987,7 @@ function Hekili.Update( initial )
             if UI.EventPayload then
                 wipe( UI.EventPayload )
             else
-                UI.EventPayload = {}
+                UI.EventPayload = {}        
             end
 
             for i = 1, numRecs do
@@ -1995,9 +1995,11 @@ function Hekili.Update( initial )
                 for k, v in pairs( Queue[ i ] ) do
                     UI.EventPayload[ i ][ k ] = v                   
                 end
-                if WeakAuras and WeakAuras.ScanEvents then
-                    WeakAuras.ScanEvents( "HEKILI_RECOMMENDATION_UPDATE", dispName, Queue[ i ].actionID, Queue[ i ].indicator, Queue[ i ].empower_to, UI.EventPayload[ i ] )
-                end
+            end
+            setmetatable(UI.EventPayload, {__index = UI.EventPayload[1], __mode="kv"})
+
+            if WeakAuras and WeakAuras.ScanEvents then
+                WeakAuras.ScanEvents( "HEKILI_RECOMMENDATION_UPDATE", dispName, Queue[ 1 ].actionID, Queue[ 1 ].indicator, Queue[ 1 ].empower_to, UI.EventPayload)
             end
 
             if debug then

--- a/Core.lua
+++ b/Core.lua
@@ -1990,12 +1990,14 @@ function Hekili.Update( initial )
                 UI.EventPayload = {}
             end
 
-            for k, v in pairs( Queue[ 1 ] ) do
-                UI.EventPayload[ k ] = v
-            end
-
-            if WeakAuras and WeakAuras.ScanEvents then
-                WeakAuras.ScanEvents( "HEKILI_RECOMMENDATION_UPDATE", dispName, Queue[ 1 ].actionID, Queue[ 1 ].indicator, Queue[ 1 ].empower_to, UI.EventPayload )
+            for i = 1, numRecs do
+                UI.EventPayload[ i ] = {}
+                for k, v in pairs( Queue[ i ] ) do
+                    UI.EventPayload[ i ][ k ] = v                   
+                end
+                if WeakAuras and WeakAuras.ScanEvents then
+                    WeakAuras.ScanEvents( "HEKILI_RECOMMENDATION_UPDATE", dispName, Queue[ i ].actionID, Queue[ i ].indicator, Queue[ i ].empower_to, UI.EventPayload[ i ] )
+                end
             end
 
             if debug then


### PR DESCRIPTION
The logic for updating the EventPayload didn't take into account the number of recommendations and would always send the payload for the first slot / recommendation only. This has two impacts:

1) It made it less efficient to use in a TSU as you were forced to use for loops and calls to  Hekili_GetRecommendedAbility as opposed to just using the information passed by the event to build the state table
2) It broke  Hekili_GetRecommendedAbility since that function seemed to assume that the EventPayload in fact did take the number of recommendations into account and thus the payload it would return was always nil

Since the EventPayload / slot has a bunch of really useful information in it (key bindings, cooldown information, etc.) having that table is pretty critical to being able to develop a useful WeakAura. In effect there was no way to get this information since the event only ever sent the first slot, and the function to get other slots always returned a nil payload table.

This pull request resolves this issue without breaking the existing contract for the WA Event