### PR TITLE
Classes: Fix DV/DC proc and unlist proc trinkets

### DIFF
--- a/Classes.lua
+++ b/Classes.lua
@@ -3497,6 +3497,7 @@ all:RegisterAbility( "grim_toll", {
     cast = 0,
     cooldown = 45,
     gcd = "off",
+    unlisted = true,
 
     item = 40256,
     aura = 60437
@@ -3511,6 +3512,7 @@ all:RegisterAbility( "mjolnir_runestone", {
     cast = 0,
     cooldown = 45,
     gcd = "off",
+    unlisted = true,
 
     item = 45931,
     aura = 65019
@@ -3525,6 +3527,7 @@ all:RegisterAbility( "dark_matter", {
     cast = 0,
     cooldown = 45,
     gcd = "off",
+    unlisted = true,
 
     item = 46038,
     aura = 65024
@@ -3539,6 +3542,7 @@ all:RegisterAbility( "whispering_fanged_skull", {
     cast = 0,
     cooldown = 45,
     gcd = "off",
+    unlisted = true,
 
     item = 50342,
     aura = 71401
@@ -3548,61 +3552,19 @@ all:RegisterAbility( "whispering_fanged_skull_heroic", {
     cast = 0,
     cooldown = 45,
     gcd = "off",
+    unlisted = true,
 
     item = 50343,
     aura = 71541
 })
 all:RegisterAura( "icy_rage", {
-    id = 67702,
+    id = 71401,
     duration = 15,
     max_stack = 1,
     copy = { 71401, 71541 }
 })
 
-all:RegisterAbility( "deaths_verdict", {
-    cast = 0,
-    cooldown = 45,
-    gcd = "off",
 
-    item = 47115,
-    aura = 67702
-})
-all:RegisterAbility( "deaths_verdict_heroic", {
-    suffix = strformat( "(%s)", ITEM_HEROIC ),
-    cast = 0,
-    cooldown = 45,
-    gcd = "off",
-
-    item = 47131,
-    aura = 67702
-})
-all:RegisterAbility( "deaths_choice", {
-    cast = 0,
-    cooldown = 45,
-    gcd = "off",
-
-    item = 47303,
-    aura = 67771
-})
-all:RegisterAbility( "deaths_choice_heroic", {
-    suffix = strformat( "(%s)", ITEM_HEROIC ),
-    cast = 0,
-    cooldown = 45,
-    gcd = "off",
-
-    item = 47464,
-    aura = 67702
-})
-all:RegisterAura( "deaths_verdict", {
-    id = 67702,
-    duration = 15,
-    max_stack = 1
-})
-all:RegisterAura( "deaths_verdict_heroic", {
-    id = 67771,
-    duration = 15,
-    max_stack = 1
-})
 
 -- x.x - Heirloom Trinket(s)
 all:RegisterAbility( "touch_of_the_void", {

--- a/State.lua
+++ b/State.lua
@@ -3653,7 +3653,7 @@ do
 
             end
 
-            local alias
+            local alias = nil
             local mode = aura.aliasMode or "first"
 
             for i, v in ipairs( aura.alias ) do

--- a/State.lua
+++ b/State.lua
@@ -3666,6 +3666,7 @@ do
                 end
 
                 if not alias and mode == "first" and child.up then return child[ k ] end
+                if mode == "latest" and ( not alias or child.last_application > alias.last_application ) then alias = child end
 
                 if child.up then
                     if mode == "shortest" and ( not alias or child.remains < alias.remains ) then alias = child

--- a/Wrath/Classes.lua
+++ b/Wrath/Classes.lua
@@ -162,6 +162,63 @@ all:RegisterAbilities( {
         }
     },
 
+    deaths_verdict = {
+        cast = 0,
+        cooldown = 45,
+        gcd = "off",
+        unlisted = true,
+
+        item = 47115,
+
+        handler = function()
+            if stat.strength >= stat.agility then 
+                applyBuff( "paragon_str" )
+            else
+                applyBuff( "paragon_agi" )
+            end
+        end,
+
+        auras = {
+            paragon_str = {
+                id = 67708,
+                duration = 15,
+                max_stack = 1,
+                copy = {67708, 67773}
+            },
+            paragon_agi = {
+                id = 67703,
+                duration = 15,
+                max_stack = 1,
+                copy = {67703, 67772}
+            },
+            paragon = {
+                alias = { "paragon_agi","paragon_str" },
+                aliasType = "buff",
+                aliasMode = "first"
+            },
+        },
+
+        copy = {47115, 47131}
+    },
+
+    deaths_choice = {
+        cast = 0,
+        cooldown = 45,
+        gcd = "off",
+        unlisted = true,
+
+        item = 47303,
+
+        handler = function()
+            if stat.strength >= stat.agility then 
+                applyBuff( "paragon_str" )
+            else
+                applyBuff( "paragon_agi" )
+            end
+        end,
+        copy = {47303, 47464}
+    },
+
     ephemeral_snowflake = {
         cast = 0,
         cooldown = 120,

--- a/Wrath/Classes.lua
+++ b/Wrath/Classes.lua
@@ -247,9 +247,7 @@ all:RegisterAbilities( {
             applyBuff( "deathbringers_will" )
         end,
 
-        aura = function()
-            return buff.deathbringers_will.id
-        end,
+        aura = "deathbringers_will",
 
     },
 
@@ -273,9 +271,7 @@ all:RegisterAbilities( {
             end
         end,
 
-        aura = function()
-            return buff.paragon.id
-        end,
+        aura = "paragon",
 
     },
 
@@ -300,9 +296,8 @@ all:RegisterAbilities( {
             end
         end,
 
-        aura = function()
-            return buff.paragon.id
-        end,
+        aura = "paragon",
+
     },
 
     ephemeral_snowflake = {

--- a/Wrath/Classes.lua
+++ b/Wrath/Classes.lua
@@ -113,6 +113,77 @@ RegisterEvent( "PLAYER_ENTERING_WORLD", ns.updateGlyphs )
 all = class.specs[ 0 ]
 
 
+all:RegisterAuras({
+    -- Phase 4 DBW only
+    aim_of_the_iron_dwarves = {
+        -- crit: DK, Hunter, Paladin
+        id = 71491,
+        duration = 30,
+        copy= {71491,71559},
+    },
+    agility_of_the_vrykul = {
+        -- agi: Druid, Hunter, Rogue, Shaman
+        id = 71485,
+        duration = 30,
+        copy= {71485,71556},
+    },
+    power_of_the_taunka = {
+        -- ap: Hunter, Rogue, Shaman
+        id = 71486,
+        duration = 30,
+        copy= {71486,71558},
+    },
+    precision_of_the_iron_dwarves = {
+        -- arp: Rogue, Shaman, Warrior
+        id = 71487,
+        duration = 30,
+        copy= {71487,71557},
+    },
+    speed_of_the_vrykul = {
+        -- haste: DK, Druid, Paladin
+        id = 71492,
+        duration = 30,
+        copy= {71492,71560},
+    },
+    strength_of_the_taunka = {
+        -- str: DK, Paladin, Warrior
+        id = 71484,
+        duration = 30,
+        copy= {71484,71561},
+    },
+    -- -- BDW Proc for forecasting.
+    --dwb_buff = {
+    --    id = 71519,
+    --    duration = 30,
+    --    copy= {71519,71562},
+    --},
+
+    -- Your attacks have a chance to awaken the powers of the races of Northrend, temporarily transforming you and increasing your combat capabilities for 30 sec.
+    deathbringers_will = {
+        alias = {"aim_of_the_iron_dwarves", "agility_of_the_vrykul", "power_of_the_taunka", "precision_of_the_iron_dwarves", "speed_of_the_vrykul", "strength_of_the_taunka"},
+        aliasMode = "latest",
+        aliasType = "buff",
+    },
+    paragon_str = {
+        id = 67708,
+        duration = 15,
+        max_stack = 1,
+        copy = {67708, 67773}
+    },
+    paragon_agi = {
+        id = 67703,
+        duration = 15,
+        max_stack = 1,
+        copy = {67703, 67772}
+    },
+    -- When you deal damage you have a chance to gain Paragon, increasing your Strength or Agility by 450/510 for 15 sec.  Your highest stat is always chosen.
+    paragon = {
+        alias = { "paragon_agi","paragon_str" },
+        aliasType = "buff",
+        aliasMode = "latest"
+    },
+})
+
 all:RegisterAbilities( {
     -- Phase 4
 
@@ -161,6 +232,25 @@ all:RegisterAbilities( {
             }
         }
     },
+    deathbringers_will = {
+        cast = 0,
+        cooldown = 105,
+        gcd = "off",
+        unlisted = true,
+
+        items = {50362, 50363},
+        item = function()
+            if equipped[ 50362 ] then return 50362 end
+            return 50363
+        end,
+
+        handler = function()
+            applyBuff( "deathbringers_will" )
+        end,
+
+        aura = buff.deathbringers_will.id
+
+    },
 
     deaths_verdict = {
         cast = 0,
@@ -168,7 +258,11 @@ all:RegisterAbilities( {
         gcd = "off",
         unlisted = true,
 
-        item = 47115,
+        items = {47115, 47131},
+        item = function()
+            if equipped[ 47115 ] then return 47115 end
+            return 47131
+        end,
 
         handler = function()
             if stat.strength >= stat.agility then 
@@ -178,27 +272,8 @@ all:RegisterAbilities( {
             end
         end,
 
-        auras = {
-            paragon_str = {
-                id = 67708,
-                duration = 15,
-                max_stack = 1,
-                copy = {67708, 67773}
-            },
-            paragon_agi = {
-                id = 67703,
-                duration = 15,
-                max_stack = 1,
-                copy = {67703, 67772}
-            },
-            paragon = {
-                alias = { "paragon_agi","paragon_str" },
-                aliasType = "buff",
-                aliasMode = "first"
-            },
-        },
+        aura = buff.paragon.id
 
-        copy = {47115, 47131}
     },
 
     deaths_choice = {
@@ -207,7 +282,12 @@ all:RegisterAbilities( {
         gcd = "off",
         unlisted = true,
 
-        item = 47303,
+        items = {47303, 47464},
+        item = function()
+            if equipped[ 47303 ] then return 47303 end
+            return 47464
+        end,
+
 
         handler = function()
             if stat.strength >= stat.agility then 
@@ -217,27 +297,7 @@ all:RegisterAbilities( {
             end
         end,
 
-        auras = {
-            paragon_str = {
-                id = 67708,
-                duration = 15,
-                max_stack = 1,
-                copy = {67708, 67773}
-            },
-            paragon_agi = {
-                id = 67703,
-                duration = 15,
-                max_stack = 1,
-                copy = {67703, 67772}
-            },
-            paragon = {
-                alias = { "paragon_agi","paragon_str" },
-                aliasType = "buff",
-                aliasMode = "first"
-            },
-        },
-        
-        copy = {47303, 47464}
+        aura = buff.paragon.id
     },
 
     ephemeral_snowflake = {

--- a/Wrath/Classes.lua
+++ b/Wrath/Classes.lua
@@ -216,6 +216,27 @@ all:RegisterAbilities( {
                 applyBuff( "paragon_agi" )
             end
         end,
+
+        auras = {
+            paragon_str = {
+                id = 67708,
+                duration = 15,
+                max_stack = 1,
+                copy = {67708, 67773}
+            },
+            paragon_agi = {
+                id = 67703,
+                duration = 15,
+                max_stack = 1,
+                copy = {67703, 67772}
+            },
+            paragon = {
+                alias = { "paragon_agi","paragon_str" },
+                aliasType = "buff",
+                aliasMode = "first"
+            },
+        },
+        
         copy = {47303, 47464}
     },
 

--- a/Wrath/Classes.lua
+++ b/Wrath/Classes.lua
@@ -114,7 +114,29 @@ all = class.specs[ 0 ]
 
 
 all:RegisterAuras({
-    -- Phase 4 DBW only
+    -- Phase 4
+    -- Death's Verdict/Choice Buffs
+    paragon_str = {
+        id = 67708,
+        duration = 15,
+        max_stack = 1,
+        copy = {67708, 67773}
+    },
+    paragon_agi = {
+        id = 67703,
+        duration = 15,
+        max_stack = 1,
+        copy = {67703, 67772}
+    },
+    -- When you deal damage you have a chance to gain Paragon, increasing your Strength or Agility by 450/510 for 15 sec.  Your highest stat is always chosen.
+    paragon = {
+        --id = 67771,
+        alias = { "paragon_agi", "paragon_str" },
+        aliasMode = "latest",
+        aliasType = "buff",        
+    },
+    
+    -- DBW Buffs
     aim_of_the_iron_dwarves = {
         -- crit: DK, Hunter, Paladin
         id = 71491,
@@ -151,37 +173,14 @@ all:RegisterAuras({
         duration = 30,
         copy= {71484,71561},
     },
-    -- -- BDW Proc for forecasting.
-    --dwb_buff = {
-    --    id = 71519,
-    --    duration = 30,
-    --    copy= {71519,71562},
-    --},
-
     -- Your attacks have a chance to awaken the powers of the races of Northrend, temporarily transforming you and increasing your combat capabilities for 30 sec.
     deathbringers_will = {
         alias = {"aim_of_the_iron_dwarves", "agility_of_the_vrykul", "power_of_the_taunka", "precision_of_the_iron_dwarves", "speed_of_the_vrykul", "strength_of_the_taunka"},
         aliasMode = "latest",
         aliasType = "buff",
     },
-    paragon_str = {
-        id = 67708,
-        duration = 15,
-        max_stack = 1,
-        copy = {67708, 67773}
-    },
-    paragon_agi = {
-        id = 67703,
-        duration = 15,
-        max_stack = 1,
-        copy = {67703, 67772}
-    },
-    -- When you deal damage you have a chance to gain Paragon, increasing your Strength or Agility by 450/510 for 15 sec.  Your highest stat is always chosen.
-    paragon = {
-        alias = { "paragon_agi","paragon_str" },
-        aliasType = "buff",
-        aliasMode = "latest"
-    },
+
+
 })
 
 all:RegisterAbilities( {
@@ -248,7 +247,9 @@ all:RegisterAbilities( {
             applyBuff( "deathbringers_will" )
         end,
 
-        aura = buff.deathbringers_will.id
+        aura = function()
+            return buff.deathbringers_will.id
+        end,
 
     },
 
@@ -272,7 +273,9 @@ all:RegisterAbilities( {
             end
         end,
 
-        aura = buff.paragon.id
+        aura = function()
+            return buff.paragon.id
+        end,
 
     },
 
@@ -297,7 +300,9 @@ all:RegisterAbilities( {
             end
         end,
 
-        aura = buff.paragon.id
+        aura = function()
+            return buff.paragon.id
+        end,
     },
 
     ephemeral_snowflake = {

--- a/Wrath/Druid.lua
+++ b/Wrath/Druid.lua
@@ -274,7 +274,7 @@ spec:RegisterStateExpr("should_rake", function()
     end
 
     local r, s = calc_rake_dpe()
-    return r >= s or (not settings.optimize_rake)
+    return r >= s
 end)
 
 spec:RegisterStateExpr("is_training_dummy", function()
@@ -2945,15 +2945,6 @@ spec:RegisterSetting( "max_ff_energy", 15, {
     min = 0,
     softMax = 100,
     step = 1,
-} )
-
-spec:RegisterSetting( "optimize_rake", false, {
-    type = "toggle",
-    name = strformat( "Optimize %s", Hekili:GetSpellLinkWithTexture( spec.abilities.rake.id ) ),
-    desc = strformat( "If checked, %s will only be suggested if it will do more damage than %s or if there is no active %s bleed.  " ..
-        "Recommendation: Checked, if stacking Armor Penetration\n\n" ..
-        "Default: Unchecked", Hekili:GetSpellLinkWithTexture( spec.abilities.rake.id ), Hekili:GetSpellLinkWithTexture( spec.abilities.shred.id ), spec.abilities.rake.name ),
-    width = "full",
 } )
 
 spec:RegisterSetting( "optimize_trinkets", false, {

--- a/Wrath/Druid.lua
+++ b/Wrath/Druid.lua
@@ -274,7 +274,7 @@ spec:RegisterStateExpr("should_rake", function()
     end
 
     local r, s = calc_rake_dpe()
-    return r >= s
+    return r >= s or (not settings.optimize_rake)
 end)
 
 spec:RegisterStateExpr("is_training_dummy", function()
@@ -477,22 +477,12 @@ spec:RegisterStateExpr("excess_e", function()
             pending_actions.mangle_cat.refresh_cost = 0
         end
 
-        if buff.savage_roar.up and combo_points.current > 0 then
+        if buff.savage_roar.up then
             pending_actions.savage_roar.refresh_time = query_time + buff.savage_roar.remains
             pending_actions.savage_roar.refresh_cost = 25 * (berserk_expected_at(query_time, query_time + buff.savage_roar.remains) and 0.5 or 1)
         else
             pending_actions.savage_roar.refresh_time = 0
             pending_actions.savage_roar.refresh_cost = 0
-        end
-
-        if pending_actions.rip.refresh_time > 0 and pending_actions.savage_roar.refresh_time > 0 then
-            if pending_actions.rip.refresh_time < pending_actions.savage_roar.refresh_time then
-                pending_actions.savage_roar.refresh_time = 0
-                pending_actions.savage_roar.refresh_cost = 0
-            else
-                pending_actions.rip.refresh_time = 0
-                pending_actions.rip.refresh_cost = 0
-            end
         end
     else
         if buff.savage_roar.up then
@@ -560,54 +550,23 @@ spec:RegisterStateExpr("excess_e", function()
     local earliest_proc_end = 0
     if settings.optimize_trinkets and debuff.rip.up then
         for entry in pairs(trinket) do
+            local t_proc_end = 0
             if tonumber(entry) then
                 local t = trinket[entry]
-                if t.proc and t.ability then
-                    local t_action = action[t.ability]
-                    if t_action and t_action.cooldown > 0 then
-                        local t_buff = nil
-
-                        -- Find the trinket buff to inspect
-                        local aura_type = type(t_action.aura)
-                        local auras_type = type(t_action.auras)
-                        if aura_type == "number" and t_action.aura > 0 then
-                            t_buff = buff[t_action.aura]
-                        elseif aura_type == "string" and #t_action.aura > 0 then
-                            t_buff = buff[t_action.aura]
-                        elseif auras_type == "table" then
-                            for a in pairs(t_action.auras) do
-                                -- Automatically use any current buffs
-                                if buff[a].up then
-                                    t_buff = buff[a]
-                                    break
-                                end
-
-                                -- Use the first buff as a basis of comparison
-                                if t_buff == nil then
-                                    t_buff = buff[a]
-                                else
-                                    -- Otherwise use buffs with the closest known possible proc time
-                                    local possible_proc = buff[a].last_application > 0 and (buff[a].last_application + t_action.cooldown) or 0
-                                    if possible_proc > 0 and (possible_proc < t_buff.last_application + t_action.cooldown) then
-                                        t_buff = buff[a]
-                                    end
-                                end
-                            end
-                        end
-
-                        if t_buff then
-                            local t_earliest_proc = t_buff.last_application > 0 and (t_buff.last_application + t_action.cooldown) or 0
-                            if t_earliest_proc > 0 and (earliest_proc == 0 or t_earliest_proc < earliest_proc) then
-                                earliest_proc = t_earliest_proc
-                                earliest_proc_end = t_earliest_proc + t_buff.duration
-                            end
-                            trinket_active = trinket_active or t_buff.up
-                        end
+                if t.proc and t.ability and action[t.ability] and action[t.ability].aura > 0 and buff[action[t.ability].aura] then
+                    local t_cooldown = action[t.ability].cooldown
+                    local t_earliest_proc = max(0, buff[action[t.ability].aura].last_application + t_cooldown)
+                    if t_cooldown > 0 and buff[action[t.ability].aura].last_application > 0 and (earliest_proc == 0 or t_earliest_proc < earliest_proc) then
+                        earliest_proc = t_earliest_proc
+                        earliest_proc_end = t_earliest_proc + buff[action[t.ability].aura].duration
+                        trinket_entry = t
                     end
+
+                    trinket_active = trinket_active or buff[action[t.ability].aura].up
                 end
             end
         end
-        
+
         if (not trinket_active) and earliest_proc > 0 and earliest_proc < time_to_cap and earliest_proc_end <= time_to_end then
             floating_energy = max(floating_energy, 100)
             Hekili:Debug("(excess_e) Pooling to "..tostring(floating_energy).." for trinket proc at approximately "..tostring(earliest_proc - query_time))
@@ -2986,6 +2945,15 @@ spec:RegisterSetting( "max_ff_energy", 15, {
     min = 0,
     softMax = 100,
     step = 1,
+} )
+
+spec:RegisterSetting( "optimize_rake", false, {
+    type = "toggle",
+    name = strformat( "Optimize %s", Hekili:GetSpellLinkWithTexture( spec.abilities.rake.id ) ),
+    desc = strformat( "If checked, %s will only be suggested if it will do more damage than %s or if there is no active %s bleed.  " ..
+        "Recommendation: Checked, if stacking Armor Penetration\n\n" ..
+        "Default: Unchecked", Hekili:GetSpellLinkWithTexture( spec.abilities.rake.id ), Hekili:GetSpellLinkWithTexture( spec.abilities.shred.id ), spec.abilities.rake.name ),
+    width = "full",
 } )
 
 spec:RegisterSetting( "optimize_trinkets", false, {

--- a/Wrath/Druid.lua
+++ b/Wrath/Druid.lua
@@ -274,7 +274,7 @@ spec:RegisterStateExpr("should_rake", function()
     end
 
     local r, s = calc_rake_dpe()
-    return r >= s or (not settings.optimize_rake)
+    return r >= s
 end)
 
 spec:RegisterStateExpr("is_training_dummy", function()
@@ -477,12 +477,22 @@ spec:RegisterStateExpr("excess_e", function()
             pending_actions.mangle_cat.refresh_cost = 0
         end
 
-        if buff.savage_roar.up then
+        if buff.savage_roar.up and combo_points.current > 0 then
             pending_actions.savage_roar.refresh_time = query_time + buff.savage_roar.remains
             pending_actions.savage_roar.refresh_cost = 25 * (berserk_expected_at(query_time, query_time + buff.savage_roar.remains) and 0.5 or 1)
         else
             pending_actions.savage_roar.refresh_time = 0
             pending_actions.savage_roar.refresh_cost = 0
+        end
+
+        if pending_actions.rip.refresh_time > 0 and pending_actions.savage_roar.refresh_time > 0 then
+            if pending_actions.rip.refresh_time < pending_actions.savage_roar.refresh_time then
+                pending_actions.savage_roar.refresh_time = 0
+                pending_actions.savage_roar.refresh_cost = 0
+            else
+                pending_actions.rip.refresh_time = 0
+                pending_actions.rip.refresh_cost = 0
+            end
         end
     else
         if buff.savage_roar.up then
@@ -550,23 +560,45 @@ spec:RegisterStateExpr("excess_e", function()
     local earliest_proc_end = 0
     if settings.optimize_trinkets and debuff.rip.up then
         for entry in pairs(trinket) do
-            local t_proc_end = 0
             if tonumber(entry) then
                 local t = trinket[entry]
-                if t.proc and t.ability and action[t.ability] and action[t.ability].aura > 0 and buff[action[t.ability].aura] then
-                    local t_cooldown = action[t.ability].cooldown
-                    local t_earliest_proc = max(0, buff[action[t.ability].aura].last_application + t_cooldown)
-                    if t_cooldown > 0 and buff[action[t.ability].aura].last_application > 0 and (earliest_proc == 0 or t_earliest_proc < earliest_proc) then
-                        earliest_proc = t_earliest_proc
-                        earliest_proc_end = t_earliest_proc + buff[action[t.ability].aura].duration
-                        trinket_entry = t
-                    end
+                if t.proc and t.ability then
+                    local t_action = action[t.ability]
+                    if t_action and t_action.cooldown > 0 then
+                        local t_buff = nil
 
-                    trinket_active = trinket_active or buff[action[t.ability].aura].up
+                        -- Find the trinket buff to inspect
+                        local aura_type = type(t_action.aura)
+                        local auras_type = type(t_action.auras)
+                        if aura_type == "number" and t_action.aura > 0 
+                        or aura_type == "string" and #t_action.aura > 0 then
+                            t_buff = buff[t_action.aura]
+                        elseif auras_type == "table" then
+                            for a in pairs(t_action.auras) do
+                                if buff[a].up then
+                                    t_buff = buff[a]
+                                    break
+                                elseif t_buff == nil 
+                                or buff[a].last_application > t_buff.last_application then
+                                    t_buff = buff[a]
+                                end
+                            end
+                        end
+
+                        if t_buff then
+                            local t_earliest_proc = t_buff.last_application > 0 and (t_buff.last_application + t_action.cooldown) or 0
+                            if t_earliest_proc > 0 and (earliest_proc == 0 or t_earliest_proc < earliest_proc) then
+                                earliest_proc = t_earliest_proc
+                                earliest_proc_end = t_earliest_proc + t_buff.duration
+                            end
+                            trinket_active = trinket_active or t_buff.up
+                            Hekili:Debug(tostring(t.ability).." trinket proc at approximately "..tostring(earliest_proc - query_time))
+                        end
+                    end
                 end
             end
         end
-
+        
         if (not trinket_active) and earliest_proc > 0 and earliest_proc < time_to_cap and earliest_proc_end <= time_to_end then
             floating_energy = max(floating_energy, 100)
             Hekili:Debug("(excess_e) Pooling to "..tostring(floating_energy).." for trinket proc at approximately "..tostring(earliest_proc - query_time))
@@ -2945,15 +2977,6 @@ spec:RegisterSetting( "max_ff_energy", 15, {
     min = 0,
     softMax = 100,
     step = 1,
-} )
-
-spec:RegisterSetting( "optimize_rake", false, {
-    type = "toggle",
-    name = strformat( "Optimize %s", Hekili:GetSpellLinkWithTexture( spec.abilities.rake.id ) ),
-    desc = strformat( "If checked, %s will only be suggested if it will do more damage than %s or if there is no active %s bleed.  " ..
-        "Recommendation: Checked, if stacking Armor Penetration\n\n" ..
-        "Default: Unchecked", Hekili:GetSpellLinkWithTexture( spec.abilities.rake.id ), Hekili:GetSpellLinkWithTexture( spec.abilities.shred.id ), spec.abilities.rake.name ),
-    width = "full",
 } )
 
 spec:RegisterSetting( "optimize_trinkets", false, {

--- a/Wrath/Druid.lua
+++ b/Wrath/Druid.lua
@@ -274,7 +274,7 @@ spec:RegisterStateExpr("should_rake", function()
     end
 
     local r, s = calc_rake_dpe()
-    return r >= s or (not settings.optimize_rake)
+    return r >= s
 end)
 
 spec:RegisterStateExpr("is_training_dummy", function()
@@ -477,12 +477,22 @@ spec:RegisterStateExpr("excess_e", function()
             pending_actions.mangle_cat.refresh_cost = 0
         end
 
-        if buff.savage_roar.up then
+        if buff.savage_roar.up and combo_points.current > 0 then
             pending_actions.savage_roar.refresh_time = query_time + buff.savage_roar.remains
             pending_actions.savage_roar.refresh_cost = 25 * (berserk_expected_at(query_time, query_time + buff.savage_roar.remains) and 0.5 or 1)
         else
             pending_actions.savage_roar.refresh_time = 0
             pending_actions.savage_roar.refresh_cost = 0
+        end
+
+        if pending_actions.rip.refresh_time > 0 and pending_actions.savage_roar.refresh_time > 0 then
+            if pending_actions.rip.refresh_time < pending_actions.savage_roar.refresh_time then
+                pending_actions.savage_roar.refresh_time = 0
+                pending_actions.savage_roar.refresh_cost = 0
+            else
+                pending_actions.rip.refresh_time = 0
+                pending_actions.rip.refresh_cost = 0
+            end
         end
     else
         if buff.savage_roar.up then
@@ -550,23 +560,55 @@ spec:RegisterStateExpr("excess_e", function()
     local earliest_proc_end = 0
     if settings.optimize_trinkets and debuff.rip.up then
         for entry in pairs(trinket) do
-            local t_proc_end = 0
             if tonumber(entry) then
                 local t = trinket[entry]
-                if t.proc and t.ability and action[t.ability] and action[t.ability].aura > 0 and buff[action[t.ability].aura] then
-                    local t_cooldown = action[t.ability].cooldown
-                    local t_earliest_proc = max(0, buff[action[t.ability].aura].last_application + t_cooldown)
-                    if t_cooldown > 0 and buff[action[t.ability].aura].last_application > 0 and (earliest_proc == 0 or t_earliest_proc < earliest_proc) then
-                        earliest_proc = t_earliest_proc
-                        earliest_proc_end = t_earliest_proc + buff[action[t.ability].aura].duration
-                        trinket_entry = t
-                    end
+                if t.proc and t.ability then
+                    local t_action = action[t.ability]
+                    if t_action and t_action.cooldown > 0 then
+                        local t_buff = nil
 
-                    trinket_active = trinket_active or buff[action[t.ability].aura].up
+                        -- Find the trinket buff to inspect
+                        local aura_type = type(t_action.aura)
+                        local auras_type = type(t_action.auras)
+                        if aura_type == "number" and t_action.aura > 0 then
+                            t_buff = buff[t_action.aura]
+                        elseif aura_type == "string" and #t_action.aura > 0 then
+                            t_buff = buff[t_action.aura]
+                        elseif auras_type == "table" then
+                            for a in pairs(t_action.auras) do
+                                -- Automatically use any current buffs
+                                if buff[a].up then
+                                    t_buff = buff[a]
+                                    break
+                                end
+
+                                -- Use the first buff as a basis of comparison
+                                if t_buff == nil then
+                                    t_buff = buff[a]
+                                else
+                                    -- Otherwise use buffs with the closest known possible proc time
+                                    local possible_proc = buff[a].last_application > 0 and (buff[a].last_application + t_action.cooldown) or 0
+                                    if possible_proc > 0 and (possible_proc < t_buff.last_application + t_action.cooldown) then
+                                        t_buff = buff[a]
+                                    end
+                                end
+                            end
+                        end
+
+                        if t_buff then
+                            local t_earliest_proc = t_buff.last_application > 0 and (t_buff.last_application + t_action.cooldown) or 0
+                            if t_earliest_proc > 0 and (earliest_proc == 0 or t_earliest_proc < earliest_proc) then
+                                earliest_proc = t_earliest_proc
+                                earliest_proc_end = t_earliest_proc + t_buff.duration
+                            end
+                            trinket_active = trinket_active or t_buff.up
+                            Hekili:Debug(tostring(t.ability).." trinket proc at approximately "..tostring(earliest_proc - query_time))
+                        end
+                    end
                 end
             end
         end
-
+        
         if (not trinket_active) and earliest_proc > 0 and earliest_proc < time_to_cap and earliest_proc_end <= time_to_end then
             floating_energy = max(floating_energy, 100)
             Hekili:Debug("(excess_e) Pooling to "..tostring(floating_energy).." for trinket proc at approximately "..tostring(earliest_proc - query_time))
@@ -2945,15 +2987,6 @@ spec:RegisterSetting( "max_ff_energy", 15, {
     min = 0,
     softMax = 100,
     step = 1,
-} )
-
-spec:RegisterSetting( "optimize_rake", false, {
-    type = "toggle",
-    name = strformat( "Optimize %s", Hekili:GetSpellLinkWithTexture( spec.abilities.rake.id ) ),
-    desc = strformat( "If checked, %s will only be suggested if it will do more damage than %s or if there is no active %s bleed.  " ..
-        "Recommendation: Checked, if stacking Armor Penetration\n\n" ..
-        "Default: Unchecked", Hekili:GetSpellLinkWithTexture( spec.abilities.rake.id ), Hekili:GetSpellLinkWithTexture( spec.abilities.shred.id ), spec.abilities.rake.name ),
-    width = "full",
 } )
 
 spec:RegisterSetting( "optimize_trinkets", false, {


### PR DESCRIPTION
- fixed icy_rage id
- unlisted a bunch of non-use items from the actions
- added deaths_verdict and deaths_choice with handler to aura
- added paragon_str/_agi proc from DV/DC and alias paragon
- added new alias mode (latest)
- added Deathbringer's Will and it's 6 possible buffs
- (@zmsl 's) changed druid-pooling for trinkets