### PR TITLE
Updated Glyphs, Talents and Abilities + added missing commas

### DIFF
--- a/Cataclysm/Warlock.lua
+++ b/Cataclysm/Warlock.lua
@@ -760,31 +760,28 @@ end)
 
 -- Abilities
 spec:RegisterAbilities( {
-    -- Banishes the enemy target, preventing all action but making it invulnerable for up to 20 sec.  Only one target can be banished at a time.  Casting Banish on a banished target will cancel the spell.  Only works on Demons and Elementals.
     banish = {
         id = 710,
-        cast = function()
-            return ( 1.5 * haste)
-        end,
+        cast = 1.5,
         cooldown = 0,
         gcd = "spell",
 
-        spend = 0.08,
+        spend = 0.08, 
         spendType = "mana",
 
-        startsCombat = false,
+        startsCombat = true,
         texture = 136135,
 
-        handler = function( rank )
-            applyDebuff( "target", "banish" )
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=710/banish"
         end,
 
-        copy = { 18647 },
     },
 
 
-    -- Taunts all enemies within 10 yards for 6 sec.
-    challenging_howl = {
+challenging_howl = {
         id = 59671,
         cast = 0,
         cooldown = 15,
@@ -801,11 +798,10 @@ spec:RegisterAbilities( {
         handler = function ()
             applyDebuff( "target", "challenging_howl" )
         end,
+		
     },
 
-
-    -- Sends a bolt of chaotic fire at the enemy, dealing 864 to 1089 Fire damage. Chaos Bolt cannot be resisted, and pierces through all absorption effects.
-    chaos_bolt = {
+chaos_bolt = {
         id = 50796,
         cast =  function()
             return ( 2.5 * haste)
@@ -822,11 +818,10 @@ spec:RegisterAbilities( {
 
         handler = function ()
         end,
+		
     },
 
-
-    -- Consumes an Immolate or Shadowflame effect on the enemy target to instantly deal damage equal to 60% of your Immolate or Shadowflame, and causes an additional 40% damage over 6 sec.
-    conflagrate = {
+conflagrate = {
         id = 17962,
         cast = 0,
         cooldown = 10,
@@ -851,35 +846,31 @@ spec:RegisterAbilities( {
             if talent.aftermath.rank == 2 then applyDebuff( "target", "aftermath" ) end
             if talent.backdraft.enabled then applyBuff( "backdraft", nil, 3 ) end
         end,
+		
     },
 
-
-    -- Corrupts the target, causing 40 Shadow damage over 12 sec.
-    corruption = {
+corruption = {
         id = 172,
         cast = 0,
         cooldown = 0,
         gcd = "spell",
 
-        spend = function() return mod_suppression( 0.09 ) end,
+        spend = 0.06, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 136118,
 
-		cycle = "corruption",
-
-        handler = function( rank )
-            applyDebuff( "target", "corruption" )
-            debuff.corruption.pmultiplier = persistent_multiplier
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=172/corruption"
         end,
 
-        copy = { 6222, 6223, 7648, 11671, 11672, 25311, 27216, 47812, 47813 },
     },
 
 
-    -- While applied to target weapon it increases damage dealt by direct spells by 1% and spell critical strike rating by 7.  Lasts for 1 hour.
-    create_firestone = {
+create_firestone = {
         id = 6366,
         cast = function()
             return ( 3 * haste)
@@ -896,56 +887,51 @@ spec:RegisterAbilities( {
         handler = function ()
         end,
 
-        copy = { 17951, 17952, 17953, 27250, 60219, 60220 },
-    },
+	},
 
-
-    -- Creates a Minor Healthstone that can be used to instantly restore 100 health.    Conjured items disappear if logged out for more than 15 minutes.
-    create_healthstone = {
+create_healthstone = {
         id = 6201,
-        cast = function()
-            return ( 3 * haste)
-        end,
+        cast = 3,
         cooldown = 0,
         gcd = "spell",
 
-        spend = 0.53,
+        spend = 0.53, 
         spendType = "mana",
 
-        startsCombat = false,
+        startsCombat = true,
         texture = 135230,
 
-        handler = function ()
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=6201/create-healthstone"
         end,
 
-        copy = { 6202, 5699, 11729, 11730, 27230, 47871, 47878 },
     },
 
 
-    -- Creates a Minor Soulstone.  The Soulstone can be used to store one target's soul.  If the target dies while their soul is stored, they will be able to resurrect with 400 health and 700 mana.    Conjured items disappear if logged out for more than 15 minutes.
-    create_soulstone = {
+create_soulstone = {
         id = 693,
-        cast = function()
-            return ( 3 * haste)
-        end,
+        cast = 3,
         cooldown = 0,
         gcd = "spell",
 
-        spend = 0.68,
+        spend = 0.68, 
         spendType = "mana",
 
-        startsCombat = false,
+        startsCombat = true,
         texture = 136210,
 
-        handler = function ()
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=693/create-soulstone"
         end,
 
-        copy = { 20752, 20755, 20756, 20757, 27238, 47884 },
     },
 
 
-    -- While applied to target weapon it increases damage dealt by periodic spells by 1% and spell haste rating by 10.  Lasts for 1 hour.
-    create_spellstone = {
+create_spellstone = {
         id = 2362,
         cast = function()
             return ( 5 * haste)
@@ -961,34 +947,11 @@ spec:RegisterAbilities( {
 
         handler = function ()
         end,
-
-        copy = { 17727, 17728, 28172, 47886, 47888 },
-    },
+	},
 
 
-    -- Curses the target with agony, causing 84 Shadow damage over 24 sec.  This damage is dealt slowly at first, and builds up as the Curse reaches its full duration.  Only one Curse per Warlock can be active on any one target.
-    curse_of_agony = {
-        id = 980,
-        cast = 0,
-        cooldown = 0,
-        gcd = function() return talent.amplify_curse.enabled and "totem" or "spell" end,
 
-        spend = function() return mod_suppression( 0.1 ) end,
-        spendType = "mana",
-
-        startsCombat = true,
-        texture = 136139,
-
-        handler = function ()
-            applyDebuff( "target", "curse_of_agony" )
-        end,
-
-        copy = { 1014, 6217, 11711, 11712, 11713, 27218, 47863, 47864 },
-    },
-
-
-    -- Curses the target with impending doom, causing 3200 Shadow damage after 1 min.  If the target yields experience or honor when it dies from this damage, a Doomguard will be summoned.  Cannot be cast on players.
-    curse_of_doom = {
+curse_of_doom = {
         id = 603,
         cast = 0,
         cooldown = 60,
@@ -1005,13 +968,10 @@ spec:RegisterAbilities( {
         handler = function( rank )
             applyDebuff( "target", "curse_of_doom" )
         end,
-
-        copy = { 30910, 47867 },
-    },
+	},
 
 
-    -- Reduces the target's movement speed by 30% for 12 sec.  Only one Curse per Warlock can be active on any one target.
-    curse_of_exhaustion = {
+curse_of_exhaustion = {
         id = 18223,
         cast = 0,
         cooldown = 0,
@@ -1026,76 +986,74 @@ spec:RegisterAbilities( {
 
         handler = function ()
             applyDebuff( "target", "curse_of_exhaustion" )
-        end
+		end,
     },
+    
 
-
-    -- Curses the target for 5 min, reducing Arcane, Fire, Frost, Nature, and Shadow resistances by 45 and increasing magic damage taken by 6%.  Only one Curse per Warlock can be active on any one target.
-    curse_of_the_elements = {
+curse_of_the_elements = {
         id = 1490,
         cast = 0,
         cooldown = 0,
-        gcd = function() return talent.amplify_curse.enabled and "totem" or "spell" end,
+        gcd = "spell",
 
-        spend = function() return mod_suppression( 0.1 ) end,
+        spend = 0.1, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 136130,
 
-        handler = function ()
-            applyDebuff( "target", "curse_of_the_elements" )
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=1490/curse-of-the-elements"
         end,
 
-        copy = { 11721, 11722, 27228, 47865 },
     },
 
 
-    -- Forces the target to speak in Demonic, increasing the casting time of all spells by 25%.  Only one Curse per Warlock can be active on any one target.  Lasts 30 sec.
     curse_of_tongues = {
         id = 1714,
         cast = 0,
         cooldown = 0,
-        gcd = function() return talent.amplify_curse.enabled and "totem" or "spell" end,
+        gcd = "spell",
 
-        spend = function() return mod_suppression( 0.04 ) end,
+        spend = 0.04, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 136140,
 
-        handler = function ()
-            applyDebuff( "target", "curse_of_tongues" )
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=1714/curse-of-tongues"
         end,
 
-        copy = { 11719 },
     },
 
 
-    -- Target's melee attack power is reduced by 21 and armor is reduced by 5% for 2 min.  Only one Curse per Warlock can be active on any one target.
     curse_of_weakness = {
         id = 702,
         cast = 0,
         cooldown = 0,
-        gcd = function() return talent.amplify_curse.enabled and "totem" or "spell" end,
+        gcd = "spell",
 
-        spend = function() return mod_suppression( 0.01 ) end,
+        spend = 0.1, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 136138,
 
-        handler = function ()
-            applyBuff( "curse_of_weakness" )
-            applyDebuff( "target", "curse_of_weakness" )
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=702/curse-of-weakness"
         end,
 
-        copy = { 1108, 6205, 7646, 11707, 11708, 27224, 30909, 50511 },
     },
 
 
-    -- Drains 305 of your summoned demon's Mana, returning 100% to you.
-    dark_pact = {
+dark_pact = {
         id = 59092,
         cast = 0,
         cooldown = 0,
@@ -1104,72 +1062,60 @@ spec:RegisterAbilities( {
         talent = "dark_pact",
         startsCombat = false,
         texture = 136141,
-
+	
         pet_cost = {
             [18220] = 305,
             [18937] = 440,
             [18938] = 545,
             [27265] = 700,
             [59092] = 1200
-        },
-
-        usable = function() return pet.mana_current > 150 + ( class.abilities.dark_pact.pet_cost[ class.abilities.dark_pact.id ] or 1200 ), "requires pet mana" end,
-
-        handler = function()
-            gain( class.abilities.dark_pact.pet_cost[ class.abilities.dark_pact.id ] or 1200, "mana" )
-        end,
-
-        copy = { 18220, 18937, 18938, 27265 }
-    },
-
-
-    -- Causes the enemy target to run in horror for 3 sec and causes 257 Shadow damage.  The caster gains 300% of the damage caused in health.
-    death_coil = {
+		},
+		end,
+		
+	},
+	
+death_coil = {
         id = 6789,
         cast = 0,
-        cooldown = 120,
+        cooldown = 2,
         gcd = "spell",
 
-        spend = function() return mod_suppression( 0.23 ) end,
+        spend = 0.23, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 136145,
 
-        toggle = "defensives",
-
-        handler = function ()
-            applyDebuff( "target", "death_coil" )
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=6789/death-coil"
         end,
 
-        copy = { 17925, 17926, 27223, 47859, 47860 },
     },
 
 
-    -- Protects the caster, increasing armor by 465, and increasing the amount of health generated through spells and effects by 20%. Only one type of Armor spell can be active on the Warlock at any time.  Lasts 30 min.
-    demon_armor = {
-        id = 706,
+demon_armor = {
+        id = 687,
         cast = 0,
         cooldown = 0,
         gcd = "spell",
 
-        spend = 0.31,
-        spendType = "mana",
+        
 
-        startsCombat = false,
+        startsCombat = true,
         texture = 136185,
-        essential = true,
 
-        handler = function ()
-            applyBuff( "demon_armor" )
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=6229/shadow-ward"
         end,
 
-        copy = { 1086, 11733, 11734, 11735, 27260, 47793, 47889 },
     },
 
 
-    -- Charge an enemy, stunning it for 3 sec.
-    demon_charge = {
+demon_charge = {
         id = 54785,
         cast = 0,
         cooldown = 45,
@@ -1187,9 +1133,7 @@ spec:RegisterAbilities( {
         end,
     },
 
-
-    -- Protects the caster, increasing armor by 90, and increasing the amount of health generated through spells and effects by 20%. Only one type of Armor spell can be active on the Warlock at any time.  Lasts 30 min.
-    demon_skin = {
+demon_skin = {
         id = 687,
         cast = 0,
         cooldown = 0,
@@ -1205,49 +1149,50 @@ spec:RegisterAbilities( {
         handler = function ()
             applyDebuff( "target", "demon_skin" )
         end,
-
-        copy = { 696 },
-    },
+	},
 
 
-    -- You summon a Demonic Circle at your feet, lasting 6 min. You can only have one Demonic Circle active at a time.
-    demonic_circle_summon = {
+demonic_circle_summon = {
         id = 48018,
-        cast = 0.5,
+        cast = 500,
         cooldown = 0,
         gcd = "spell",
 
-        spend = 0.15,
+        spend = 0.15, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 237559,
 
-        handler = function ()
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=48018/demonic-circle-summon"
         end,
+
     },
 
-
-    -- Teleports you to your Demonic Circle and removes all snare effects.
-    demonic_circle_teleport = {
+demonic_circle_teleport = {
         id = 48020,
         cast = 0,
-        cooldown = function() return glyph.demonic_circle.enabled and 26 or 30 end,
+        cooldown = 30,
         gcd = "spell",
 
-        spend = 100,
+        spend = 100, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 237560,
 
-        handler = function ()
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=48020/demonic-circle-teleport"
         end,
+
     },
 
-
-    -- Grants the Warlock's summoned demon Empowerment.    Imp - Increases the Imp's spell critical strike chance by 20% for 30 sec.    Voidwalker - Increases the Voidwalker's health by 20%, and its threat generated from spells and attacks by 20% for 20 sec.    Succubus and Incubus - Instantly vanishes, causing the demon to go into an improved Invisibility state. The vanish effect removes all stuns, snares and movement impairing effects from the demon.    Felhunter - Dispels all magical effects from the Felhunter.    Felguard - Increases the Felguard's attack speed by 20% and breaks all stun, snare and movement impairing effects and makes your Felguard immune to them for 15 sec.
-    demonic_empowerment = {
+demonic_empowerment = {
         id = 47193,
         cast = 0,
         cooldown = function() return 60 * ( 1 - ( 0.1 * talent.nemesis.rank ) ) end,
@@ -1269,9 +1214,7 @@ spec:RegisterAbilities( {
         end,
     },
 
-
-    -- Allows the friendly target to detect lesser invisibility for 10 min.
-    detect_invisibility = {
+detect_invisibility = {
         id = 132,
         cast = 0,
         cooldown = 0,
@@ -1285,43 +1228,49 @@ spec:RegisterAbilities( {
 
         handler = function ()
             applyBuff( "detect_invisibility" )
-        end
     },
 
-
-    -- Transfers 10 health every 1 sec from the target to the caster.  Lasts 5 sec.
-    drain_life = {
-        id = 689,
-        cast = function() return ( 5 * haste) end,
+drain_life = {
+        id = 89420,
+        cast = Channeled,
         cooldown = 0,
         gcd = "spell",
-		channeled = true,
-        breakable = true,
-        spend = function() return mod_suppression( 0.17 ) end,
+
+        spend = 0.12, 
         spendType = "mana",
+
         startsCombat = true,
         texture = 136169,
-        aura = "drain_life",
-		tick_time = function () return class.auras.drain_life.tick_time end,
-        start = function( rank )
-            applyDebuff( "target", "drain_life" )
-            if talent.everlasting_affliction.rank == 5 and dot.corruption.ticking then dot.corruption.expires = query_time + dot.corruption.duration end
-            -- TODO: Decide whether to model health gains; Soul Siphon.
-        end,
-		tick = function () end,
-		breakchannel = function ()
-            removeDebuff( "target", "drain_life" )
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=89420/drain-life"
         end,
 
-		handler = function ()
+    },
+	
+drain_life = {
+        id = 689,
+        cast = Channeled,
+        cooldown = 0,
+        gcd = "spell",
+
+        spend = 0.12, 
+        spendType = "mana",
+
+        startsCombat = true,
+        texture = 136169,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=689/drain-life"
         end,
 
-        copy = { 699, 709, 7651, 11699, 11700, 27219, 27220, 47857 },
     },
 
-
-    -- Transfers 3% of target's maximum mana every 1 sec from the target to the caster (up to a maximum of 6% of the caster's maximum mana every 1 sec).  Lasts 5 sec.
-    drain_mana = {
+drain_mana = {
         id = 5138,
         cast = function() return ( 5 * haste) end,
         cooldown = 0,
@@ -1346,104 +1295,90 @@ spec:RegisterAbilities( {
         end,
     },
 
-
-    -- Drains the soul of the target, causing 55 Shadow damage over 15 sec.  If the target is at or below 25% health, Drain Soul causes four times the normal damage. If the target dies while being drained, and yields experience or honor, the caster gains a Soul Shard.  Each time the Drain Soul damages the target, it also has a chance to generate a Soul Shard.  Soul Shards are required for other spells.
-    drain_soul = {
+drain_soul = {
         id = 1120,
-        cast = function() return ( 15 * haste) end,
+        cast = Channeled,
         cooldown = 0,
         gcd = "spell",
-		channeled = true,
-        breakable = true,
-        spend = function() return mod_suppression( 0.14 ) end,
+
+        spend = 0.14, 
         spendType = "mana",
+
         startsCombat = true,
         texture = 136163,
-        aura = "drain_soul",
-		tick_time = function () return class.auras.drain_soul.tick_time end,
-        start = function( rank )
-            applyDebuff( "target", "drain_soul" )
-            if talent.everlasting_affliction.rank == 5 and dot.corruption.ticking then dot.corruption.expires = query_time + dot.corruption.duration end
-        end,
-		tick = function () end,
 
-		 breakchannel = function ()
-            removeDebuff( "target", "drain_soul" )
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=1120/drain-soul"
         end,
 
-		handler = function ()
-        end,
-
-        copy = { 8288, 8289, 11675, 27217, 47855 },
     },
 
 
-    -- Summons an Eye of Kilrogg and binds your vision to it.  The eye moves quickly but is very fragile.
-    eye_of_kilrogg = {
+eye_of_kilrogg = {
         id = 126,
         cast = 5,
         cooldown = 0,
         gcd = "spell",
 
-        spend = 0.04,
+        spend = 0.04, 
         spendType = "mana",
 
-        startsCombat = false,
+        startsCombat = true,
         texture = 136155,
 
-        handler = function ()
-            applyBuff( "eye_of_kilrogg" )
-        end
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=126/eye-of-kilrogg"
+        end,
+
     },
 
 
-    -- Strikes fear in the enemy, causing it to run in fear for up to 10 sec.  Damage caused may interrupt the effect.  Only 1 target can be feared at a time.
-    fear = {
-        id = 6215,
-        cast = function()
-            return ( 1.5 * haste)
-        end,
+fear = {
+        id = 5782,
+        cast = 1.7,
         cooldown = 0,
         gcd = "spell",
 
-        spend = function() return mod_suppression( 0.12 ) end,
+        spend = 0.12, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 136183,
 
+        --fix:
+        stance = "None",
         handler = function()
-            applyDebuff( "target", "fear" )
+            --"/cata/spell=5782/fear"
         end,
 
-        copy = { 5782, 6213 },
     },
 
 
-    -- Surrounds the caster with fel energy, increasing spell power by 50 plus additional spell power equal to 30% of your Spirit. In addition, you regain 2% of your maximum health every 5 sec. Only one type of Armor spell can be active on the Warlock at any time.  Lasts 30 min.
-    fel_armor = {
-        id = 47893,
+fel_armor = {
+        id = 28176,
         cast = 0,
         cooldown = 0,
         gcd = "spell",
 
-        spend = 0.28,
-        spendType = "mana",
+        
 
-        startsCombat = false,
+        startsCombat = true,
         texture = 136156,
-        essential = true,
 
-        handler = function ()
-            applyBuff( "fel_armor" )
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=6229/shadow-ward"
         end,
 
-        copy = { 28176, 28189, 47892 },
     },
 
 
-    -- Your next Imp, Voidwalker, Succubus, Incubus, Felhunter or Felguard Summon spell has its casting time reduced by 5.5 sec and its Mana cost reduced by 50%.
-    fel_domination = {
+fel_domination = {
         id = 18708,
         cast = 0,
         cooldown = function() return 180 * ( 1 - ( 0.1 * talent.nemesis.rank ) ) end,
@@ -1457,12 +1392,10 @@ spec:RegisterAbilities( {
 
         handler = function ()
             applyBuff( "fel_domination" )
-        end
     },
+    
 
-
-    -- You send a ghostly soul into the target, dealing 405 to 473 Shadow damage and increasing all damage done by your Shadow damage-over-time effects on the target by 20% for 12 sec. When the Haunt spell ends or is dispelled, the soul returns to you, healing you for 100% of the damage it did to the target.
-    haunt = {
+haunt = {
         id = 48181,
         cast = function()
             return ( 1.5 * haste)
@@ -1488,206 +1421,173 @@ spec:RegisterAbilities( {
         end,
     },
 
-
-    -- Gives 12 health to the caster's pet every second for 10 sec as long as the caster channels.
-    health_funnel = {
-        id = 47856,
-        cast = 0,
+health_funnel = {
+        id = 755,
+        cast = Channeled,
         cooldown = 0,
         gcd = "spell",
 
-        spend = function()
-            return ( ability.health_cost[ ability.id ] or 520 ) * ( 1 + 0.1 * talent.improved_health_funnel.rank )
-        end,
-        spendType = "health",
+        
 
-        health_cost = {
-            [755]  = 12,
-            [3698] = 24,
-            [3699] = 43,
-            [3700] = 64,
-            [11693] = 89,
-            [11694] = 119,
-            [11695] = 153,
-            [27259] = 188,
-            [47856] = 520,
-        },
-
-        startsCombat = false,
+        startsCombat = true,
         texture = 136168,
-        aura = "health_funnel",
 
-        start = function( rank )
-            applyBuff( "health_funnel" )
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=755/health-funnel"
         end,
 
-        copy = { 755, 3698, 3699, 3700, 11693, 11694, 11695, 27259 },
     },
 
 
-    -- Ignites the area surrounding the caster, causing 87 Fire damage to herself and 87 Fire damage to all nearby enemies every 1 sec.  Lasts 15 sec.
-    hellfire = {
-        id = 47823,
-        cast = 0,
+hellfire = {
+        id = 85403,
+        cast = Channeled,
         cooldown = 0,
         gcd = "spell",
 
-        spend = function() return mod_cataclysm( 0.64 ) end,
+        spend = 0.64, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 135818,
 
-        aura = "hellfire",
-
-        start = function( rank )
-            applyBuff( "hellfire" )
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=5857/hellfire"
         end,
 
-        copy = { 1949, 11683, 11684, 27213 },
+    },
+	
+	
+hellfire = {
+        id = 1949,
+        cast = Channeled,
+        cooldown = 0,
+        gcd = "spell",
+
+        spend = 0.64, 
+        spendType = "mana",
+
+        startsCombat = true,
+        texture = 135818,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=5857/hellfire"
+        end,
+
     },
 
 
-    -- Howl, causing 5 enemies within 10 yds to flee in terror for 6 sec.  Damage caused may interrupt the effect.
-    howl_of_terror = {
-        id = 17928,
-        cast = function() return 1.5 * ( 1 - 0.5 * talent.improved_howl_of_terror.rank ) end,
-        cooldown = function() return glyph.howl_of_terror.enabled and 32 or 40 end,
+howl_of_terror = {
+        id = 5484,
+        cast = 1.5,
+        cooldown = 40,
         gcd = "spell",
 
-        spend = function() return mod_suppression( 0.08 ) end,
+        spend = 0.08, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 136147,
 
-        handler = function( rank )
-            applyDebuff( "target", "howl_of_terror" )
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=5484/howl-of-terror"
         end,
 
-        copy = { 5484 },
     },
 
 
-    -- Burns the enemy for 10 Fire damage and then an additional 20 Fire damage over 15 sec.
-    immolate = {
+immolate = {
         id = 348,
-        cast = function() return ( 2 - 0.1 * talent.bane.rank ) * ( 1 - 0.1 * ( buff.backdraft.up and talent.backdraft.rank or 0 ) ) end,
+        cast = 0,
         cooldown = 0,
         gcd = "spell",
 
-        spend = function() return mod_cataclysm( 0.17 ) end,
+        spend = 0.08, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 135817,
-		cycle = "immolate",
 
+        --fix:
+        stance = "None",
         handler = function()
-            removeDebuff( "target", "unstable_affliction" )
-            applyDebuff( "target", "immolate" )
-            removeStack( "backdraft" )
+            --"/cata/spell=348/immolate"
         end,
 
-        copy = { 707, 1094, 2941, 11665, 11667, 11668, 25309, 27215, 47810, 47811 },
     },
 
 
-    -- Ignites the area surrounds you, causing 481 Fire damage to all nearby enemies every 0.9 sec.  Lasts 13.45 sec.
-    immolation_aura = {
+immolation_aura = {
         id = 50589,
         cast = 0,
         cooldown = 30,
         gcd = "spell",
 
-        spend = 0.64,
+        spend = 0.64, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 135818,
 
-        buff = "metamorphosis",
-
-        handler = function ()
-            applyBuff( "immolation_aura" )
+        --fix:
+        stance = "Metamorphosis",
+        handler = function()
+            --"/cata/spell=50590/immolation"
         end,
+
     },
 
 
-    -- Deals 416 to 480 Fire damage to your target and an additional 104 to 120 Fire damage if the target is affected by an Immolate spell.
-    incinerate = {
-        id = 47838,
-        cast = function()
-            if buff.backlash.up then return 0 end
-            return ( 2.5 - 0.05 * talent.emberstorm.rank ) * ( 1 - 0.1 * ( buff.molten_core.up and talent.molten_core.rank or 0 ) ) * ( 1 - 0.1 * ( buff.backdraft.up and talent.backdraft.rank or 0 ) )
-        end,
+incinerate = {
+        id = 29722,
+        cast = 0,
         cooldown = 0,
         gcd = "spell",
 
-        spend = function() return mod_cataclysm( 0.14 ) end,
+        spend = 0.14, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 135789,
 
-        handler = function ()
-            removeBuff( "backlash" )
-            removeStack( "molten_core", 1 )
-            removeStack( "backdraft" )
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=29722/incinerate"
         end,
 
-        copy = { 29722, 32231, 47837 },
     },
 
 
-    -- Converts 286 health into 40 mana.  Spell power increases the amount of mana returned.
-    life_tap = {
-        id = 57946,
+life_tap = {
+        id = 1454,
         cast = 0,
         cooldown = 0,
         gcd = "spell",
 
-        spend = function()
-            if ability.id == 57946 then return 2000 + stat.spirit * 1.5 end
-            if ability.id == 27222 then return 1164 + stat.spirit * 1.5 end
-            if ability.id == 11689 then return  867 + stat.spirit * 1.5 end
-            if ability.id == 11688 then return  346 + stat.spirit * 1.5 end
-            if ability.id == 11687 then return  249 + stat.spirit * 1.5 end
-            if ability.id ==  1456 then return  159 + stat.spirit * 1.5 end
-            if ability.id ==  1455 then return   86 + stat.spirit * 1.5 end
-            if ability.id ==  1454 then return   41 + stat.spirit * 1.5 end
-            return 2000 + stat.spirit * 1.5
-        end,
-        spendType = "health",
+        
 
-        startsCombat = false,
+        startsCombat = true,
         texture = 136126,
 
-        handler = function ()
-            local amt = 2000
-
-            if     ability.id == 57946 then amt = 2000
-            elseif ability.id == 27222 then amt = 1164
-            elseif ability.id == 11689 then amt =  867
-            elseif ability.id == 11688 then amt =  346
-            elseif ability.id == 11687 then amt =  249
-            elseif ability.id ==  1456 then amt =  159
-            elseif ability.id ==  1455 then amt =   86
-            elseif ability.id ==  1454 then amt =   41 end
-
-            amt = amt + stat.spell_power * 0.5
-            amt = amt * ( 1 + 0.1 * talent.improved_life_tap.rank )
-
-            gain( amt, "mana" )
-            if glyph.life_tap.enabled then applyBuff( "life_tap" ) end
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=1454/life-tap"
         end,
 
-        copy = { 1454, 1455, 1456, 11687, 11688, 11689, 27222 },
     },
 
 
-    -- You transform into a Demon for 30 sec.  This form increases your armor contribution from items by 600%, damage by 20%, reduces the chance you'll be critically hit by melee attacks by 6% and reduces the duration of stun and snare effects by 50%.  You gain some unique demon abilities in addition to your normal abilities.
-    metamorphosis = {
+metamorphosis = {
         id = 47241,
         cast = 0,
         cooldown = function() return 180 * ( 1 - ( 0.1 * talent.nemesis.rank ) ) end,
@@ -1702,117 +1602,113 @@ spec:RegisterAbilities( {
             applyBuff( "metamorphosis" )
         end,
     },
-
-
-    -- Calls down a fiery rain to burn enemies in the area of effect for 246 Fire damage over 8 sec.
-    rain_of_fire = {
-        id = 5740,
-        cast = 0,
+	
+rain_of_fire = {
+            id = 5740,
+        cast = Channeled,
         cooldown = 0,
         gcd = "spell",
 
-        spend = function() return mod_cataclysm( 0.57 ) end,
+        spend = 0.57, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 136186,
 
-        aura = "rain_of_fire",
-
-        start = function( rank )
-            applyBuff( "rain_of_fire" )
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=42223/rain-of-fire"
         end,
 
-        copy = { 6219, 11677, 11678, 27212, 47819, 47820 },
     },
 
 
-    --[[ Begins a ritual that creates a Soulwell.  Raid members can click the Soulwell to acquire a Master Healthstone.  The Soulwell lasts for 3 min or 25 charges.  Requires the caster and 2 additional party members to complete the ritual.  In order to participate, all players must right-click the soul portal and not move until the ritual is complete.
-    ritual_of_souls = {
+ritual_of_souls = {
         id = 29893,
-        cast = 0,
-        cooldown = 300,
+        cast = Channeled,
+        cooldown = 5,
         gcd = "spell",
 
-        spend = function() return 0.8 * ( glyph.souls.enabled and 0.3 or 1 ) end,
+        spend = 0.27, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 136194,
 
-        handler = function ()
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=29893/ritual-of-souls"
         end,
 
-        copy = { 58887 },
-    }, ]]
+    },
 
 
-    --[[ Begins a ritual that creates a summoning portal.  The summoning portal can be used by 2 party or raid members to summon a targeted party or raid member.  The ritual portal requires the caster and 2 additional party or raid members to complete.  In order to participate, all players must be out of combat and right-click the portal and not move until the ritual is complete.
-    ritual_of_summoning = {
+ritual_of_summoning = {
         id = 698,
-        cast = 0,
-        cooldown = 120,
+        cast = Channeled,
+        cooldown = 2,
         gcd = "spell",
 
-        spend = 0,
+        spend = 0.12, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 136223,
 
-        handler = function ()
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=698/ritual-of-summoning"
         end,
-    }, ]]
+
+    },
 
 
-    -- Inflict searing pain on the enemy target, causing 38 to 47 Fire damage.  Causes a high amount of threat.
-    searing_pain = {
+searing_pain = {
         id = 5676,
-        cast = function() return 1.5 * ( 1 - 0.1 * ( buff.backdraft.up and talent.backdraft.rank or 0 ) ) end,
+        cast = 0,
         cooldown = 0,
         gcd = "spell",
 
-        spend = function() return mod_cataclysm( 0.08 ) end,
+        spend = 0.12, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 135827,
 
-        handler = function ()
-            removeStack( "backdraft" )
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=5676/searing-pain"
         end,
 
-        copy = { 17919, 17920, 17921, 17922, 17923, 27210, 30459, 47814, 47815 },
     },
 
 
-    -- Imbeds a demon seed in the enemy target, causing 1044 Shadow damage over 18 sec.  When the target takes 1044 total damage or dies, the seed will inflict 1110 to 1290 Shadow damage to all enemies within 15 yards of the target.  Only one Corruption spell per Warlock can be active on any one target.
-    seed_of_corruption = {
+seed_of_corruption = {
         id = 27243,
-        cast = function()
-            return ( 2 * haste)
-        end,
+        cast = 0,
         cooldown = 0,
         gcd = "spell",
 
-        spend = function() return mod_suppression( 0.34 ) end,
+        spend = 0.34, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 136193,
 
-        cycle = "seed_of_corruption",
-
+        --fix:
+        stance = "None",
         handler = function()
-            applyDebuff( "target", "seed_of_corruption" )
+            --"/cata/spell=27243/seed-of-corruption"
         end,
 
-        copy = { 47835, 47836 },
     },
 
 
-    --[[ Shows the location of all nearby demons on the minimap until cancelled.  Only one form of tracking can be active at a time.
-    sense_demons = {
+sense_demons = {
         id = 5500,
         cast = 0,
         cooldown = 0,
@@ -1823,49 +1719,30 @@ spec:RegisterAbilities( {
 
         handler = function ()
         end,
-    }, ]]
+    },
 
-
-    -- Sends a shadowy bolt at the enemy, causing 13 to 18 Shadow damage.
-    shadow_bolt = {
-        id = 47809,
-        cast = function()
-            if buff.backlash.up then return 0 end
-            if buff.shadow_trance.up then return 0 end
-            return ( 1.7 - 0.1 * talent.bane.rank ) * ( 1 - 0.1 * ( buff.backdraft.up and talent.backdraft.rank or 0 ) * haste )
-        end,
+shadow_bolt = {
+        id = 686,
+        cast = 0,
         cooldown = 0,
         gcd = "spell",
 
-        spend = function() return mod_cataclysm( 0.1 ) * ( glyph.shadow_bolt.enabled and 0.9 or 1 ) end,
+        spend = 0.1, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 136197,
 
-		cycle = "shadow_bolt",
-
-		velocity = 6,
-		impact = function()
-            if talent.improved_shadow_bolt.rank == 5 then applyDebuff( "target", "shadow_mastery", nil, debuff.shadow_mastery.stack + 1 ) end
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=686/shadow-bolt"
         end,
 
-        handler = function ()
-            -- TODO: Confirm order in which Backlash vs. Shadow Trace would be consumed.
-            if buff.backlash.up then removeBuff( "backlash" )
-            elseif buff.shadow_trance.up then removeBuff( "shadow_trance" ) end
-            if talent.shadow_embrace.enabled then applyDebuff( "target", "shadow_embrace", nil, debuff.shadow_embrace.stack + 1 ) end
-            if talent.everlasting_affliction.rank == 5 and dot.corruption.ticking then dot.corruption.expires = query_time + dot.corruption.duration end
-            removeStack( "backdraft" )
-        end,
-
-        copy = { 686, 695, 705, 1088, 1106, 7641, 11659, 11660, 11661, 25307, 27209, 47808 },
     },
 
 
-
-    -- Inflicts 110 Shadow damage to an enemy target and nearby allies, affecting up to 3 targets.
-    shadow_cleave = {
+shadow_cleave = {
         id = 50581,
         cast = 0,
         cooldown = 6,
@@ -1887,30 +1764,28 @@ spec:RegisterAbilities( {
         end,
     },
 
-
-    -- Absorbs 290 shadow damage.  Lasts 30 sec.
-    shadow_ward = {
+shadow_ward = {
         id = 6229,
         cast = 0,
         cooldown = 30,
         gcd = "spell",
 
-        spend = 0.12,
+        spend = 0.12, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 136121,
 
-        handler = function ()
-            applyBuff( "shadow_ward" )
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=6229/shadow-ward"
         end,
 
-        copy = { 11739, 11740, 28610, 47890, 47891 },
     },
 
 
-    -- Instantly blasts the target for 91 to 104 Shadow damage.  If the target dies within 5 sec of Shadowburn, and yields experience or honor, the caster gains a Soul Shard.
-    shadowburn = {
+shadowburn = {
         id = 47827,
         cast = 0,
         cooldown = 15,
@@ -1931,32 +1806,49 @@ spec:RegisterAbilities( {
         end,
 
         copy = { 17877, 18867, 18868, 18869, 18870, 18871, 27263, 30546, 47826 }
-    },
+		
+	},
 
-
-    -- Targets in a cone in front of the caster take 530 to 578 Shadow damage and an additional 544 Fire damage over 8 sec.
-    shadowflame = {
+shadowflame = {
         id = 47897,
         cast = 0,
-        cooldown = 15,
+        cooldown = 12,
         gcd = "spell",
 
-        spend = 0.25,
+        spend = 0.25, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 236302,
-		cycle = "shadowflame",
-        handler = function ()
-            applyDebuff( "target", "shadowflame" )
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=47897/shadowflame"
         end,
 
-        copy = { 61290 },
+    },
+	
+shadowflame = {
+        id = 47960,
+        cast = 0,
+        cooldown = 0,
+        gcd = "off",
+
+        
+
+        startsCombat = true,
+        texture = 236302,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=47960/shadowflame"
+        end,
+
     },
 
-
-    -- Shadowfury is unleashed, causing 357 to 422 Shadow damage and stunning all enemies within 8 yds for 3 sec.
-    shadowfury = {
+shadowfury = {
         id = 30283,
         cast = 0,
         cooldown = 20,
@@ -1974,36 +1866,28 @@ spec:RegisterAbilities( {
         end,
     },
 
-
-    -- Burn the enemy's soul, causing 640 to 801 Fire damage.
-    soul_fire = {
-        id = 47824,
-        cast = function() return ( 6 - 0.4 * talent.bane.rank ) * ( 1 - 0.2 * ( buff.decimation.up and talent.decimation.rank or 0 ) ) * ( 1 - 0.1 * ( buff.backdraft.up and talent.backdraft.rank or 0 ) ) end,
+soul_fire = {
+        id = 6353,
+        cast = 0,
         cooldown = 0,
         gcd = "spell",
 
-        spend = function() return mod_cataclysm( 0.09 ) end,
+        spend = 0.09, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 135808,
 
-        usable = function() return buff.decimation.up or soul_shards > 0, "requires decimation or a soul_shard" end,
-
-        handler = function( rank )
-            if buff.decimation.down then
-                soul_shards = max( 0, soul_shards - 1 )
-            end
-            removeStack( "molten_core", 1 )
-            removeStack( "backdraft" )
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=6353/soul-fire"
         end,
 
-        copy = { 6353, 17924, 27211, 30545 },
     },
 
 
-    -- When active, 20% of all damage taken by the caster is taken by your Imp, Voidwalker, Succubus, Felhunter, Felguard, or subjugated demon instead.  That damage cannot be prevented. Lasts as long as the demon is active and controlled.
-    soul_link = {
+soul_link = {
         id = 19028,
         cast = 0,
         cooldown = 0,
@@ -2022,57 +1906,53 @@ spec:RegisterAbilities( {
 
         handler = function()
             applyBuff( "soul_link" )
-        end
+		end,
     },
+    
 
-
-    -- Reduces threat by 50% for all enemies within 50 yards.
-    soulshatter = {
+soulshatter = {
         id = 29858,
         cast = 0,
-        cooldown = 180,
+        cooldown = 2,
         gcd = "spell",
 
-        spend = 573,
+        spend = 0.08, 
         spendType = "health",
 
         startsCombat = true,
         texture = 135728,
 
-        usable = function() return soul_shards > 0, "requires a soul_shard" end,
-
+        --fix:
+        stance = "None",
         handler = function()
-            soul_shards = max( 0, soul_shards - 1 )
-        end
+            --"/cata/spell=29858/soulshatter"
+        end,
+
     },
 
 
-    -- Subjugates the target demon, up to level 45, forcing it to do your bidding.  While subjugated, the time between the demon's attacks is increased by 30% and its casting speed is slowed by 20%.  Lasts up to 5 min.
-    subjugate_demon = {
-        id = 61191,
-        cast = function() return glyph.subjugate_demon.enabled and 1.5 or 3 end,
+subjugate_demon = {
+        id = 1098,
+        cast = 3,
         cooldown = 0,
         gcd = "spell",
 
-        spend = 0.27,
+        spend = 0.27, 
         spendType = "mana",
 
         startsCombat = true,
         texture = 136154,
 
-        usable = function() return not pet.exists, "cannot have a pet" end,
-
-        handler = function( rank )
-            applyDebuff( "target", "enslave_demon" )
-            summonPet( "controlled_demon" )
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=1098/subjugate-demon"
         end,
 
-        copy = { 1098, 11725, 11726 },
     },
 
 
-    -- Summons a Felguard under the command of the Warlock.
-    summon_felguard = {
+summon_felguard = {
         id = 30146,
         cast = function() return 10 - ( 2 * talent.master_summoner.rank ) - ( buff.fel_domination.up and 5.5 or 0 ) end,
         cooldown = 0,
@@ -2096,10 +1976,10 @@ spec:RegisterAbilities( {
             summonPet( "felguard" )
 			dismissPet( "infernal" )
             soul_shards = max( 0, soul_shards - 1 )
-        end
     },
+    
 
-	inferno = {
+inferno = {
         id = 1122,
         cast = function() return (1.5 * haste) end,
         cooldown = 600,
@@ -2119,164 +1999,136 @@ spec:RegisterAbilities( {
             dismissPet( "succubus" )
             dismissPet( "felguard" )
 			summonPet( "infernal" )
-        end
     },
+    }
 
-
-    -- Summons a Felhunter under the command of the Warlock.
-    summon_felhunter = {
+summon_felhunter = {
         id = 691,
-        cast = function() return 10 - ( 2 * talent.master_summoner.rank ) - ( buff.fel_domination.up and 5.5 or 0 ) end,
+        cast = 6,
         cooldown = 0,
         gcd = "spell",
 
-        spend = function() return 0.8 * ( buff.fel_domination.up and 0.5 or 1 ) * ( 1 - 0.2 * talent.master_summoner.rank ) end,
+        spend = 0.8, 
         spendType = "mana",
 
-        startsCombat = false,
+        startsCombat = true,
         texture = 136217,
-        essential = true,
 
-        usable = function() return soul_shards > 0, "requires a soul_shard" end,
-
+        --fix:
+        stance = "None",
         handler = function()
-            dismissPet( "imp" )
-            dismissPet( "voidwalker" )
-            summonPet( "felhunter" )
-            dismissPet( "succubus" )
-            dismissPet( "felguard" )
-			dismissPet( "infernal" )
-            soul_shards = max( 0, soul_shards - 1 )
-        end
+            --"/cata/spell=691/summon-felhunter"
+        end,
+
     },
 
 
-    -- Summons an Imp under the command of the Warlock.
-    summon_imp = {
+summon_imp = {
         id = 688,
-        cast = function() return 10 - ( 2 * talent.master_summoner.rank ) - ( buff.fel_domination.up and 5.5 or 0 ) end,
+        cast = 6,
         cooldown = 0,
         gcd = "spell",
 
-        spend = function() return 0.64 * ( buff.fel_domination.up and 0.5 or 1 ) * ( 1 - 0.2 * talent.master_summoner.rank ) end,
+        spend = 0.64, 
         spendType = "mana",
-        essential = true,
 
-        startsCombat = false,
+        startsCombat = true,
         texture = 136218,
 
+        --fix:
+        stance = "None",
         handler = function()
-            summonPet( "imp" )
-            dismissPet( "voidwalker" )
-            dismissPet( "felhunter" )
-            dismissPet( "succubus" )
-            dismissPet( "felguard" )
-			dismissPet( "infernal" )
-        end
+            --"/cata/spell=688/summon-imp"
+        end,
+
     },
 
 
-    -- Summons an Incubus under the command of the Warlock.
-    summon_incubus = {
+summon_incubus = {
         id = 713,
-        cast = function() return 10 - ( 2 * talent.master_summoner.rank ) - ( buff.fel_domination.up and 5.5 or 0 ) end,
+        cast = 6,
         cooldown = 0,
         gcd = "spell",
 
-        spend = function() return 0.80 * ( buff.fel_domination.up and 0.5 or 1 ) * ( 1 - 0.2 * talent.master_summoner.rank ) end,
+        spend = 0.8, 
         spendType = "mana",
 
-        startsCombat = false,
+        startsCombat = true,
         texture = 4352492,
-        essential = true,
 
+        --fix:
+        stance = "None",
         handler = function()
-            dismissPet( "imp" )
-            dismissPet( "voidwalker" )
-            dismissPet( "felhunter" )
-            summonPet( "succubus" )
-            dismissPet( "felguard" )
-			dismissPet( "infernal" )
-            soul_shards = max( 0, soul_shards - 1 )
-        end
+            --"/cata/spell=713/summon-incubus"
+        end,
+
     },
 
 
-    -- Summons a Succubus under the command of the Warlock.
-    summon_succubus = {
+summon_succubus = {
         id = 712,
-        cast = function() return 10 - ( 2 * talent.master_summoner.rank ) - ( buff.fel_domination.up and 5.5 or 0 ) end,
+        cast = 6,
         cooldown = 0,
         gcd = "spell",
 
-        spend = function() return 0.80 * ( buff.fel_domination.up and 0.5 or 1 ) * ( 1 - 0.2 * talent.master_summoner.rank ) end,
+        spend = 0.8, 
         spendType = "mana",
 
-        startsCombat = false,
+        startsCombat = true,
         texture = 136220,
-        essential = true,
 
+        --fix:
+        stance = "None",
         handler = function()
-            dismissPet( "imp" )
-            dismissPet( "voidwalker" )
-            dismissPet( "felhunter" )
-            summonPet( "succubus" )
-            dismissPet( "felguard" )
-			dismissPet( "infernal" )
-            soul_shards = max( 0, soul_shards - 1 )
-        end
+            --"/cata/spell=712/summon-succubus"
+        end,
+
     },
 
 
-    -- Summons a Voidwalker under the command of the Warlock.
-    summon_voidwalker = {
+summon_voidwalker = {
         id = 697,
-        cast = function() return 10 - ( 2 * talent.master_summoner.rank ) - ( buff.fel_domination.up and 5.5 or 0 ) end,
+        cast = 6,
         cooldown = 0,
         gcd = "spell",
 
-        spend = function() return 0.80 * ( buff.fel_domination.up and 0.5 or 1 ) * ( 1 - 0.2 * talent.master_summoner.rank ) end,
+        spend = 0.8, 
         spendType = "mana",
 
-        startsCombat = false,
+        startsCombat = true,
         texture = 136221,
-        essential = true,
 
-        usable = function() return soul_shards > 0, "requires a soul_shard" end,
-
+        --fix:
+        stance = "None",
         handler = function()
-            dismissPet( "imp" )
-            summonPet( "voidwalker" )
-            dismissPet( "felhunter" )
-            dismissPet( "succubus" )
-            dismissPet( "felguard" )
-			dismissPet( "infernal" )
-            soul_shards = max( 0, soul_shards - 1 )
-        end
+            --"/cata/spell=697/summon-voidwalker"
+        end,
+
     },
 
 
-    -- Allows the target to breathe underwater for 10 min.
-    unending_breath = {
+unending_breath = {
         id = 5697,
         cast = 0,
         cooldown = 0,
         gcd = "spell",
 
-        spend = 0.02,
+        spend = 0.02, 
         spendType = "mana",
 
-        startsCombat = false,
+        startsCombat = true,
         texture = 136148,
 
-        handler = function ()
-            applyBuff( "unending_breath" )
-        end
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=5697/unending-breath"
+        end,
+
     },
 
 
-    -- Shadow energy slowly destroys the target, causing 550 damage over 15 sec.  In addition, if the ` Affliction is dispelled it will cause 990 damage to the dispeller and silence them for 5 sec. Only one Unstable Affliction or Immolate per Warlock can be active on any one target.
-    unstable_affliction = {
+unstable_affliction = {
         id = 47843,
         cast = function()
             return ( glyph.unstable_affliction.enabled and 1.3 or 1.5 ) * haste
@@ -2298,10 +2150,494 @@ spec:RegisterAbilities( {
         end,
 
         copy = { 30108, 30404, 30405, 47841 }
+	},
+
+bane_of_doom = {
+        id = 603,
+        cast = 0,
+        cooldown = 0,
+        gcd = "spell",
+
+        spend = 0.15, 
+        spendType = "mana",
+
+        startsCombat = true,
+        texture = 136122,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=603/bane-of-doom"
+        end,
+
     },
-} )
 
 
+bane_of_agony = {
+        id = 980,
+        cast = 0,
+        cooldown = 0,
+        gcd = "spell",
+
+        spend = 0.1, 
+        spendType = "mana",
+
+        startsCombat = true,
+        texture = 136139,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=980/bane-of-agony"
+        end,
+
+    },
+
+
+dark_intent = {
+        id = 80398,
+        cast = 0,
+        cooldown = 0,
+        gcd = "spell",
+
+        spend = 0.06, 
+        spendType = "mana",
+
+        startsCombat = true,
+        texture = 463285,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=85767/dark-intent"
+        end,
+
+    },
+
+
+shadow_mastery = {
+        id = 87339,
+        cast = 0,
+        cooldown = 0,
+        gcd = "off",
+
+        
+
+        startsCombat = true,
+        texture = 136215,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=87339/shadow-mastery"
+        end,
+
+    },
+
+
+soul_swap_exhale = {
+        id = 86213,
+        cast = 0,
+        cooldown = 0,
+        gcd = "totem",
+
+        spend = 0.06, 
+        spendType = "mana",
+
+        startsCombat = true,
+        texture = 132291,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=86213/soul-swap-exhale"
+        end,
+
+    },
+
+
+amplify_curse = {
+        id = 84741,
+        cast = 0,
+        cooldown = 0,
+        gcd = "off",
+
+        
+
+        startsCombat = true,
+        texture = 136137,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=87389/corruption"
+        end,
+
+    },
+
+
+soulburn = {
+        id = 74434,
+        cast = 0,
+        cooldown = 45,
+        gcd = "off",
+
+        spend = 1, 
+        spendType = "shards",
+
+        startsCombat = true,
+        texture = 463286,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=358742/drain-life"
+        end,
+
+    },
+
+
+demon_soul = {
+        id = 77801,
+        cast = 0,
+        cooldown = 2,
+        gcd = "off",
+
+        spend = 0.15, 
+        spendType = "mana",
+
+        startsCombat = true,
+        texture = 463284,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=77801/demon-soul"
+        end,
+
+    },
+
+
+summon_doomguard = {
+        id = 18540,
+        cast = 0,
+        cooldown = 10,
+        gcd = "spell",
+
+        spend = 0.8, 
+        spendType = "mana",
+
+        startsCombat = true,
+        texture = 236418,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=60478/summon-doomguard"
+        end,
+
+    },
+
+
+demon_leap = {
+        id = 54785,
+        cast = 0,
+        cooldown = 45,
+        gcd = "spell",
+
+        
+
+        startsCombat = true,
+        texture = 132368,
+
+        --fix:
+        stance = "Metamorphosis",
+        handler = function()
+            --"/cata/spell=54786/demon-leap"
+        end,
+
+    },
+	
+demon_leap = {
+        id = 54786,
+        cast = 0,
+        cooldown = 45,
+        gcd = "spell",
+
+        
+
+        startsCombat = true,
+        texture = 132368,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=54786/demon-leap"
+        end,
+
+    },
+
+demonic_knowledge = {
+        id = 84740,
+        cast = 0,
+        cooldown = 0,
+        gcd = "off",
+
+        
+
+        startsCombat = true,
+        texture = 425957,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=84740/demonic-knowledge"
+        end,
+
+    },
+
+
+dreadsteed = {
+        id = 23161,
+        cast = 1.5,
+        cooldown = 0,
+        gcd = "off",
+
+        
+
+        startsCombat = true,
+        texture = 132238,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=23161/dreadsteed"
+        end,
+
+    },
+
+
+soul_harvest = {
+        id = 79268,
+        cast = Channeled,
+        cooldown = 30,
+        gcd = "spell",
+
+        
+
+        startsCombat = true,
+        texture = 236223,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=79268/soul-harvest"
+        end,
+
+    },
+
+
+summon_infernal = {
+        id = 1122,
+        cast = 1.5,
+        cooldown = 10,
+        gcd = "spell",
+
+        spend = 0.8, 
+        spendType = "mana",
+
+        startsCombat = true,
+        texture = 136219,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=22703/infernal-awakening"
+        end,
+
+    },
+
+
+felsteed = {
+        id = 5784,
+        cast = 1.5,
+        cooldown = 0,
+        gcd = "off",
+
+        
+
+        startsCombat = true,
+        texture = 136103,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=5784/felsteed"
+        end,
+
+    },
+
+
+immolation = {
+        id = 50590,
+        cast = 0,
+        cooldown = 0,
+        gcd = "off",
+
+        
+
+        startsCombat = true,
+        texture = 135818,
+
+        --fix:
+        stance = "Metamorphosis",
+        handler = function()
+            --"/cata/spell=50590/immolation"
+        end,
+
+    },
+
+
+demonic_rebirth = {
+        id = 88448,
+        cast = 0,
+        cooldown = 3,
+        gcd = "off",
+
+        
+
+        startsCombat = true,
+        texture = 136082,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=79623/summon-imp"
+        end,
+
+    },
+
+
+infernal_awakening = {
+        id = 22703,
+        cast = 0,
+        cooldown = 0,
+        gcd = "off",
+
+        
+
+        startsCombat = true,
+        texture = 135860,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=22703/infernal-awakening"
+        end,
+
+    },
+
+
+suppression = {
+        id = 87330,
+        cast = 0,
+        cooldown = 0,
+        gcd = "off",
+
+        
+
+        startsCombat = true,
+        texture = 136154,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=87330/suppression"
+        end,
+
+    },
+
+
+fel_flame = {
+        id = 77799,
+        cast = 0,
+        cooldown = 0,
+        gcd = "spell",
+
+        spend = 0.06, 
+        spendType = "mana",
+
+        startsCombat = true,
+        texture = 135795,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=77799/fel-flame"
+        end,
+
+    },
+
+
+cataclysm = {
+        id = 84739,
+        cast = 0,
+        cooldown = 0,
+        gcd = "off",
+
+        
+
+        startsCombat = true,
+        texture = 135821,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=84739/cataclysm"
+        end,
+
+    },
+
+
+nether_ward = {
+        id = 91711,
+        cast = 0,
+        cooldown = 30,
+        gcd = "spell",
+
+        spend = 0.12, 
+        spendType = "mana",
+
+        startsCombat = true,
+        texture = 135796,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=91711/nether-ward"
+        end,
+
+    },
+
+
+demonic_immolate = {
+        id = 75445,
+        cast = 0,
+        cooldown = 0,
+        gcd = "off",
+
+        
+
+        startsCombat = true,
+        texture = 135817,
+
+        --fix:
+        stance = "None",
+        handler = function()
+            --"/cata/spell=54090/area-despawn"
+        end,
+
+    },
 local curses = {}
 
 spec:RegisterSetting( "solo_curse", "curse_of_agony", {


### PR DESCRIPTION
Talents Updated for Cataclysm Classic

Updated Glyph List: The glyph list has been updated from the Wrath of the Lich King version to the Cataclysm Classic version.

Alphabetical Sorting: The new glyph list is now sorted alphabetically for better readability and maintenance.

Removed Glyphs: curse_of_agony
curse_of_exhausion
quick_decay
searing_pain
siphon_life
souls
succubus

Added Glyphs: lash_of_pain

Changes: chaos_bolt ID changed from [63304] to [45781]. conflagrate ID changed from [56235] to [42454].
corruption ID changed from [56218] to [42455].
death_coil ID changed from [56232] to [42457].
demonic_circle ID changed from [63309] to [45782]


Updated Abilities:
The following abilities were updated with new information from data.lua: Updated properties:
banish
challenging_howl
chaos_bolt
conflagrate
corruption

New Abilities:
The following abilities were added to Warlock.LUA.

bane_of_doom
curse_of_the_elements
bane_of_agony
seed_of_corruption
dark_intent

Added missing commas after each ability definition block from lines 761 to 2650 to prevent potential syntax errors.