### PR TITLE
fix: use correct attribute name for resource type

### DIFF
--- a/Dragonflight/WarriorArms.lua
+++ b/Dragonflight/WarriorArms.lua
@@ -822,7 +822,7 @@ spec:RegisterAbilities( {
         icd = 1,
 
         spend = -20,
-        spentType = "rage",
+        spendType = "rage",
 
         startsCombat = true,
         texture = 132337,

--- a/Dragonflight/WarriorFury.lua
+++ b/Dragonflight/WarriorFury.lua
@@ -1028,7 +1028,7 @@ spec:RegisterAbilities( {
         gcd = "off",
 
         spend = -20,
-        spentType = "rage",
+        spendType = "rage",
 
         startsCombat = true,
         texture = 132337,

--- a/Dragonflight/WarriorProtection.lua
+++ b/Dragonflight/WarriorProtection.lua
@@ -798,7 +798,7 @@ spec:RegisterAbilities( {
         icd = 1,
 
         spend = function () return -20 * ( buff.unnerving_focus.up and 1.5 or 1 ) end,
-        spentType = "rage",
+        spendType = "rage",
 
         startsCombat = true,
         texture = 132337,


### PR DESCRIPTION
Change `spentType` to `spendType`. The latter is the correct attribute name for the resource used by a spell.