### PR TITLE
feat: more spirit bomb for Vengeance DH

### DIFF
--- a/Dragonflight/APLs/DemonHunterVengeance.simc
+++ b/Dragonflight/APLs/DemonHunterVengeance.simc
@@ -23,10 +23,9 @@ actions+=/soul_carver,if=(!talent.fiery_demise|(talent.fiery_demise&dot.fiery_br
 actions+=/fel_devastation,if=(!talent.fiery_demise|(talent.fiery_demise&dot.fiery_brand.ticking))
 actions+=/fiery_brand,if=remains<tick_time|!ticking
 actions+=/immolation_aura
-actions+=/sigil_of_flame
+actions+=/sigil_of_flame,if=fury.deficit>35&soul_fragments<=4
 actions+=/spirit_bomb,if=(soul_fragments>=4&!buff.metamorphosis.up)|(soul_fragments>=3&buff.metamorphosis.up)
 actions+=/soul_cleave
-actions+=/sigil_of_flame
 actions+=/immolation_aura
 actions+=/fracture
 actions+=/shear

--- a/Dragonflight/APLs/DemonHunterVengeance.simc
+++ b/Dragonflight/APLs/DemonHunterVengeance.simc
@@ -20,7 +20,7 @@ actions+=/call_action_list,name=racials
 actions+=/the_hunt
 actions+=/elysian_decree
 actions+=/soul_carver,if=(!talent.fiery_demise|(talent.fiery_demise&dot.fiery_brand.ticking))&soul_fragments<=3
-actions+=/fel_devastation,if=(!talent.fiery_demise|(talent.fiery_demise&dot.fiery_brand.ticking))
+actions+=/fel_devastation,if=!talent.fiery_demise|talent.fiery_demise&dot.fiery_brand.ticking
 actions+=/fiery_brand,if=remains<tick_time|!ticking
 actions+=/immolation_aura
 actions+=/sigil_of_flame,if=fury.deficit>35&soul_fragments<=4

--- a/Dragonflight/APLs/DemonHunterVengeance.simc
+++ b/Dragonflight/APLs/DemonHunterVengeance.simc
@@ -26,7 +26,6 @@ actions+=/immolation_aura
 actions+=/sigil_of_flame,if=fury.deficit>35&soul_fragments<=4
 actions+=/spirit_bomb,if=(soul_fragments>=4&!buff.metamorphosis.up)|(soul_fragments>=3&buff.metamorphosis.up)
 actions+=/soul_cleave
-actions+=/immolation_aura
 actions+=/fracture
 actions+=/shear
 actions+=/throw_glaive

--- a/Dragonflight/APLs/DemonHunterVengeance.simc
+++ b/Dragonflight/APLs/DemonHunterVengeance.simc
@@ -20,7 +20,7 @@ actions+=/call_action_list,name=racials
 actions+=/the_hunt
 actions+=/elysian_decree
 actions+=/soul_carver,if=(!talent.fiery_demise|(talent.fiery_demise&dot.fiery_brand.ticking))&soul_fragments<=3
-actions+=/fel_devastation
+actions+=/fel_devastation,if=(!talent.fiery_demise|(talent.fiery_demise&dot.fiery_brand.ticking))
 actions+=/fiery_brand,if=remains<tick_time|!ticking
 actions+=/immolation_aura
 actions+=/sigil_of_flame

--- a/Dragonflight/APLs/DemonHunterVengeance.simc
+++ b/Dragonflight/APLs/DemonHunterVengeance.simc
@@ -24,9 +24,11 @@ actions+=/fel_devastation,if=(!talent.fiery_demise|(talent.fiery_demise&dot.fier
 actions+=/fiery_brand,if=remains<tick_time|!ticking
 actions+=/immolation_aura
 actions+=/sigil_of_flame,if=fury.deficit>35&soul_fragments<=4
+actions+=/fracture,if=((soul_fragments<4&!buff.metamorphosis.up&fury.deficit<25)|(soul_fragments<3&buff.metamorphosis.up&fury.deficit<45))
 actions+=/spirit_bomb,if=(soul_fragments>=4&!buff.metamorphosis.up)|(soul_fragments>=3&buff.metamorphosis.up)
-actions+=/soul_cleave
+actions+=/soul_cleave,if=soul_fragments<2
 actions+=/fracture
+actions+=/soul_cleave
 actions+=/shear
 actions+=/throw_glaive
 actions+=/felblade


### PR DESCRIPTION
Simulations use the SimC generator profile: https://github.com/simulationcraft/simc/blob/dragonflight/profiles/generators/Tier30/T30_Generate_Demon_Hunter.simc#L29

This profile uses the "raid spec" for Veng, which makes me a little warry about using "Dungeon Slice", but I included it anyways.


## Comparisons

### Dungeon Slice

Default (79,803 DPS): https://www.raidbots.com/simbot/report/coZsd9hm1YWQ2tcrCiAWJY
Patched (71,226 DPS): https://www.raidbots.com/simbot/report/fbmHMJFspju9Ts2AZ9WPFS


### Patchwerk - 6 mins, 1 bosses

Default (72,702 DPS): https://www.raidbots.com/simbot/report/nyoMbdut2ZWdsCpKm1QhP5
Patched (74,155 DPS): https://www.raidbots.com/simbot/report/dekauGRURmwwMa1VxkMXEH


### Patchwerk - 6 mins, 3 bosses

Default (122,357 DPS): https://www.raidbots.com/simbot/report/5qSQf7QVJXNcXsiRFLGGyb
Patched (129,416 DPS): https://www.raidbots.com/simbot/report/uGNUje2SQYrV5Pe4BSAaYj

### Patchwerk - 6 mins, 5 bosses

Default (171,008 DPS): https://www.raidbots.com/simbot/report/qDkfzeAZHNQKBF6v3VBCJL
Patched (182,447 DPS): https://www.raidbots.com/simbot/report/aTyzq3AYiNVMEAi8EdiryL



