### PR TITLE
Maybe more possible incremental fixes to #3641

### DIFF
--- a/TheWarWithin/MageArcane.lua
+++ b/TheWarWithin/MageArcane.lua
@@ -471,7 +471,6 @@ spec:RegisterAuras( {
         max_stack = 1
     },
     magis_spark = {
-        id = 450004,
         duration = 12,
         max_stack = 1
     },
@@ -1135,9 +1134,9 @@ spec:RegisterHook( "reset_precast", function ()
     incanters_flow.reset()
 
     if debuff.magis_spark.up then
-        if action.arcane_barrage.lastCast < debuff.magis_spark.applied then applyDebuff( "target", "magis_spark_arcane_barrage", buff.magis_spark.remains ) end
-        if action.arcane_blast.lastCast < debuff.magis_spark.applied then applyDebuff( "target", "magis_spark_arcane_blast", buff.magis_spark.remains ) end
-        if action.arcane_missiles.lastCast < debuff.magis_spark.applied then applyDebuff( "target", "magis_spark_arcane_missiles", buff.magis_spark.remains ) end
+        if action.arcane_barrage.lastCast < debuff.magis_spark.applied then applyDebuff( "target", "magis_spark_arcane_barrage", debuff.magis_spark.remains ) end
+        if action.arcane_blast.lastCast < debuff.magis_spark.applied then applyDebuff( "target", "magis_spark_arcane_blast", debuff.magis_spark.remains ) end
+        if action.arcane_missiles.lastCast < debuff.magis_spark.applied then applyDebuff( "target", "magis_spark_arcane_missiles", debuff.magis_spark.remains ) end
     end
 
     if talent.nether_munitions.enabled and debuff.touch_of_the_magi.up then
@@ -1214,7 +1213,7 @@ spec:RegisterAbilities( {
 
             if debuff.magis_spark_arcane_barrage.up then
                 removeDebuff( "target", "magis_spark_arcane_barrage" )
-                if debuff.magis_spark_arcane_blast.down and debuff.magis_spark_arcane_missiles.down then removeBuff( "magis_spark" ) end
+                if debuff.magis_spark_arcane_blast.down and debuff.magis_spark_arcane_missiles.down then removeDebuff( "target", "magis_spark" ) end
             end
         end,
     },
@@ -1256,7 +1255,7 @@ spec:RegisterAbilities( {
 
             if debuff.magis_spark_arcane_blast.up then
                 removeDebuff( "target", "magis_spark_arcane_blast" )
-                if debuff.magis_spark_arcane_barrage.down and debuff.magis_spark_arcane_missiles.down then removeBuff( "magis_spark" ) end
+                if debuff.magis_spark_arcane_barrage.down and debuff.magis_spark_arcane_missiles.down then removeBuff( "target", "magis_spark" ) end
             end
 
             if arcane_charges.current == arcane_charges.max then
@@ -1406,7 +1405,7 @@ spec:RegisterAbilities( {
 
             if debuff.magis_spark_arcane_missiles.up then
                 removeDebuff( "target", "magis_spark_arcane_missiles" )
-                if debuff.magis_spark_arcane_blast.down and debuff.magis_spark_arcane_barrage.down then removeBuff( "magis_spark" ) end
+                if debuff.magis_spark_arcane_blast.down and debuff.magis_spark_arcane_barrage.down then removeDebuff( "target", "magis_spark" ) end
             end
 
             if buff.clearcasting.up then


### PR DESCRIPTION
A few more fixes related to the previous one, since Magis Spark is not a self buff. 

Removed also the id on magis_spark since what is applied is Touch of the Magi as a debuff. Unless that needs to be kept. The spell ID referenced originally, https://www.wowhead.com/spell=450004/magis-spark, isn't actually a buff applied to the caster at all. It's the debuff Touch of the Magi that is modified to behave differently.

All that said, none of these changes still seem to work to make it so that Arcane Blast is recommended ONCE touch of the magi is applied when talented into Magis Spark, while in AOE.

This snapshot shows the sequence recommended, but when Touch of the Magi is actually pressed, it doesn't seem like the debuff.magis_spark.arcane_blast or even other ones, is applied at all in reality.

Arcane Blast is recommended:
https://pastebin.com/mPY8ZQJ2

Once Touch of the Magi is cast, somehow, debuff.magis_spark doesn't seem to be applied.

https://pastebin.com/ym8eTv4h