### PR TITLE
Ret Pal, Sub Rogue, Destro Lock, DPS DKs, Druid

### DIFF
--- a/TheWarWithin/DeathKnightFrost.lua
+++ b/TheWarWithin/DeathKnightFrost.lua
@@ -1056,7 +1056,6 @@ spec:RegisterAbilities( {
         cooldown = function() return 60 - ( talent.antimagic_barrier.enabled and 15 or 0 ) - ( talent.unyielding_will.enabled and -20 or 0 ) - ( pvptalent.spellwarden.enabled and 10 or 0 ) end,
         gcd = "off",
 
-        talent = "antimagic_shell",
         startsCombat = false,
 
         toggle = function()

--- a/TheWarWithin/DeathKnightUnholy.lua
+++ b/TheWarWithin/DeathKnightUnholy.lua
@@ -1302,7 +1302,6 @@ me:RegisterAbilities( {
         cooldown = function() return 60 - ( talent.antimagic_barrier.enabled and 20 or 0 ) - ( talent.unyielding_will.enabled and -20 or 0 ) - ( pvptalent.spellwarden.enabled and 10 or 0 ) end,
         gcd = "off",
 
-        talent = "antimagic_shell",
         startsCombat = false,
 
         toggle = function()

--- a/TheWarWithin/DruidBalance.lua
+++ b/TheWarWithin/DruidBalance.lua
@@ -2839,7 +2839,7 @@ spec:RegisterAbilities( {
         gcd = "spell",
 
         spend = function ()
-            if not state.spec.balance then return ( talent.starlight.conduit.enabled and 0.003 or 0.006 ) end
+            if not state.spec.balance then return ( talent.starlight_conduit.enabled and 0.003 or 0.006 ) end
             if buff.oneths_clear_vision.up or buff.starweavers_weft.up then return 0 end
             return ( 40 - ( buff.incarnation.up and talent.elunes_guidance.enabled and 8 or 0 ) - ( buff.touch_the_cosmos.up and 5 or 0 ) ) * ( 1 - 0.05 * buff.rattled_stars.stack ) * ( 1 - 0.1 * buff.timeworn_dreambinder.stack )
         end,

--- a/TheWarWithin/PaladinRetribution.lua
+++ b/TheWarWithin/PaladinRetribution.lua
@@ -1744,7 +1744,7 @@ spec:RegisterAbilities( {
         cooldown = 0.0,
         gcd = "spell",
 
-        spend = function() return buff.divine_purpose.up and 0 or 3 end,
+        spend = function() return buff.divine_purpose.up and 0 or 5 end,
         spendType = 'holy_power',
 
         startsCombat = true,

--- a/TheWarWithin/RogueSubtlety.lua
+++ b/TheWarWithin/RogueSubtlety.lua
@@ -1485,7 +1485,22 @@ spec:RegisterOptions( {
     package = "Subtlety",
 } )
 
+spec:RegisterSetting( "priority_rotation", false, {
+    name = "Subtlety Rogue is able to do funnel damage. Head over to |cFFFFD100Toggles|r to learn how to turn the feature on and off. " ..
+    "If funnel is enabled, the default priority will recommend building combo points with |T1375677:0|t Shuriken Storm and spending on single-target finishers in order to do priority damage.\n\n",
+    desc = "",
+    type = "description",
+    fontSize = "medium",
+    width = "full"
+})
 
+--[[
+spec:RegisterStateExpr( "priority_rotation", function ()
+    local prio = settings.priority_rotation
+    if prio == nil then return true end
+    return prio
+end )
+--]]
 
 spec:RegisterSetting( "mfd_points", 3, {
     name = "|T236340:0|t Marked for Death Combo Points",
@@ -1498,18 +1513,6 @@ spec:RegisterSetting( "mfd_points", 3, {
 } )
 
 
-spec:RegisterSetting( "priority_rotation", false, {
-    name = "Use Priority Rotation (Funnel Damage)",
-    desc = "If checked, the default priority will recommend building combo points with |T1375677:0|t Shuriken Storm and spending on single-target finishers.",
-    type = "toggle",
-    width = "full"
-})
-
-spec:RegisterStateExpr( "priority_rotation", function ()
-    local prio = settings.priority_rotation
-    if prio == nil then return true end
-    return prio
-end )
 
 spec:RegisterSetting( "rupture_duration", 12, {
     name = strformat( "%s Duration", Hekili:GetSpellLinkWithTexture( 1943 ) ),

--- a/TheWarWithin/WarlockDestruction.lua
+++ b/TheWarWithin/WarlockDestruction.lua
@@ -1995,23 +1995,24 @@ spec:RegisterSetting( "default_pet", "summon_sayaad", {
             summon_voidwalker = class.abilityList.summon_voidwalker,
         }
     end,
-    width = "full"
+    width = "normal"
 } )
 
 spec:RegisterSetting( "cleave_apl", false, {
-    name = function() return "|T" .. ( GetSpellTexture( 116858 ) ) .. ":0|t Funnel Damage in AOE" end,
-    desc = function()
-        return "If checked, the addon will use its cleave priority to funnel damage into your primary target (via |T" .. ( GetSpellTexture( 116858 ) ) .. ":0|t Chaos Bolt) instead of spending Soul Shards on |T" .. ( GetSpellTexture( 5740 ) ) .. ":0|t Rain of Fire.\n\n" ..
-        "You may wish to change this option for different fights and scenarios, which can be done here, via the minimap button, or with |cFFFFD100/hekili toggle cleave_apl|r."
-    end,
-    type = "toggle",
+    name = "\n\nDestruction Warlock is able to do funnel damage. Head over to |cFFFFD100Toggles|r to learn how to turn the feature on and off. " ..
+        "If funnel is enabled, the default priority will recommend spending with Chaos Bolt in AoE in order to do priority damage.\n\n",
+    desc = "",
+    type = "description",
+    fontSize = "medium",
     width = "full",
 } )
 
+--[[
 spec:RegisterVariable( "cleave_apl", function()
     if settings.cleave_apl ~= nil then return settings.cleave_apl end
     return false
 end )
+--]]
 
 --[[ Retired 2023-02-20.
 spec:RegisterSetting( "fixed_aoe_3_plus", false, {


### PR DESCRIPTION
Retribution Paladin
- Fix Hammer of Light holy power cost

Subtlety Rogue
- UI Clarity around funnel option

Destruction Warlock
- UI Clarity around funnel option
- Make pet selection dropdown not difficult to read

Death Knight
- Antimagic Shell is now baseline, not a talent.
 - Fixed for Frost and Unholy, seemed to already be in place for Blood 

Druid
- Fixed typo related to Starlight Conduit