### PR TITLE
Warrior 11.0.2 changes

### DIFF
--- a/TheWarWithin/WarriorArms.lua
+++ b/TheWarWithin/WarriorArms.lua
@@ -264,6 +264,11 @@ spec:RegisterAuras( {
         duration = 3,
         max_stack = 1
     },
+    brutal_finish = {
+        id = 446918,
+        duration = 10,
+        max_stack = 1
+    },
     champions_might = {
         id = 386286,
         duration = 8,
@@ -286,6 +291,11 @@ spec:RegisterAuras( {
         id = 334783,
         duration = 30,
         max_stack = 20
+    },
+    colossal_might = {
+        id = 440989,
+        duration = 24,
+        max_stack = function() return 5 + ( talent.dominance_of_the_colossus.enabled and 5 or 10 ) end
     },
     colossus_smash = {
         id = 208086,
@@ -389,6 +399,11 @@ spec:RegisterAuras( {
         id = 383290,
         duration = 12,
         max_stack = 15
+    },
+    opportunist = {
+        id = 456120,
+        duration = 8,
+        max_stack = 1
     },
     overpower = {
         id = 7384,
@@ -838,6 +853,12 @@ spec:RegisterAbilities( {
             if talent.merciless_bonegrinder.enabled then
                 state:QueueAuraExpiration( "bladestorm_merciless_bonegrinder", ExpireBladestorm, buff.bladestorm.expires )
             end
+            -- the final tick brutal finish gets applied before the final Bladestorm tick goes off.
+            -- If using imminent demise, it will affect the final MS instead of the one that
+            -- comes after the bladestorm, which means we dont need to track it.
+            if talent.brutal_finish.enabled and not talent.imminent_demise.enabled then
+                applyBuff( "brutal_finish" )
+            end
         end,
 
         copy = { 227847, 389774 }
@@ -884,6 +905,11 @@ spec:RegisterAbilities( {
             applyDebuff( "target" , "deep_wounds" )
             active_dot.deep_wounds = max( active_dot.deep_wounds, active_enemies )
             removeBuff( "overpower" )
+
+            if talent.demolish.enabled and active_enemies > 2 then
+                if talent.dominance_of_the_colossus.enabled and buff.colossal_might.stack == 10 then reduceCooldown( "demolish", 2 ) end
+                if talent.colossal_might.enabled then addStack( "colossal_might" ) end
+            end
         end,
     },
 
@@ -1037,6 +1063,8 @@ spec:RegisterAbilities( {
             if talent.executioners_precision.enabled then applyDebuff( "target", "executioners_precision", nil, min( 2, debuff.executioners_precision.stack + 1 ) ) end
             if legendary.exploiter.enabled then applyDebuff( "target", "exploiter", nil, min( 2, debuff.exploiter.stack + 1 ) ) end
             if talent.juggernaut.enabled then addStack( "juggernaut" ) end
+            if talent.dominance_of_the_colossus.enabled and buff.colossal_might.stack == 10 then reduceCooldown( "demolish", 2 ) end
+            if talent.colossal_might.enabled then addStack( "colossal_might" ) end
         end,
 
         auras = {
@@ -1227,6 +1255,8 @@ spec:RegisterAbilities( {
             if target.health.pct < 35 and talent.bloodletting.enabled then
                 applyDebuff ( "target", "rend" )
             end
+            if talent.dominance_of_the_colossus.enabled and buff.colossal_might.stack == 10 then reduceCooldown( "demolish", 2 ) end
+            if talent.colossal_might.enabled then addStack( "colossal_might" ) end
         end,
     },
 
@@ -1247,6 +1277,7 @@ spec:RegisterAbilities( {
         texture = 132223,
 
         handler = function ()
+            removeBuff( "opportunist" )
             if talent.martial_prowess.enabled then applyBuff( "overpower" ) end
         end,
     },

--- a/TheWarWithin/WarriorArms.lua
+++ b/TheWarWithin/WarriorArms.lua
@@ -1,5 +1,7 @@
 -- WarriorArms.lua
--- November 2022
+-- August 2024
+-- 11.0.2
+
 
 if UnitClassBase( "player" ) ~= "WARRIOR" then return end
 
@@ -98,7 +100,7 @@ spec:RegisterTalents( {
     leeching_strikes                = { 90371, 382258, 1 }, -- Leech increased by 3%.
     menace                          = { 90383, 275338, 1 }, -- Intimidating Shout will knock back all nearby enemies except your primary target, and cause them all to cower in fear for 15 sec instead of fleeing.
     overwhelming_rage               = { 90378, 382767, 2 }, -- Maximum Rage increased by 15.
-    pain_and_gain                   = { 90353, 382549, 1 }, -- When you take any damage, heal for 3.50% of your maximum health. This can only occur once every 10 sec.
+    pain_and_gain                   = { 90353, 382549, 1 }, -- When you take any damage, heal for 2% of your maximum health. This can only occur once every 10 sec.
     piercing_challenge              = { 90379, 382948, 1 }, -- Champion's Spear's damage increased by 50% and its Rage generation is increased by 100%.
     piercing_howl                   = { 90348, 12323 , 1 }, -- Snares all enemies within 12 yards, reducing their movement speed by 70% for 8 sec.
     rallying_cry                    = { 90331, 97462 , 1 }, -- Lets loose a rallying cry, granting all party or raid members within 40 yards 10% temporary and maximum health for 10 sec.
@@ -494,7 +496,7 @@ spec:RegisterAuras( {
     test_of_might = {
         id = 385013,
         duration = 12,
-        max_stack = 1, -- TODO: Possibly implement fake stacks to track the Strength % increase gained from the buff
+        max_stack = 1,
     },
     thunder_clap = {
         id = 6343,
@@ -836,7 +838,6 @@ spec:RegisterAbilities( {
             if talent.merciless_bonegrinder.enabled then
                 state:QueueAuraExpiration( "bladestorm_merciless_bonegrinder", ExpireBladestorm, buff.bladestorm.expires )
             end
-            --TODO: Implement Unhinged - Every other time Bladestorm or Ravager deal damage, you automatically cast a Mortal Strike at your target or random nearby enemy.
         end,
 
         copy = { 227847, 389774 }
@@ -1541,7 +1542,6 @@ spec:RegisterAbilities( {
         hasteCD = true,
         gcd = "spell",
 
-        --TODO: Verify Rage Cost on 11.0
         spend = 20,
         spendType = "rage",
 

--- a/TheWarWithin/WarriorFury.lua
+++ b/TheWarWithin/WarriorFury.lua
@@ -1,5 +1,7 @@
 -- WarriorFury.lua
--- November 2022
+-- August 2024
+-- 11.0.2
+
 
 if UnitClassBase( "player" ) ~= "WARRIOR" then return end
 
@@ -135,7 +137,7 @@ spec:RegisterTalents( {
     leeching_strikes             = { 90371, 382258, 1 }, -- Leech increased by 3%.
     menace                       = { 90383, 275338, 1 }, -- Intimidating Shout will knock back all nearby enemies except your primary target, and cause them all to cower in fear for 15 sec instead of fleeing.
     overwhelming_rage            = { 90378, 382767, 2 }, -- Maximum Rage increased by 15.
-    pain_and_gain                = { 90353, 382549, 1 }, -- When you take any damage, heal for 3.50% of your maximum health. This can only occur once every 10 sec.
+    pain_and_gain                = { 90353, 382549, 1 }, -- When you take any damage, heal for 2% of your maximum health. This can only occur once every 10 sec.
     piercing_challenge           = { 90379, 382948, 1 }, -- Champion's Spear's damage increased by 50% and its Rage generation is increased by 100%.
     piercing_howl                = { 90348, 12323 , 1 }, -- Snares all enemies within 12 yards, reducing their movement speed by 70% for 8 sec.
     rallying_cry                 = { 90331, 97462 , 1 }, -- Lets loose a rallying cry, granting all party or raid members within 40 yards 10% temporary and maximum health for 10 sec.
@@ -180,7 +182,7 @@ spec:RegisterTalents( {
     improved_execute             = { 90430, 316402, 1 }, -- Execute no longer costs Rage and now generates 20 Rage.
     improved_raging_blow         = { 90390, 383854, 1 }, -- Raging Blow has 2 charges and has a 20% chance to instantly reset its own cooldown.
     improved_whirlwind           = { 90427, 12950 , 1 }, -- Whirlwind causes your next 4 single-target attacks to strike up to 4 additional targets for 55% damage. Whirlwind generates 3 Rage, plus an additional 1 per target hit. Maximum 8 Rage.
-    invigorating_fury            = { 90393, 383468, 1 }, -- Enraged Regeneration lasts 3 sec longer and instantly heals for 15% of your maximum health.
+    invigorating_fury            = { 90393, 383468, 1 }, -- Enraged Regeneration lasts 3 sec longer and instantly heals for 10% of your maximum health.
     massacre                     = { 90410, 206315, 1 }, -- Execute is now usable on targets below 35% health, and its cooldown is reduced by 1.5 sec.
     meat_cleaver                 = { 90391, 280392, 1 }, -- Whirlwind deals 25% more damage and now affects your next 4 single-target melee attacks, instead of the next 2 attacks.
     odyns_fury                   = { 90418, 385059, 1 }, -- Unleashes your power, dealing 356,472 Physical damage and an additional 147,436 Physical damage over 4 sec to all enemies within 12 yards. Generates 15 Rage. 
@@ -481,7 +483,7 @@ spec:RegisterAuras( {
         max_stack = 1,
     },
     thunder_blast = {
-        id = 435615, -- TODO: Verify ID
+        id = 435615,
         duration = 15,
         max_stack = 2
     },
@@ -918,7 +920,7 @@ spec:RegisterAbilities( {
         end,
     },
 
-    bladestorm = { --TODO: Figure out how many hits occur within the 6 second (hasted) channel.
+    bladestorm = {
         id = 227847,
         cast = 0,
         cooldown = 90,
@@ -1006,7 +1008,6 @@ spec:RegisterAbilities( {
                 applyBuff( "enrage" )
                 applyDebuff( "target", "hit_by_fresh_meat" )
             end
-            if talent.invigorating_fury.enabled then gain ( health.max * 0.15 , "health" ) end
         
             if legendary.cadence_of_fujieda.enabled then
                 if buff.cadence_of_fujieda.stack < 5 then stat.haste = stat.haste + 0.01 end
@@ -1094,8 +1095,7 @@ spec:RegisterAbilities( {
                 applyBuff( "enrage" )
                 applyDebuff( "target", "hit_by_fresh_meat" )
             end
-            if talent.invigorating_fury.enabled then gain ( health.max * 0.15 , "health" ) end
-        
+
             if legendary.cadence_of_fujieda.enabled then
                 if buff.cadence_of_fujieda.stack < 5 then stat.haste = stat.haste + 0.01 end
                 addStack( "cadence_of_fujieda" )
@@ -1261,13 +1261,13 @@ spec:RegisterAbilities( {
 
         handler = function ()
             applyBuff( "enraged_regeneration" )
-            if ( talent.invigorating_fury.enabled ) then gain( health.max * 0.15 , "health" ) end
+            if ( talent.invigorating_fury.enabled ) then gain( health.max * 0.10 , "health" ) end
         end,
     },
 
 
     execute = {
-        id = function () return talent.massacre.enabled and 280735 or 5308 end, -- TODO: Need to make sure we capture all situations that change ID to 280735.
+        id = function () return talent.massacre.enabled and 280735 or 5308 end,
 	    known = 5308,
         noOverride = 317485,
         cast = 0,
@@ -1784,7 +1784,6 @@ spec:RegisterAbilities( {
         hasteCD = true,
         bind = "thunder_blast",
 
-        --TODO: Verify Rage Cost on 11.0
         spend = 20,
         spendType = "rage",
 
@@ -1852,7 +1851,6 @@ spec:RegisterAbilities( {
 
         startsCombat = true,
 
-        -- TODO: Find a way to calculate the extra 1 rage per extra target hit?
         spend = function() return talent.improved_whirlwind.enabled and ( -3 - min( 5, active_enemies ) ) or 0 end,
         spendType = "rage",
 

--- a/TheWarWithin/WarriorFury.lua
+++ b/TheWarWithin/WarriorFury.lua
@@ -315,6 +315,11 @@ spec:RegisterAuras( {
         duration = 20,
         max_stack = 1
     },
+    brutal_finish = {
+        id = 446918,
+        duration = 10,
+        max_stack = 1
+    },
     burst_of_power = {
         id = 437121,
         duration = 15,
@@ -408,6 +413,11 @@ spec:RegisterAuras( {
         tick_time = 1,
         max_stack = 1,
         copy = { "odyns_fury_torment", "odyns_fury_torment_mh" }
+    },
+    opportunist = {
+        id = 456120,
+        duration = 8,
+        max_stack = 1,
     },
     piercing_howl = {
         id = 12323,
@@ -944,6 +954,8 @@ spec:RegisterAbilities( {
             if talent.merciless_bonegrinder.enabled then
                 state:QueueAuraExpiration( "bladestorm_merciless_bonegrinder", ExpireBladestorm, buff.bladestorm.expires )
             end
+
+            if talent.brutal_finish.enabled then applyBuff( "brutal_finish" ) end
         end,
 
         copy = { 227847, 389774 }
@@ -1187,6 +1199,7 @@ spec:RegisterAbilities( {
 
         handler = function ()
             removeStack( "whirlwind" )
+            removeBuff( "opportunist" )
             removeBuff( "reckless_abandon" )
             spendCharges( "raging_blow", 1 )
             if buff.will_of_the_berserker.up then buff.will_of_the_berserker.expires = query_time + 12 end
@@ -1561,6 +1574,7 @@ spec:RegisterAbilities( {
         handler = function ()
             removeStack( "whirlwind" )
             spendCharges( "crushing_blow", 1 )
+            removeBuff( "opportunist" )
             if buff.will_of_the_berserker.up then buff.will_of_the_berserker.expires = query_time + 12 end
             if talent.slaughtering_strikes.enabled then addStack( "slaughtering_strikes_raging_blow" ) end
         end,
@@ -1611,6 +1625,7 @@ spec:RegisterAbilities( {
                 applyBuff( "reckless_abandon_crushing_blow" )
             end
             if set_bonus.tier30_4pc > 0 then addStack( "merciless_assault" ) end
+            removeBuff( "brutal_finish" )
         end,
     },
 

--- a/TheWarWithin/WarriorProtection.lua
+++ b/TheWarWithin/WarriorProtection.lua
@@ -293,7 +293,7 @@ spec:RegisterAuras( {
     colossal_might = {
         id = 440989,
         duration = 24,
-        max_stack = function() return 5 + ( talent.dominance_of_the_colossus.enabled and 5 or 0 ) end
+        max_stack = function() return 5 + ( talent.dominance_of_the_colossus.enabled and 5 or 10 ) end
     },
     concussive_blows = {
         id = 383116,
@@ -1088,7 +1088,8 @@ spec:RegisterAbilities( {
             end
             if talent.juggernaut.enabled then addStack( "juggernaut" ) end
 
-            if talent.colossal_might then addStack( "colossal_might" ) end
+            if talent.dominance_of_the_colossus.enabled and buff.colossal_might.stack == 10 then reduceCooldown( "demolish", 2 ) end
+            if talent.colossal_might.enabled then addStack( "colossal_might" ) end
         end,
     },
 
@@ -1461,7 +1462,7 @@ spec:RegisterAbilities( {
 
             if talent.demolish.enabled and active_enemies > 2 then
                 if talent.dominance_of_the_colossus.enabled and buff.colossal_might.stack == 10 then reduceCooldown( "demolish", 2 ) end
-                addStack( "colossal_might" )
+                if talent.colossal_might.enabled then addStack( "colossal_might" ) end
              end
         end,
     },
@@ -1613,6 +1614,9 @@ spec:RegisterAbilities( {
                 removeDebuff( "target", "thunderous_roar" )
                 if set_bonus.tier31_4pc > 0 then applyBuff( "fervid_opposition" ) end
             end
+
+            if talent.dominance_of_the_colossus.enabled and buff.colossal_might.stack == 10 then reduceCooldown( "demolish", 2 ) end
+            if talent.colossal_might then addStack( "colossal_might" ) end
         end,
     },
 

--- a/TheWarWithin/WarriorProtection.lua
+++ b/TheWarWithin/WarriorProtection.lua
@@ -1,6 +1,6 @@
 -- WarriorProtection.lua
--- July 2024
--- TODO: Model Ravager better for rage generation
+-- August 2024
+-- 11.0.2
 
 if UnitClassBase( "player" ) ~= "WARRIOR" then return end
 
@@ -52,6 +52,21 @@ spec:RegisterResource( Enum.PowerType.Rage, {
         interval = 1,
 
         value = 4,
+    },
+
+    ravager = {
+        aura = "ravager",
+
+        last = function ()
+            local app = state.buff.ravager.applied
+            local t = state.query_time
+
+            return app + floor( ( t - app ) / state.haste ) * state.haste
+        end,
+
+        interval = function () return state.haste end,
+
+        value = function () return state.talent.storm_of_steel.enabled and 20 or 10 end,
     },
 } )
 
@@ -134,7 +149,7 @@ spec:RegisterTalents( {
     fueled_by_violence              = { 90451, 383103, 1 }, -- You are healed for 110% of the damage dealt by Deep Wounds.
     heavy_repercussions             = { 90319, 203177, 1 }, -- Shield Slam generates 2 more Rage and extends the duration of Shield Block by 1.0 sec.
     ignore_pain                     = { 90295, 190456, 1 }, -- Fight through the pain, ignoring 50% of damage taken, up to 1.8 million total damage prevented.
-    impenetrable_wall               = { 90310, 384072, 1 }, -- Shield Slam generates an additional 3 Rage and reduces the remaining cooldown of Shield Wall by 5 sec.
+    impenetrable_wall               = { 90310, 384072, 1 }, -- Shield Slam generates an additional 4 Rage and reduces the remaining cooldown of Shield Wall by 6 sec.
     indomitable                     = { 90434, 202095, 1 }, -- Your maximum health is increased by 6%, and every 20 Rage you spend heals you for 1% of your maximum health.
     instigate                       = { 90301, 394311, 1 }, -- Devastate deals 20% increased damage and generates 2 Rage. Devastator deals 10% increased damage and generates 1 Rage.
     into_the_fray                   = { 90319, 202603, 1 }, -- You gain 2% Haste for each enemy or ally within 10 yards, up to 8% Haste.
@@ -1585,7 +1600,7 @@ spec:RegisterAbilities( {
             if talent.punish.enabled then applyDebuff( "target", "punish" ) end
 
             if ( legendary.the_wall.enabled or talent.impenetrable_wall.enabled ) and cooldown.shield_wall.remains > 0 then
-                reduceCooldown( "shield_wall", 5 )
+                reduceCooldown( "shield_wall", 6 )
             end
 
             if set_bonus.tier30_2pc > 0 then


### PR DESCRIPTION
In prep for 11.0.2 on August 13th.

[https://www.wowhead.com/news/war-within-launch-patch-11-0-2-patch-notes-345734](https://www.wowhead.com/news/war-within-launch-patch-11-0-2-patch-notes-345734)

Patch notes have a fair bit of stuff already implemented in the LUA, but this PR covers the missed/rest to sync it back up.

This PR wouldn't change rotations or gameplay massively... could probably take it early if you want to; with no huge impact to warrior.