### PR TITLE
Warrior: 10.1 Patch T30 Set integration + Small changes

### DIFF
--- a/Dragonflight/WarriorArms.lua
+++ b/Dragonflight/WarriorArms.lua
@@ -499,12 +499,22 @@ local TriggerCollateralDamage = setfenv( function()
     collateralDmgStacks = 0
 end, state )
 
+local TriggerCrushingAdvance = setfenv( function()
+    addStack( "crushing_advance" )
+end, state )
+
+
 spec:RegisterCombatLogEvent( function( _, subtype, _,  sourceGUID, sourceName, _, _, destGUID, destName, destFlags, _, spellID, spellName, _, _, _, _, critical_swing, _, _, critical_spell )
     if sourceGUID == state.GUID then
         if subtype == "SPELL_CAST_SUCCESS" then
             if ( spellName == class.abilities.colossus_smash.name or spellName == class.abilities.warbreaker.name ) then
                 last_cs_target = destGUID
             end
+        -- Tier30 4pc Set Bonus check
+        elseif subtype == "SPELL_DAMAGE" and state.set_bonus.tier30_4pc > 0 then
+            local ability = class.abilities[ spellID ]
+            if not ability then return end
+            if ability.key == "deep_wounds" and critical_spell then TriggerCrushingAdvance() end
         end
     end
 end )
@@ -1146,6 +1156,7 @@ spec:RegisterAbilities( {
             removeBuff( "overpower" )
             removeBuff( "executioners_precision" )
             removeBuff( "battlelord" )
+            if state.set_bonus.tier30_4pc > 0 then removeBuff( "crushing_advance" ) end
         end,
     },
 

--- a/Dragonflight/WarriorArms.lua
+++ b/Dragonflight/WarriorArms.lua
@@ -611,6 +611,17 @@ spec:RegisterAura( "strike_vulnerabilities", {
     max_stack = 1
 } )
 
+spec:RegisterGear( "tier30", 202446, 202444, 202443, 202442, 202441 )
+spec:RegisterSetBonuses( "tier30_2pc", 405577, "tier30_4pc", 405578 )
+--(2) Set Bonus: Deep Wounds increases your chance to critically strike and critical strike damage dealt to afflicted targets by 5%.
+--(4) Deep Wounds critical strikes have a chance to increase the damage of your next Mortal Strike by 10% and cause it to deal
+--    [(19.32% of Attack power) * 2] Physical damage to enemies in front of you, stacking up to 3 times. Damage reduced above 5 targets. (2s cooldown)
+spec:RegisterAura( "crushing_advance", {
+    id = 410138,
+    duration = 30,
+    max_stack = 3
+} )
+
 
 -- Abilities
 spec:RegisterAbilities( {

--- a/Dragonflight/WarriorArms.lua
+++ b/Dragonflight/WarriorArms.lua
@@ -285,7 +285,8 @@ spec:RegisterAuras( {
     },
     fatal_mark = {
         id = 383704,
-        duration = 120,
+        -- TODO: Remove retail/PTR compatibility if statement post 10.1 release.
+        duration = function() return Hekili.CurrentBuild > 100007 and 180 or 120 end ,
         max_stack = 999
     },
     hamstring = {
@@ -1157,6 +1158,11 @@ spec:RegisterAbilities( {
             removeBuff( "executioners_precision" )
             removeBuff( "battlelord" )
             if state.set_bonus.tier30_4pc > 0 then removeBuff( "crushing_advance" ) end
+            -- Patch 10.1 adds auto Rend to target using MS with talent under 35% HP
+            -- TODO: Remove retail/PTR compatibility if statement post 10.1 release.
+            if Hekili.CurrentBuild > 100007 and target.health.pct < 35 and talent.bloodletting.enabled then
+                applyDebuff ( "target", "rend" )
+            end
         end,
     },
 

--- a/Dragonflight/WarriorArms.lua
+++ b/Dragonflight/WarriorArms.lua
@@ -500,22 +500,12 @@ local TriggerCollateralDamage = setfenv( function()
     collateralDmgStacks = 0
 end, state )
 
-local TriggerCrushingAdvance = setfenv( function()
-    addStack( "crushing_advance" )
-end, state )
-
-
 spec:RegisterCombatLogEvent( function( _, subtype, _,  sourceGUID, sourceName, _, _, destGUID, destName, destFlags, _, spellID, spellName, _, _, _, _, critical_swing, _, _, critical_spell )
     if sourceGUID == state.GUID then
         if subtype == "SPELL_CAST_SUCCESS" then
             if ( spellName == class.abilities.colossus_smash.name or spellName == class.abilities.warbreaker.name ) then
                 last_cs_target = destGUID
             end
-        -- Tier30 4pc Set Bonus check
-        elseif subtype == "SPELL_DAMAGE" and state.set_bonus.tier30_4pc > 0 then
-            local ability = class.abilities[ spellID ]
-            if not ability then return end
-            if ability.key == "deep_wounds" and critical_spell then TriggerCrushingAdvance() end
         end
     end
 end )

--- a/Dragonflight/WarriorArms.lua
+++ b/Dragonflight/WarriorArms.lua
@@ -72,7 +72,7 @@ spec:RegisterTalents( {
     leeching_strikes                = { 90344, 382258, 1 }, -- Leech increased by 5%.
     menace                          = { 90383, 275338, 1 }, -- Intimidating Shout will knock back all nearby enemies except your primary target, and cause them all to cower in fear for 15 sec instead of fleeing.
     overwhelming_rage               = { 90378, 382767, 2 }, -- Maximum Rage increased by 15.
-    pain_and_gain                   = { 90353, 382549, 1 }, -- When you take any damage, heal for 4.50% of your maximum health. This can only occur once every 10 sec.
+    pain_and_gain                   = { 90353, 382549, 1 }, -- When you take any damage, heal for 3.50% of your maximum health. This can only occur once every 10 sec.
     piercing_howl                   = { 90348, 12323 , 1 }, -- Snares all enemies within 12 yards, reducing their movement speed by 70% for 8 sec.
     piercing_verdict                = { 90379, 382948, 1 }, -- Spear of Bastion's instant damage increased by 50% and its Rage generation is increased by 100%.
     rallying_cry                    = { 90331, 97462 , 1 }, -- Lets loose a rallying cry, granting all party or raid members within 40 yards 15% temporary and maximum health for 10 sec.
@@ -146,7 +146,7 @@ spec:RegisterTalents( {
     skullsplitter                   = { 90281, 260643, 1 }, -- Bash an enemy's skull, dealing 1,909 Physical damage. Skullsplitter causes your Deep Wounds to expire instantly. Generates 15 Rage.
     spiteful_serenity               = { 90289, 400314, 1 }, -- Colossus Smash and Avatar's durations are increased by 100% but their damage bonuses are reduced by 40%.
     storm_of_swords                 = { 90267, 385512, 1 }, -- Whirlwind costs 20 more Rage and has a 14.0 sec cooldown. It now deals 175% more damage.
-    storm_wall                      = { 90269, 388807, 1 }, -- Whenever you Parry, you heal for 10.00% of your maximum health. Can only occur once per second.
+    storm_wall                      = { 90269, 388807, 1 }, -- Whenever you Parry, you heal for 8.00% of your maximum health. Can only occur once per second.
     strength_of_arms                = { 92536, 400803, 1 }, -- Overpower has 10% increased critical strike chance, deals 10% increased critical strike damage and on enemies below 35% health Overpower generates 8 Rage.
     sudden_death                    = { 90274, 29725 , 1 }, -- Your attacks have a chance to make your next Execute cost no Rage, be usable on any target regardless of their health, and deal damage as if you spent 40 Rage.
     tactician                       = { 90282, 184783, 1 }, -- You have a 2.30% chance per Rage spent on abilities to reset the remaining cooldown on Overpower.

--- a/Dragonflight/WarriorFury.lua
+++ b/Dragonflight/WarriorFury.lua
@@ -1457,7 +1457,7 @@ spec:RegisterAbilities( {
             removeStack( "whirlwind" )
             if talent.frenzy.enabled then addStack( "frenzy" ) end
             if talent.reckless_abandon.enabled then addStack( "reckless_abandon", nil, 2 ) end
-            if state.set_bonus.tier30_4pc > 0 then addStack ( "merciless_assault" ) end
+            if state.set_bonus.tier30_4pc > 0 then addStack( "merciless_assault" ) end
         end,
     },
 

--- a/Dragonflight/WarriorFury.lua
+++ b/Dragonflight/WarriorFury.lua
@@ -482,6 +482,16 @@ spec:RegisterSetBonuses( "tier29_2pc", 393708, "tier29_4pc", 393709 )
 -- 2-Set - Execute’s chance to critically strike increased by 10%.
 -- 4-Set - Sudden Death’s chance to reset the cooldown of Execute and make it usable on any target, regardless of health, is greatly increased.
 
+spec:RegisterGear( "tier30", 202446, 202444, 202443, 202442, 202441 )
+spec:RegisterSetBonuses( "tier30_2pc", 405579, "tier30_4pc", 405580 )
+--(2) Rampage damage and critical strike chance increased by 10%.
+--(4) Rampage causes your next Bloodthirst to have a 10% increased critical strike chance, deal 25% increased damage and generate 2 additional Rage. Stacking up to 10 times.
+spec:RegisterAura( "merciless_assault", {
+    id = 409983,
+    duration = 14,
+    max_stack = 10
+} )
+
 spec:RegisterGear( 'tier20', 147187, 147188, 147189, 147190, 147191, 147192 )
     spec:RegisterAura( "raging_thirst", {
         id = 242300,

--- a/Dragonflight/WarriorFury.lua
+++ b/Dragonflight/WarriorFury.lua
@@ -130,7 +130,7 @@ spec:RegisterTalents( {
     leeching_strikes          = { 90344, 382258, 1 }, -- Leech increased by 5%.
     menace                    = { 90383, 275338, 1 }, -- Intimidating Shout will knock back all nearby enemies except your primary target, and cause them all to cower in fear for 15 sec instead of fleeing.
     overwhelming_rage         = { 90378, 382767, 2 }, -- Maximum Rage increased by 15.
-    pain_and_gain             = { 90353, 382549, 1 }, -- When you take any damage, heal for 4.50% of your maximum health. This can only occur once every 10 sec.
+    pain_and_gain             = { 90353, 382549, 1 }, -- When you take any damage, heal for 3.50% of your maximum health. This can only occur once every 10 sec.
     piercing_howl             = { 90348, 12323 , 1 }, -- Snares all enemies within 12 yards, reducing their movement speed by 70% for 8 sec.
     piercing_verdict          = { 90379, 382948, 1 }, -- Spear of Bastion's instant damage increased by 50% and its Rage generation is increased by 100%.
     rallying_cry              = { 90331, 97462 , 1 }, -- Lets loose a rallying cry, granting all party or raid members within 40 yards 15% temporary and maximum health for 10 sec.
@@ -188,7 +188,7 @@ spec:RegisterTalents( {
     improved_execute          = { 90430, 316402, 1 }, -- Execute no longer costs Rage and now generates 20 Rage.
     improved_raging_blow      = { 90390, 383854, 1 }, -- Raging Blow has 2 charges and has a 20% chance to instantly reset its own cooldown.
     improved_whirlwind        = { 90427, 12950 , 1 }, -- Whirlwind causes your next 2 single-target attacks to strike up to 4 additional targets for 50% damage. Whirlwind generates 3 Rage, plus an additional 1 per target hit. Maximum 8 Rage.
-    invigorating_fury         = { 90393, 383468, 1 }, -- Enraged Regeneration lasts 3 sec longer and instantly heals for 20% of your maximum health.
+    invigorating_fury         = { 90393, 383468, 1 }, -- Enraged Regeneration lasts 3 sec longer and instantly heals for 15% of your maximum health.
     massacre                  = { 90410, 206315, 1 }, -- Execute is now usable on targets below 35% health, and its cooldown is reduced by 1.5 sec.
     meat_cleaver              = { 90391, 280392, 1 }, -- Whirlwind deals 25% more damage and now affects your next 4 single-target melee attacks, instead of the next 2 attacks.
     odyns_fury                = { 90418, 385059, 1 }, -- Unleashes your power, dealing 4,578 Physical damage and an additional 1,720 Physical damage over 4 sec to all enemies within 12 yards. Generates 15 Rage.
@@ -900,7 +900,7 @@ spec:RegisterAbilities( {
                 applyBuff( "enrage" )
                 applyDebuff( "target", "hit_by_fresh_meat" )
             end
-            if talent.invigorating_fury.enabled then gain ( health.max * 0.2 , "health" ) end
+            if talent.invigorating_fury.enabled then gain ( health.max * 0.15 , "health" ) end
 
             if legendary.cadence_of_fujieda.enabled then
                 if buff.cadence_of_fujieda.stack < 5 then stat.haste = stat.haste + 0.01 end

--- a/Dragonflight/WarriorFury.lua
+++ b/Dragonflight/WarriorFury.lua
@@ -1457,7 +1457,7 @@ spec:RegisterAbilities( {
             removeStack( "whirlwind" )
             if talent.frenzy.enabled then addStack( "frenzy" ) end
             if talent.reckless_abandon.enabled then addStack( "reckless_abandon", nil, 2 ) end
-            if state.set_bonus.tier30_4pc > 0 then addStack ("merciless_assault") end
+            if state.set_bonus.tier30_4pc > 0 then addStack ( "merciless_assault" ) end
         end,
     },
 

--- a/Dragonflight/WarriorFury.lua
+++ b/Dragonflight/WarriorFury.lua
@@ -870,7 +870,12 @@ spec:RegisterAbilities( {
         cooldown = function () return ( 3 - talent.deft_experience.rank * 0.75 ) * haste end,
         gcd = "spell",
 
-        spend = -8,
+        spend = function()
+            if state.set_bonus.tier30_4pc > 0 and buff.merciless_assault.stack > 0 then
+                return -8 - ( 2 * buff.merciless_assault.stack )
+            else return -8
+            end
+        end,
         spendType = "rage",
 
         cycle = function () return talent.fresh_meat.enabled and "hit_by_fresh_meat" or nil end,
@@ -901,6 +906,8 @@ spec:RegisterAbilities( {
                 if buff.cadence_of_fujieda.stack < 5 then stat.haste = stat.haste + 0.01 end
                 addStack( "cadence_of_fujieda" )
             end
+
+            if state.set_bonus.tier30_4pc > 0 then removeBuff( "merciless_assault" ) end
         end,
     },
 
@@ -930,7 +937,12 @@ spec:RegisterAbilities( {
         cooldown = function () return ( 4.5 - talent.deft_experience.rank * 0.75 ) * haste end,
         gcd = "spell",
 
-        spend = -8,
+        spend = function()
+            if state.set_bonus.tier30_4pc > 0 and buff.merciless_assault.stack > 0 then
+                return -8 - ( 2 * buff.merciless_assault.stack )
+            else return -8
+            end
+        end,
         spendType = "rage",
 
         cycle = function () return talent.fresh_meat.enabled and "hit_by_fresh_meat" or nil end,
@@ -961,6 +973,7 @@ spec:RegisterAbilities( {
                 addStack( "cadence_of_fujieda" )
             end
 
+            if state.set_bonus.tier30_4pc > 0 then removeBuff( "merciless_assault" ) end
         end,
 
         auras = {
@@ -1444,6 +1457,7 @@ spec:RegisterAbilities( {
             removeStack( "whirlwind" )
             if talent.frenzy.enabled then addStack( "frenzy" ) end
             if talent.reckless_abandon.enabled then addStack( "reckless_abandon", nil, 2 ) end
+            if state.set_bonus.tier30_4pc > 0 then addStack ("merciless_assault") end
         end,
     },
 

--- a/Dragonflight/WarriorProtection.lua
+++ b/Dragonflight/WarriorProtection.lua
@@ -517,6 +517,16 @@ spec:RegisterAura( "vanguards_determination", {
     max_stack = 1,
 } )
 
+spec:RegisterGear( "tier30", 202446, 202444, 202443, 202442, 202441 )
+spec:RegisterSetBonuses( "tier30_2pc", 405581, "tier30_4pc", 405582 )
+--(2) Shield Slam deals 15% increased damage and reduces the cooldown of Last Stand by 1 sec. During Last Stand these effects are doubled.
+--(4) For 10 sec after Last Stand ends, Shield Slam unleashes a wave of force dealing (45% of Attack power) Physical damage to enemies in front of you and reducing damage they deal to you by 5% for 5 sec.
+spec:RegisterAura( "earthen_tenacity", {
+    id = 410218,
+    duration = 10,
+    max_stack = 1
+} )
+
 
 local rageSpent = 0
 local gloryRage = 0

--- a/Dragonflight/WarriorProtection.lua
+++ b/Dragonflight/WarriorProtection.lua
@@ -1142,7 +1142,7 @@ spec:RegisterAbilities( {
                 applyBuff( "unnerving_focus" )
             end
 
-            if state.tier30_4pc > 0 then
+            if state.set_bonus.tier30_4pc > 0 then
                 state:QueueAuraExpiration( "last_stand_earthen_tenacity", TriggerEarthenTenacity, buff.last_stand.expires )
             end
         end,

--- a/Dragonflight/WarriorProtection.lua
+++ b/Dragonflight/WarriorProtection.lua
@@ -93,7 +93,7 @@ spec:RegisterTalents( {
     leeching_strikes                = { 90344, 382258, 1 }, -- Leech increased by 5%.
     menace                          = { 90383, 275338, 1 }, -- Intimidating Shout will knock back all nearby enemies except your primary target, and cause them all to cower in fear for 15 sec instead of fleeing.
     overwhelming_rage               = { 90378, 382767, 2 }, -- Maximum Rage increased by 15.
-    pain_and_gain                   = { 90353, 382549, 1 }, -- When you take any damage, heal for 4.50% of your maximum health. This can only occur once every 10 sec.
+    pain_and_gain                   = { 90353, 382549, 1 }, -- When you take any damage, heal for 3.50% of your maximum health. This can only occur once every 10 sec.
     piercing_howl                   = { 90348, 12323 , 1 }, -- Snares all enemies within 12 yards, reducing their movement speed by 70% for 8 sec.
     piercing_verdict                = { 90379, 382948, 1 }, -- Spear of Bastion's instant damage increased by 50% and its Rage generation is increased by 100%.
     rallying_cry                    = { 90331, 97462 , 1 }, -- Lets loose a rallying cry, granting all party or raid members within 40 yards 15% temporary and maximum health for 10 sec.
@@ -1030,10 +1030,12 @@ spec:RegisterAbilities( {
         handler = function ()
             if buff.ignore_pain.up then
                 buff.ignore_pain.expires = query_time + class.auras.ignore_pain.duration
-                buff.ignore_pain.v1 = min( 0.3 * health.max, buff.ignore_pain.v1 + stat.attack_power * 3.5 * ( 1 + stat.versatility_atk_mod / 100 ) )
+                -- TODO: Remove retail/PTR compatibility statement post 10.1 release. (3.5 [retail] vs 4.375 [10.1 patch])
+                buff.ignore_pain.v1 = min( 0.3 * health.max, buff.ignore_pain.v1 + stat.attack_power * (Hekili.CurrentBuild > 100007 and 4.375 or 3.5) * ( 1 + stat.versatility_atk_mod / 100 ) )
             else
                 applyBuff( "ignore_pain" )
-                buff.ignore_pain.v1 = min( 0.3 * health.max, stat.attack_power * 3.5 * ( 1 + stat.versatility_atk_mod / 100 ) )
+                -- TODO: Remove retail/PTR compatibility statement post 10.1 release. (3.5 [retail] vs 4.375 [10.1 patch])
+                buff.ignore_pain.v1 = min( 0.3 * health.max, stat.attack_power * (Hekili.CurrentBuild > 100007 and 4.375 or 3.5) * ( 1 + stat.versatility_atk_mod / 100 ) )
             end
         end,
     },
@@ -1438,9 +1440,7 @@ spec:RegisterAbilities( {
             end
 
             if state.set_bonus.tier30_2pc > 0 then
-                if buff.last_stand.up then reduceCooldown( "last_stand", 2 )
-                else reduceCooldown ( "last_stand", 1 )
-                end
+                reduceCooldown ( "last_stand", buff.last_stand.up and 4 or 2 )
             end
         end,
     },

--- a/Dragonflight/WarriorProtection.lua
+++ b/Dragonflight/WarriorProtection.lua
@@ -1440,7 +1440,7 @@ spec:RegisterAbilities( {
             end
 
             if state.set_bonus.tier30_2pc > 0 then
-                reduceCooldown ( "last_stand", buff.last_stand.up and 4 or 2 )
+                reduceCooldown( "last_stand", buff.last_stand.up and 4 or 2 )
             end
         end,
     },


### PR DESCRIPTION
Includes all 3 warrior specs new tier30 set bonuses and integrations into abilities and logic.
Also includes the various small tweaks to warrior for upcoming 10.1

Tested in PTR with no warnings/errors. Probably worth a quick test in retail before taking the PR. 

Didn't touch APL's obviously.