### PR TITLE
Exclude players affected by Corruption on Echo of Neltharion mythic

### DIFF
--- a/Targets.lua
+++ b/Targets.lua
@@ -205,7 +205,9 @@ local enemyExclusions = {
     [204560] = true       -- Incorporeal Being
 }
 
-local FindExclusionAuraByID
+local FindExclusionAuraByID = {
+    [410972]  = true,      -- Corruption aura on Echo of Neltharion mythic fight
+}
 
 RegisterEvent( "NAME_PLATE_UNIT_ADDED", function( event, unit )
     local id = UnitGUID( unit )


### PR DESCRIPTION
Attempt to exclude players affected by Corruption on Echo of Neltharion mythic from target count https://www.wowhead.com/spell=410972/corruption