### PR TITLE
bug(outlaw): correct cp gain from fan_the_hammer procs

### DIFF
--- a/Dragonflight/RogueOutlaw.lua
+++ b/Dragonflight/RogueOutlaw.lua
@@ -1170,7 +1170,7 @@ spec:RegisterAbilities( {
             -- If Fan the Hammer is talented, let's generate more.
             if talent.fan_the_hammer.enabled then
                 local shots = min( talent.fan_the_hammer.rank, buff.opportunity.stack )
-                gain( shots * (action.pistol_shot.cp_gain - 1), "combo_points" )
+                gain( shots * ( action.pistol_shot.cp_gain - 1 ), "combo_points" )
                 removeStack( "opportunity", shots )
             end
         end,

--- a/Dragonflight/RogueOutlaw.lua
+++ b/Dragonflight/RogueOutlaw.lua
@@ -1170,7 +1170,7 @@ spec:RegisterAbilities( {
             -- If Fan the Hammer is talented, let's generate more.
             if talent.fan_the_hammer.enabled then
                 local shots = min( talent.fan_the_hammer.rank, buff.opportunity.stack )
-                gain( shots * action.pistol_shot.cp_gain, "combo_points" )
+                gain( shots * (action.pistol_shot.cp_gain - 1), "combo_points" )
                 removeStack( "opportunity", shots )
             end
         end,


### PR DESCRIPTION
Minor bug in Outlaw "Fan the Hammer" cp gain logic, subsequent shots generate 1 fewer combo points. (https://www.wowhead.com/spell=381846/fan-the-hammer) 

At DF release it didn't have the "few combo points" behaviour, they nerf the talent in 10.0.5 ( https://www.wowhead.com/spell=381846/fan-the-hammer#changelog)