### PR TITLE
Various Changes from HPal Testing

### DIFF
--- a/TheWarWithin/PaladinHoly.lua
+++ b/TheWarWithin/PaladinHoly.lua
@@ -329,6 +329,11 @@ spec:RegisterAuras( {
             c.caster = "unknown"
         end
     },
+    consecration_strength_of_conviction = {
+        id = 188370,
+        duration = 12,
+        max_stack = 1,
+    },
     contemplation = {
         id = 121183,
         duration = 8,

--- a/TheWarWithin/PaladinHoly.lua
+++ b/TheWarWithin/PaladinHoly.lua
@@ -178,6 +178,11 @@ spec:RegisterAuras( {
     afterimage = {
         id = 385414,
     },
+    afterimage_stacks = {
+        id = 400745,
+        duration = 3600,
+        max_stack = 39,
+    },
     aura_mastery = {
         id = 31821,
         duration = 8,
@@ -467,7 +472,7 @@ spec:RegisterAuras( {
     rising_sunlight = {
         id = 414204,
         duration = 30,
-        max_stack = 2,
+        max_stack = 4,
     },
     rule_of_law = {
         id = 214202,
@@ -853,7 +858,7 @@ spec:RegisterAbilities( {
     blessing_of_sacrifice = {
         id = 6940,
         cast = 0,
-        cooldown = function() return talent.sacrifice_of_the_just.enabled and 45 or 60 end,
+        cooldown = function() return talent.sacrifice_of_the_just.enabled and 105 or 120 end,
         gcd = "spell",
 
         spend = 0.07,
@@ -1490,6 +1495,7 @@ spec:RegisterAbilities( {
 
         handler = function ()
             spend( 0.18 * mana.max, "mana" )
+            if buff.divine_purpose.down and buff.shining_righteousness_ready.down then addStack( "afterimage_stacks", nil, 3 ) end
             removeBuff( "divine_purpose" )
             removeBuff( "shining_righteousness_ready" )
             if talent.maraads_dying_breath.enabled then applyBuff( "maraads_dying_breath" ) end
@@ -1585,6 +1591,7 @@ spec:RegisterAbilities( {
         equipped = "shield",
 
         handler = function ()
+            if buff.divine_purpose.down and buff.shining_righteousness_ready.down then addStack( "afterimage_stacks", nil, 3 ) end
             removeBuff( "divine_purpose" )
             reduceCooldown( "crusader_strike", 1.5 )
 
@@ -1673,6 +1680,8 @@ spec:RegisterAbilities( {
         texture = 133192,
 
         handler = function ()
+            if buff.afterimage_stacks.stack >= 20 then removeStack( "afterimage_stacks", 20 ) end
+            if buff.divine_purpose.down and buff.shining_righteousness_ready.down then addStack( "afterimage_stacks", nil, 3 ) end
             removeBuff( "divine_purpose" )
             removeBuff( "shining_righteousness_ready" )
             removeBuff( "empyrean_legacy" )


### PR DESCRIPTION
- **Afterimage**: added stack tracking and usage for Afterimage, which is under a separate spell ID 400745.  Spending holy power adds stacks, casting Word of Glory can remove them.  Tested stacking and it caps at 39, and using WoG only removes 20 stacks.  The WoG that triggers spending will also add stacks if HP was spent.  If HP wasn't spent due to Divine Purpose or Shining Righteousness, stacks are not added.
- **Blessing of Sacrifice**: cooldown was increased in 11.0.
- **Consecration**: Strength of Conviction talent gives a buff (188370) which you can lose by walking out of it, so buff.consecration.up won't detect it using the other code handling that.  I added this buff to detect only the you're-standing-in-it-now part as that might want to trigger an early recast for folks.  I confirmed that the spell ID is the same whether you have 1 or 2 points in the talent.
- **Rising Sunlight**: this can stack to 4, so if you use Divine Toll *and Wings (in either order), you can have 4 stacks up at once.