### PR TITLE
[Sub Rogue] Backstab can be used for the 'Danse Macabre' talent

### DIFF
--- a/Dragonflight/RogueSubtlety.lua
+++ b/Dragonflight/RogueSubtlety.lua
@@ -774,6 +774,11 @@ spec:RegisterAbilities( {
             return 1 + ( buff.broadside.up and 1 or 0 )
         end,
 
+        used_for_danse = function()
+            if not talent.danse_macabre.enabled or buff.shadow_dance.down then return false end
+            return danse_macabre_tracker.backstab
+        end,
+
         handler = function ()
             removeBuff( "honed_blades" )
             applyDebuff( "target", "shadows_grasp", 8 )


### PR DESCRIPTION
The talent [Danse Macabre](https://www.wowhead.com/spell=382528/danse-macabre) stacks up with the use of Backstab, but Hekili currently ignores that. This PR adds a Danse stack when Backstab is used.