### PR TITLE
Fix missing default values.

### DIFF
--- a/Options.lua
+++ b/Options.lua
@@ -216,7 +216,8 @@ local displayTemplate = {
 
     border = {
         enabled = true,
-        width = 1,
+        thickness = 1,
+        fit = false,
         coloring = 'custom',
         color = { 0, 0, 0, 1 },
     },
@@ -332,6 +333,8 @@ local displayTemplate = {
         fontStyle = "OUTLINE",
 
         lowercase = false,
+
+        separateQueueStyle = false,
 
         queuedFont = ElvUI and "PT Sans Narrow" or "Arial Narrow",
         queuedFontSize = 12,


### PR DESCRIPTION
Some of the default settings were missing.
When the user adjusted those settings, no Lua error occurred, but the warning `"Unable to get a value for %s in WrapDesc."` did occurred.