### PR TITLE
Update Warlock.lua

### DIFF
--- a/Cataclysm/Warlock.lua
+++ b/Cataclysm/Warlock.lua
@@ -958,9 +958,10 @@ spec:RegisterAbilities( {
 
         spend = function() return mod_cataclysm( 0.07 ) end,
         spendType = "mana",
-
-        spend = 1,
-        spendType = "soul_shards",
+		
+		-- fix for issue #3478
+        --spend = 1,
+        --spendType = "soul_shards",
 
         talent = "chaos_bolt",
         startsCombat = true,
@@ -1877,9 +1878,10 @@ spec:RegisterAbilities( {
 
         spend = function() return mod_cataclysm( 0.2 ) end,
         spendType = "mana",
-
-        spend = 1,
-        spendType = "soul_shards",
+		
+		-- fix for issue #3478
+        --spend = 1,
+        --spendType = "soul_shards",
 
         talent = "shadowburn",
         startsCombat = true,


### PR DESCRIPTION
remove soul shard requirement for chaos bolt and shadowburn (issue #3478)