### PR TITLE
feat: auto-import captions from APL profile

### DIFF
--- a/Options.lua
+++ b/Options.lua
@@ -4001,7 +4001,18 @@ do
                 end
 
                 if comment then
-                    action = action .. ',description=' .. comment:gsub( ",", ";" )
+                    -- Comments can have the form 'Caption::Description'.
+                    -- Any whitespace around the '::' is truncated.
+                    local caption, description= comment:match( "(.+)::(.*)" )
+                    if caption and description then
+                        -- Truncate whitespace and change commas to semicolons.
+                        caption = caption:gsub( "%s+$", "" ):gsub( ",", ";" )
+                        description = description:gsub( "^%s+", "" ):gsub( ",", ";" )
+                        action = action .. ',caption=' .. caption .. ',description=' .. description
+                    else
+                        -- Change commas to semicolons.
+                        action = action .. ',description=' .. comment:gsub( ",", ";" )
+                    end
                     comment = nil
                 end
 

--- a/Options.lua
+++ b/Options.lua
@@ -4008,6 +4008,8 @@ do
                         -- Truncate whitespace and change commas to semicolons.
                         caption = caption:gsub( "%s+$", "" ):gsub( ",", ";" )
                         description = description:gsub( "^%s+", "" ):gsub( ",", ";" )
+                        -- Replace "[<texture-id>]" in the caption with the escape sequence for the texture.
+                        caption = caption:gsub( "%[(%d+)%]", "|T%1:0|t" )
                         action = action .. ',caption=' .. caption .. ',description=' .. description
                     else
                         -- Change commas to semicolons.
@@ -11602,7 +11604,11 @@ do
                             value = SpaceOut( value )
                         end
 
-                        if key == 'caption' or key == 'description' then
+                        if key == 'caption' then
+                            value = value:gsub( "||", "|" ):gsub( ";", "," )
+                        end
+
+                        if key == 'description' then
                             value = value:gsub( ";", "," )
                         end
 

--- a/Options.lua
+++ b/Options.lua
@@ -3982,7 +3982,13 @@ do
 
         for line in apl:gmatch( "\n([^\n^$]*)") do
             local newComment = line:match( "^# (.+)" )
-            if newComment then comment = newComment end
+            if newComment then
+                if comment then
+                    comment = comment .. ' ' .. newComment
+                else
+                    comment = newComment
+                end
+            end
 
             local list, action = line:match( "^actions%.(%S-)%+?=/?([^\n^$]*)" )
 

--- a/Options.lua
+++ b/Options.lua
@@ -11585,7 +11585,7 @@ do
                             value = SpaceOut( value )
                         end
 
-                        if key == 'description' then
+                        if key == 'caption' or key == 'description' then
                             value = value:gsub( ";", "," )
                         end
 


### PR DESCRIPTION
This implements the idea in #3664 -- during the import of a profile, if the comment on an action includes text of the form `{{string}}`, then `string` is used as the caption for the action. This doesn't change the format of an APL profile in any way, but would allow for captions to be added to the profile in-line in the comment body, e.g.:
```
# Avoid {{cap}}ping on charges of Infernal Strike.
actions+=/infernal_strike,if=full_recharge_time<gcd
```