### PR TITLE
Fixes and Improvements to Retail Holy Paladin

### DIFF
--- a/Dragonflight/APLs/PaladinHoly.simc
+++ b/Dragonflight/APLs/PaladinHoly.simc
@@ -1,21 +1,67 @@
-actions+=/rebuke
-actions+=/avenging_wrath
-actions+=/avenging_crusader
-actions+=/blessing_of_summer
-actions+=/blessing_of_autumn
-actions+=/blessing_of_winter
-actions+=/blessing_of_spring
-actions+=/use_items
-actions+=/call_action_list,name=spenders,strict=1,if=!talent.avenging_crusader|cooldown.avenging_crusader.remains>gcd.max|holy_power.deficit=0
-actions+=/divine_toll
-actions+=/lights_hammer
-actions+=/holy_prism
-actions+=/consecration,if=!consecration.up&target.within10
-actions+=/hammer_of_wrath
-actions+=/judgment
-actions+=/holy_shock
-actions+=/crusader_strike,if=cooldown.holy_shock.remains>gcd.max
+# Ensure we've got the aura active along with both beacons.
+actions.precombat+=/devotion_aura,if=buff.paladin_aura.down
+actions.precombat+=/beacon_of_light,if=buff.beacon_of_light.down
+actions.precombat+=/beacon_of_faith,if=buff.beacon_of_faith.down
+# Blessing of Sacrifice is here as a visual reminder to be casting
+# it on pull, along with Holy Shock (preferrably on the tank).
+actions.precombat+=/blessing_of_sacrifice
+actions.precombat+=/holy_shock
+# It's unlikely we get as far as casting Consecration before combat
+# starts, but it's a good visual reminder to put it up here as this
+# is otherwise very deep down the priority list.
+actions.precombat+=/consecration
 
-actions.spenders+=/shield_of_the_righteous,if=!talent.awakening|active_enemies>1
+actions+=/rebuke
+actions+=/cleanse
+actions+=/call_action_list,name=procs
+actions+=/call_action_list,name=mitigation
+actions+=/call_action_list,name=cooldowns
+actions+=/call_action_list,name=spenders
+actions+=/call_action_list,name=standard
+
+actions.procs+=/judgment,if=buff.awakening_ready.up
+actions.procs+=/judgment,if=buff.infusion_of_light.up
+# Ensure we use Tyr's Deliverance after Hand of Divinity,
+# ...and ensure we following it up Holy Light until the buff ends on the second cast!
+actions.procs+=/tyrs_deliverance,if=buff.hand_of_divinity.up
+actions.procs+=/holy_light,if=buff.hand_of_divinity.up
+# Use Daybreak AFTER Divine Toll and BEFORE its Glimmers expire
+# ...but hold on to them for a few seconds for max value!
+actions.procs+=/daybreak,if=!talent.quickened_invocation&cooldown.divine_toll.remains>40&cooldown.divine_toll.remains<50
+actions.procs+=/daybreak,if=talent.quickened_invocation&cooldown.divine_toll.remains>25&cooldown.divine_toll.remains<30
+
+actions.mitigation+=/divine_protection
+actions.mitigation+=/divine_shield
+actions.mitigation+=/stoneform
+actions.mitigation+=/lay_on_hands
+actions.mitigation+=/aura_mastery
+
+actions.cooldowns+=/avenging_wrath
+actions.cooldowns+=/avenging_crusader
+actions.cooldowns+=/barrier_of_faith
+actions.cooldowns+=/blessing_of_sacrifice
+actions.cooldowns+=/blessing_of_summer
+actions.cooldowns+=/blessing_of_autumn
+actions.cooldowns+=/blessing_of_winter
+actions.cooldowns+=/blessing_of_spring
+actions.cooldowns+=/divine_toll
+# Space out the usage of Tyrs/Hand/Light and Toll/Daybreak combos
+# ...Divine Toll comes first shortly after pull, and this triggers a bit later into the pull.
+actions.cooldowns+=/hand_of_divinity,if=!talent.quickened_invocationcooldown.divine_toll.remains<35
+actions.cooldowns+=/hand_of_divinity,if=talent.quickened_invocationcooldown.divine_toll.remains<25
+
+# For spenders, we're assuming that player health correlates with amount
+# of healing that needs to be done. If we're healthy, spend on offensive
+# abilities. Otherwise, spend on healing abilities.
+actions.spenders+=/shield_of_the_righteous,if=target.within6&health.pct>90
 actions.spenders+=/light_of_dawn,if=talent.awakening&group
 actions.spenders+=/word_of_glory,if=talent.awakening
+
+actions.standard+=/use_items
+actions.standard+=/lights_hammer
+actions.standard+=/holy_prism
+actions.standard+=/consecration,if=!consecration.up&target.within10
+actions.standard+=/hammer_of_wrath
+actions.standard+=/judgment
+actions.standard+=/holy_shock
+actions.standard+=/crusader_strike,if=cooldown.holy_shock.remains>gcd.max

--- a/Dragonflight/APLs/PaladinHoly.simc
+++ b/Dragonflight/APLs/PaladinHoly.simc
@@ -57,8 +57,8 @@ actions.cooldowns+=/hand_of_divinity,if=talent.quickened_invocation&cooldown.div
 # of healing that needs to be done. If we're healthy, spend on offensive
 # abilities. Otherwise, spend on healing abilities.
 actions.spenders+=/shield_of_the_righteous,if=target.within6&health.pct>95
-actions.spenders+=/word_of_glory,if=group_members>5
-actions.spenders+=/light_of_dawn,if=group_members<6
+actions.spenders+=/word_of_glory,if=group_members<6
+actions.spenders+=/light_of_dawn,if=group_members>5
 
 
 actions.standard+=/use_items

--- a/Dragonflight/APLs/PaladinHoly.simc
+++ b/Dragonflight/APLs/PaladinHoly.simc
@@ -1,3 +1,4 @@
+actions.precombat+=/shield_of_the_righteous
 # Ensure we've got the aura active along with both beacons.
 actions.precombat+=/devotion_aura,if=buff.paladin_aura.down
 actions.precombat+=/beacon_of_light,if=buff.beacon_of_light.down
@@ -25,10 +26,12 @@ actions.procs+=/judgment,if=buff.infusion_of_light.up
 # ...and ensure we following it up Holy Light until the buff ends on the second cast!
 actions.procs+=/tyrs_deliverance,if=buff.hand_of_divinity.up
 actions.procs+=/holy_light,if=buff.hand_of_divinity.up
-# Use Daybreak AFTER Divine Toll and BEFORE its Glimmers expire
+[# ]Use Daybreak AFTER Divine Toll and BEFORE its Glimmers expire
 # ...but hold on to them for a few seconds for max value!
 actions.procs+=/daybreak,if=!talent.quickened_invocation&cooldown.divine_toll.remains>40&cooldown.divine_toll.remains<50
 actions.procs+=/daybreak,if=talent.quickened_invocation&cooldown.divine_toll.remains>25&cooldown.divine_toll.remains<30
+# If we're taking a beating and lack Holy Power, prioritise getting more if we're one GCD away from a spender
+actions.standard+=/crusader_strike,if=health.pct<50&holy_power<3&holy_power>0
 
 actions.mitigation+=/divine_protection
 actions.mitigation+=/divine_shield
@@ -47,15 +50,16 @@ actions.cooldowns+=/blessing_of_spring
 actions.cooldowns+=/divine_toll
 # Space out the usage of Tyrs/Hand/Light and Toll/Daybreak combos
 # ...Divine Toll comes first shortly after pull, and this triggers a bit later into the pull.
-actions.cooldowns+=/hand_of_divinity,if=!talent.quickened_invocationcooldown.divine_toll.remains<35
-actions.cooldowns+=/hand_of_divinity,if=talent.quickened_invocationcooldown.divine_toll.remains<25
+actions.cooldowns+=/hand_of_divinity,if=!talent.quickened_invocation&cooldown.divine_toll.remains<35
+actions.cooldowns+=/hand_of_divinity,if=talent.quickened_invocation&cooldown.divine_toll.remains<25
 
 # For spenders, we're assuming that player health correlates with amount
 # of healing that needs to be done. If we're healthy, spend on offensive
 # abilities. Otherwise, spend on healing abilities.
-actions.spenders+=/shield_of_the_righteous,if=target.within6&health.pct>90
-actions.spenders+=/light_of_dawn,if=raid_event.exists
-actions.spenders+=/word_of_glory,if=!raid_event.exists
+actions.spenders+=/shield_of_the_righteous,if=target.within6&health.pct>95
+actions.spenders+=/word_of_glory,if=group_members>5
+actions.spenders+=/light_of_dawn,if=group_members<6
+
 
 actions.standard+=/use_items
 actions.standard+=/lights_hammer

--- a/Dragonflight/APLs/PaladinHoly.simc
+++ b/Dragonflight/APLs/PaladinHoly.simc
@@ -54,7 +54,7 @@ actions.cooldowns+=/hand_of_divinity,if=talent.quickened_invocationcooldown.divi
 # of healing that needs to be done. If we're healthy, spend on offensive
 # abilities. Otherwise, spend on healing abilities.
 actions.spenders+=/shield_of_the_righteous,if=target.within6&health.pct>90
-actions.spenders+=/light_of_dawn,if=talent.awakening&group
+actions.spenders+=/light_of_dawn,if=talent.awakening&group&boss
 actions.spenders+=/word_of_glory,if=talent.awakening
 
 actions.standard+=/use_items

--- a/Dragonflight/APLs/PaladinHoly.simc
+++ b/Dragonflight/APLs/PaladinHoly.simc
@@ -54,8 +54,8 @@ actions.cooldowns+=/hand_of_divinity,if=talent.quickened_invocationcooldown.divi
 # of healing that needs to be done. If we're healthy, spend on offensive
 # abilities. Otherwise, spend on healing abilities.
 actions.spenders+=/shield_of_the_righteous,if=target.within6&health.pct>90
-actions.spenders+=/light_of_dawn,if=talent.awakening&group&boss
-actions.spenders+=/word_of_glory,if=talent.awakening
+actions.spenders+=/light_of_dawn,if=raid_event.exists
+actions.spenders+=/word_of_glory,if=!raid_event.exists
 
 actions.standard+=/use_items
 actions.standard+=/lights_hammer

--- a/Dragonflight/APLs/PaladinHoly.simc
+++ b/Dragonflight/APLs/PaladinHoly.simc
@@ -31,7 +31,7 @@ actions.procs+=/holy_light,if=buff.hand_of_divinity.up
 actions.procs+=/daybreak,if=!talent.quickened_invocation&cooldown.divine_toll.remains>40&cooldown.divine_toll.remains<50
 actions.procs+=/daybreak,if=talent.quickened_invocation&cooldown.divine_toll.remains>25&cooldown.divine_toll.remains<30
 # If we're taking a beating and lack Holy Power, prioritise getting more if we're one GCD away from a spender
-actions.standard+=/crusader_strike,if=health.pct<50&holy_power<3&holy_power>0
+actions.procs+=/crusader_strike,if=health.pct<50&holy_power<3&holy_power>0
 
 actions.mitigation+=/divine_protection
 actions.mitigation+=/divine_shield

--- a/Dragonflight/PaladinHoly.lua
+++ b/Dragonflight/PaladinHoly.lua
@@ -393,7 +393,7 @@ spec:RegisterAuras( {
         id = 384897,
     },
     shield_of_the_righteous = {
-        id = 132403,
+        id = 53600,
         duration = 4.5,
         max_stack = 1,
     },
@@ -951,7 +951,14 @@ spec:RegisterAbilities( {
         startsCombat = false,
         texture = 135949,
 
+        usable = function ()
+            return buff.dispellable_poison.up or buff.dispellable_disease.up or buff.dispellable_magic.up, "requires poison or disease"
+        end,
+
         handler = function ()
+            removeBuff( "dispellable_poison" )
+            removeBuff( "dispellable_disease" )
+            removeBuff( "dispellable_magic" )
         end,
     },
 

--- a/Dragonflight/PaladinHoly.lua
+++ b/Dragonflight/PaladinHoly.lua
@@ -520,7 +520,7 @@ spec:RegisterAbilities( {
         startsCombat = false,
         texture = 135872,
 
-        toggle = "cooldowns",
+        toggle = "defensives",
 
         handler = function ()
             applyBuff( "aura_mastery" )
@@ -1378,7 +1378,7 @@ spec:RegisterAbilities( {
         startsCombat = false,
         texture = 135928,
 
-        toggle = "cooldowns",
+        toggle = "defensives",
 
         handler = function ()
             applyDebuff( "player", "forbearance" )
@@ -1532,6 +1532,33 @@ spec:RegisterAbilities( {
                 end
             end
         end,
+    },
+
+
+    stoneform = {
+        id = 20594,
+        cast = 0,
+        cooldown = 120,
+        gcd = "off",
+        toggle = "defensives",
+
+        handler = function ()
+            removeBuff( "dispellable_poison" )
+            removeBuff( "dispellable_disease" )
+            removeBuff( "dispellable_curse" )
+            removeBuff( "dispellable_magic" )
+            removeBuff( "dispellable_bleed" )
+
+            applyBuff( "stoneform" )
+        end,
+
+        auras = {
+            stoneform = {
+                id = 65116,
+                duration = 8,
+                max_stack = 1
+            }
+        }
     },
 
 

--- a/Dragonflight/PaladinRetribution.lua
+++ b/Dragonflight/PaladinRetribution.lua
@@ -347,9 +347,9 @@ spec:RegisterAuras( {
         end
     },
     -- Damage taken reduced by $w1%.
-    -- https://wowhead.com/beta/spell=403876
+    -- https://wowhead.com/beta/spell=498
     divine_protection = {
-        id = 403876,
+        id = 498,
         duration = 8,
         max_stack = 1
     },
@@ -1255,7 +1255,7 @@ spec:RegisterAbilities( {
 
     -- Talent: Reduces all damage you take by $s1% for $d.
     divine_protection = {
-        id = 403876,
+        id = 498,
         cast = 0,
         cooldown = function () return 60 * ( talent.unbreakable_spirit.enabled and 0.7 or 1 ) end,
         gcd = "off",


### PR DESCRIPTION
I really enjoy how this addon teaches me the muscle memory for the rotations, and having recently swapped to Holy Paladin (yeah... I know...) I've made some improvements to what appeared to be a lacking rotation. Hopefully someone else finds this useful ❤️ 

With these changes, a Prot/Ret Paladin in Retail with ~ilvl 340 can swap to Holy and rock up in Mythic+ dungeons and comfortably hit +2 on 11s. Testing this on the **tanking** training dummy in Valdraken had me survive for about 2 minutes, pulling 25k damage and 40k healing: [Logs](https://www.warcraftlogs.com/reports/7rRdk3BcXQtWvng1#fight=last) (ignore the two other random dps players in my vacinity).

Bug Fixes:
   * `divine_protection` for both Retribution and Holy is using the wrong Spell ID, so it never shows up as a suggestion.
   *  `shield_of_the_righteous` for Holy was using a valid Spell ID, but it didn't match whats in the class Spell Book, so it was unable to find the action on the bars to grab the keybind.
   * `cleanse` for Holy was missing some magic to make sensible recommendations, I've largely borrowed it from the Protection Paladin. It's also now in the rotation, so if the play picks up a dispellable DOT they're more aware that they should be using this button a lot more.

Improvements:
  * The Holy Paladin rotation now pushes players into some vaguely correct order for the big cooldowns ([Divine Toll and Daybreak] and [Hand of Divinity, Tyr's Deliverance, Holy Shock, Holy Shock]).
  * If the player proc's something good, we bump that action higher up the priority list.
  * The spenders are now vaguely better at distributing Holy Power between defence and offence.
