### PR TITLE
fix: use correct spell ID for Thunderous Roar debuff

### DIFF
--- a/Dragonflight/WarriorArms.lua
+++ b/Dragonflight/WarriorArms.lua
@@ -466,7 +466,7 @@ spec:RegisterAuras( {
         max_stack = 1
     },
     thunderous_roar = {
-        id = 384318,
+        id = 397364,
         duration = function () return 8 + ( talent.thunderous_words.enabled and 2 or 0 ) + ( talent.bloodletting.enabled and 6 or 0 ) end,
         tick_time = 2,
         max_stack = 1

--- a/Dragonflight/WarriorFury.lua
+++ b/Dragonflight/WarriorFury.lua
@@ -455,7 +455,7 @@ spec:RegisterAuras( {
         max_stack = 1
     },
     thunderous_roar = {
-        id = 384318,
+        id = 397364,
         duration = 8,
         tick_time = 2,
         max_stack = 1

--- a/Dragonflight/WarriorProtection.lua
+++ b/Dragonflight/WarriorProtection.lua
@@ -474,7 +474,7 @@ spec:RegisterAuras( {
         max_stack = 1
     },
     thunderous_roar = {
-        id = 384318,
+        id = 397364,
         duration = function () return talent.thunderous_words.enabled and 10 or 8 end,
         tick_time = 2,
         max_stack = 1


### PR DESCRIPTION
The Thunderous Roar spell (384318) has a different spell ID than the debuff (397364) that it applies.