### PR TITLE
feat: add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig (https://editorconfig.org)
+
+# Top-most EditorConfig file.
+root = true
+
+# Unix-style newlines in every file.
+[*]
+end_of_line = lf
+
+# Set default charset.
+[*.{lua,toc,xml}]
+charset = utf-8
+
+# 4-space indentation.
+[*.lua]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Add a `.editorconfig` file at the top-level of the source tree to maintain consistency for whitespace usage across various editors and IDEs, e.g., VSCode, Notepad++, NeoVim, etc.

The current definitions match the existing code conventions of using 4-space tabs for indentation.