### PR TITLE
Retribution Paladin: Remove wrathful_sanction from debuff tracking

### DIFF
--- a/Dragonflight/PaladinRetribution.lua
+++ b/Dragonflight/PaladinRetribution.lua
@@ -1639,9 +1639,6 @@ spec:RegisterAbilities( {
             removeBuff( "recompense" )
             gain( talent.boundless_judgment.enabled and 2 or 1, "holy_power" )
 
-            if debuff.expurgation.up and set_bonus.tier31_2pc > 0 then
-                applyDebuff( "target", "wrathful_sanction" )
-            end
             if talent.divine_arbiter.enabled then addStack( "divine_arbiter" ) end
             if talent.empyrean_legacy.enabled and debuff.empyrean_legacy_icd.down then
                 applyBuff( "empyrean_legacy" )


### PR DESCRIPTION
This aura is not registered which is causing warnings. Also Wrathful Sanction is a damage proc and has no duration so it probably doesn't make sense to track it. Echoes of Wrath is the 4pc and that does have a duration and is registered and tracked properly.