### PR TITLE
Register copy of Bladestorm with Unrelenting Onslaught hero talent

### DIFF
--- a/TheWarWithin/WarriorArms.lua
+++ b/TheWarWithin/WarriorArms.lua
@@ -861,7 +861,7 @@ spec:RegisterAbilities( {
             end
         end,
 
-        copy = { 227847, 389774 }
+        copy = { 227847, 389774, 446035 }
     },
 
 

--- a/TheWarWithin/WarriorFury.lua
+++ b/TheWarWithin/WarriorFury.lua
@@ -958,7 +958,7 @@ spec:RegisterAbilities( {
             if talent.brutal_finish.enabled then applyBuff( "brutal_finish" ) end
         end,
 
-        copy = { 227847, 389774 }
+        copy = { 227847, 389774, 446035 }
     },
 
 


### PR DESCRIPTION
Unrelenting Onslaught changes Bladestorm spell ID for bot Fury and Arms. Register the changed version as copy (Issue #3534)