### PR TITLE
Outlaw Adjustments for Between the Eyes bugs. Request #3701

### DIFF
--- a/TheWarWithin/RogueAssassination.lua
+++ b/TheWarWithin/RogueAssassination.lua
@@ -256,6 +256,7 @@ local stealth = {
 
     improved_garrote = { "improved_garrote", "sepsis_buff" },
 
+    primal = { "stealth" },
     basic = { "stealth", "vanish" },
     mantle = { "stealth", "vanish" },
     rogue = { "stealth", "vanish", "subterfuge", "shadow_dance" },

--- a/TheWarWithin/RogueOutlaw.lua
+++ b/TheWarWithin/RogueOutlaw.lua
@@ -1481,9 +1481,9 @@ spec:RegisterSetting( "crackshot_lock", false, {
 } )
 
 spec:RegisterSetting( "stealth_lock", false, {
-    name = strformat( "%s: %s |cFFFF0000Only|r", Hekili:GetSpellLinkWithTexture( spec.abilities.stealth.id ), Hekili:GetSpellLinkWithTexture( assassin.abilities.stealth.id ) ),
-    desc = strformat( "If checked and %s is talented, %s will never be recommended outside of %s.\n\nThis is |cFFFF0000NOT|r the default simulation behavior, "
-        .. "but can prevent %s from being placed on a long cooldown.", Hekili:GetSpellLinkWithTexture( spec.talents.crackshot[2] ),
+    name = strformat( "%s: Not in normal Stealth", Hekili:GetSpellLinkWithTexture( spec.abilities.between_the_eyes.id ), Hekili:GetSpellLinkWithTexture( assassin.abilities.stealth.id ) ),
+    desc = strformat( "If checked and %s is talented, %s will NOT be recommended as an opener spell during normal Stealth.\n\nThis is |cFFFF0000NOT|r the default simulation behavior, "
+        .. "but can prevent %s from being placed on a long cooldown due to the notorious bug.", Hekili:GetSpellLinkWithTexture( spec.talents.crackshot[2] ),
         Hekili:GetSpellLinkWithTexture( spec.abilities.between_the_eyes.id ), Hekili:GetSpellLinkWithTexture( assassin.abilities.stealth.id ),
         Hekili:GetSpellLinkWithTexture( spec.abilities.between_the_eyes.id ), assassin.abilities.stealth.name ),
     type = "toggle",

--- a/TheWarWithin/RogueOutlaw.lua
+++ b/TheWarWithin/RogueOutlaw.lua
@@ -980,7 +980,7 @@ spec:RegisterAbilities( {
         texture = 135610,
 
         usable = function()
-            -- if settings.crackshot_lock and talent.crackshot.enabled and not stealthed.all then return false, "userpref requires stealth" end
+            if ( settings.crackshot_lock and talent.crackshot.enabled and not stealthed.all ) or ( settings.stealth_lock and talent.crackshot.enabled and stealthed.primal ) then return false, "userpref requires stealth" end
             return combo_points.current > 0, "requires combo points"
         end,
 
@@ -1470,7 +1470,7 @@ spec:RegisterSetting( "stealth_padding", 0.1, {
     width = "full",
 } )
 
---[[ spec:RegisterSetting( "crackshot_lock", false, {
+spec:RegisterSetting( "crackshot_lock", false, {
     name = strformat( "%s: %s |cFFFF0000Only|r", Hekili:GetSpellLinkWithTexture( spec.abilities.between_the_eyes.id ), Hekili:GetSpellLinkWithTexture( assassin.abilities.stealth.id ) ),
     desc = strformat( "If checked and %s is talented, %s will never be recommended outside of %s.\n\nThis is |cFFFF0000NOT|r the default simulation behavior, "
         .. "but can prevent %s from being placed on a long cooldown.", Hekili:GetSpellLinkWithTexture( spec.talents.crackshot[2] ),
@@ -1478,7 +1478,17 @@ spec:RegisterSetting( "stealth_padding", 0.1, {
         Hekili:GetSpellLinkWithTexture( spec.abilities.between_the_eyes.id ), assassin.abilities.stealth.name ),
     type = "toggle",
     width = "full"
-} ) ]]
+} )
+
+spec:RegisterSetting( "stealth_lock", false, {
+    name = strformat( "%s: %s |cFFFF0000Only|r", Hekili:GetSpellLinkWithTexture( spec.abilities.stealth.id ), Hekili:GetSpellLinkWithTexture( assassin.abilities.stealth.id ) ),
+    desc = strformat( "If checked and %s is talented, %s will never be recommended outside of %s.\n\nThis is |cFFFF0000NOT|r the default simulation behavior, "
+        .. "but can prevent %s from being placed on a long cooldown.", Hekili:GetSpellLinkWithTexture( spec.talents.crackshot[2] ),
+        Hekili:GetSpellLinkWithTexture( spec.abilities.between_the_eyes.id ), Hekili:GetSpellLinkWithTexture( assassin.abilities.stealth.id ),
+        Hekili:GetSpellLinkWithTexture( spec.abilities.between_the_eyes.id ), assassin.abilities.stealth.name ),
+    type = "toggle",
+    width = "full"
+} )
 
 spec:RegisterSetting( "check_blade_rush_range", true, {
     name = strformat( "%s: Melee Only", Hekili:GetSpellLinkWithTexture( spec.abilities.blade_rush.id ) ),


### PR DESCRIPTION
Outlaw Adjustments for Between the Eyes bugs. Mentioned in #3701 
It is 1,25-2% DPS loss in solo target. It should not be executed for Raids, only for Mythic Plus where it should be gain in DPS.