### PR TITLE
BM TWW Updates + Todo items

### DIFF
--- a/Dragonflight/HunterBeastMastery.lua
+++ b/Dragonflight/HunterBeastMastery.lua
@@ -829,16 +829,6 @@ spec:RegisterAuras( {
         duration = 8,
         max_stack = 4,
     },
-
-    -- Suffering $w1 Fire damage every $t1 sec.
-    -- https://wowhead.com/beta/spell=270332
-    pheromone_bomb = {
-        id = 270332,
-        duration = 6,
-        tick_time = 1,
-        type = "Ranged",
-        max_stack = 1
-    },
     -- Pinned in place.
     -- https://wowhead.com/beta/spell=50245
     pin = {
@@ -946,15 +936,6 @@ spec:RegisterAuras( {
         duration = 20,
         max_stack = 1
     },
-    -- Suffering $w1 Fire damage every $t1 sec.  $?s259387[Mongoose Bite][Raptor Strike] and Butchery apply a stack of Internal Bleeding.
-    -- https://wowhead.com/beta/spell=270339
-    shrapnel_bomb = {
-        id = 270339,
-        duration = 6,
-        tick_time = 1,
-        type = "Ranged",
-        max_stack = 1
-    },
     -- Damage taken reduced by $s1%.
     -- https://wowhead.com/beta/spell=263938
     silverback = {
@@ -1051,13 +1032,6 @@ spec:RegisterAuras( {
     },
     -- Suffering $w1 Fire damage every $t1 sec.
     -- https://wowhead.com/beta/spell=271049
-    volatile_bomb = {
-        id = 271049,
-        duration = 6,
-        tick_time = 1,
-        type = "Magic",
-        max_stack = 1
-    },
     -- Talent: Silenced.
     -- https://wowhead.com/beta/spell=355596
     wailing_arrow = {
@@ -1099,13 +1073,6 @@ spec:RegisterAuras( {
     },
     -- Suffering $w1 Fire damage every $t1 sec.
     -- https://wowhead.com/beta/spell=269747
-    wildfire_bomb = {
-        id = 269747,
-        duration = 6,
-        tick_time = 1,
-        type = "Magic",
-        max_stack = 1
-    },
     -- Movement speed reduced by $s1%.
     -- https://wowhead.com/beta/spell=195645
     wing_clip = {
@@ -1525,7 +1492,6 @@ spec:RegisterAbilities( {
             applyBuff( "camouflage" )
         end,
     },
-
     -- Talent: A quick shot causing ${$s2*$<mult>} Physical damage.    Reduces the cooldown of Kill Command by $?s378244[${$s3+($378244s1/-1000)}][$s3] sec.
     cobra_shot = {
         id = 193455,

--- a/TheWarWithin/Generated/HunterBeastMastery.lua
+++ b/TheWarWithin/Generated/HunterBeastMastery.lua
@@ -371,9 +371,9 @@ spec:RegisterAuras( {
     },
     -- Critical damage dealt increased by $s1%.
     howl_of_the_pack = {
-        id = 462515,
+        id = 445707,
         duration = 8.0,
-        max_stack = 1,
+        max_stack = 3,
     },
     -- Can always be seen and tracked by the Hunter.; Damage taken increased by $428402s4% while above $s3% health.
     hunters_mark = {
@@ -392,7 +392,7 @@ spec:RegisterAuras( {
     huntmasters_call = {
         id = 459731,
         duration = 3600,
-        max_stack = 1,
+        max_stack = 3,
     },
     -- Redirecting spells to the Hunter's pet.
     interlope = {
@@ -552,9 +552,9 @@ spec:RegisterAuras( {
     },
     -- Critical strike chance increased by $s1%.
     thrill_of_the_hunt = {
-        id = 257946,
+        id = 257944,
         duration = 8.0,
-        max_stack = 1,
+        max_stack = 3,
 
         -- Affected by:
         -- savagery[424557] #1: { 'type': APPLY_AURA, 'subtype': ADD_FLAT_MODIFIER, 'points': 2000.0, 'target': TARGET_UNIT_CASTER, 'modifies': BUFF_DURATION, }


### PR DESCRIPTION
Done
- howl of the pack stacks to 3, and wrong spellid
- huntmasters call requires 3 casts
- thrill of the hunt, wrong ID, stacks to 3 with a single talent point

To do
- redo a murder of crows, wrong IDs
- lone survivor does duration AND cd
 - Needs an entry? How is it referenced by survival of the fittest
- venoms bite missing, every 5th barb does a serpent sting
- bestial wrath also affected by piercing fangs crit damage
- black arrow effect: 10% on damage to generate barbed shot
- kill command is affected by killer instinct
- kill shot has survival version in the file too?
