### PR TITLE
Affliction and Demo Warlock rotations fixing and cleanup

### DIFF
--- a/Cataclysm/APLs/WarlockAfflictionBeta.simc
+++ b/Cataclysm/APLs/WarlockAfflictionBeta.simc
@@ -9,8 +9,8 @@ actions+=/solo_curse,if=debuff.my_curse.down
 actions+=/haunt,use_off_gcd=1,if=!target.debuff.haunt.up|dot.haunt.remains<cast_time+latency+1
 actions+=/demon_soul,if=pet.alive
 actions+=/unstable_affliction,if=debuff.unstable_affliction.down
+actions+=/run_action_list,name=aoe,if=active_enemies>1
 actions+=/run_action_list,name=st
-actions+=/call_action_list,name=aoe,if=active_enemies>1
 
 # Single Target Rotation
 actions.st+=/summon_felhunter,if=!pet.alive

--- a/Cataclysm/APLs/WarlockAfflictionBeta.simc
+++ b/Cataclysm/APLs/WarlockAfflictionBeta.simc
@@ -7,19 +7,20 @@ actions.precombat+=/soul_harvest,if=soul_shards<3
 # Default
 actions+=/synapse_springs
 actions+=/shadow_bolt,if=debuff.shadow_embrace.down & target.health.pct > 25
-actions+=/group_curse,if=debuff.my_curse.down&curse_grouped
-actions+=/solo_curse,if=debuff.my_curse.down
+actions+=/group_curse,if=debuff.my_curse.down & curse_grouped & (debuff.my_curse.id != debuff.curse_of_the_elements.id | talent.jinx.rank & target.debuff.jinx_curse_elements.down)
+actions+=/solo_curse,if=debuff.my_curse.down & (debuff.my_curse.id != debuff.curse_of_the_elements.id | talent.jinx.rank & target.debuff.jinx_curse_elements.down)
+
 actions+=/haunt,use_off_gcd=1,if=!target.debuff.haunt.up|dot.haunt.remains<cast_time+latency+1
 actions+=/demon_soul,if=pet.alive
 actions+=/unstable_affliction,if=debuff.unstable_affliction.down
 actions+=/haunt,use_off_gcd=1,if=!target.debuff.haunt.up|dot.haunt.remains<cast_time+latency+3
+actions+=/fel_flame,if=buff.fel_spark.up
 actions+=/run_action_list,name=aoe,if=active_enemies>1
 actions+=/run_action_list,name=st,if=active_enemies<2
+actions+=/fel_flame,if=moving
 
 # Single Target Rotation
 actions.st+=/summon_felhunter,if=!pet.alive
-actions.st+=/group_curse,if=target.debuff.my_curse.down&curse_grouped
-actions.st+=/solo_curse,if=target.debuff.my_curse.down
 actions.st+=/corruption,if=target.debuff.corruption.remains<tick_time
 actions.st+=/bane,if=target.debuff.my_bane.remains<15
 actions.st+=/unstable_affliction,if=target.debuff.unstable_affliction.remains<tick_time&target.health.pct>25
@@ -28,7 +29,6 @@ actions.st+=/shadowflame,if=target.distance<7
 actions.st+=/soulburn,if=moving
 actions.st+=/soul_fire,if=buff.soulburn.up
 actions.st+=/demon_soul
-actions.st+=/fel_flame,if=buff.fel_spark.up|moving
 actions.st+=/shadow_bolt,if=target.health.pct > 25 & target.distance > 7 |debuff.shadow_embrace.down & target.health.pct > 25|target.distance<7&cooldown.shadowflame.remains>3
 actions.st+=/life_tap,if=mana.pct<10|glyph.life_tap.enabled&buff.life_tap.remains<5
 

--- a/Cataclysm/APLs/WarlockAfflictionBeta.simc
+++ b/Cataclysm/APLs/WarlockAfflictionBeta.simc
@@ -3,22 +3,25 @@ actions.precombat+=/volcanic_potion
 actions.precombat+=/fel_armor,if=buff.armor.down
 actions.precombat+=/summon_felhunter,if=!pet.alive
 actions.precombat+=/soul_harvest,if=soul_shards<3
+
+# Default
+actions+=/synapse_springs
 actions+=/shadow_bolt,if=debuff.shadow_embrace.down & target.health.pct > 25
 actions+=/group_curse,if=debuff.my_curse.down&curse_grouped
 actions+=/solo_curse,if=debuff.my_curse.down
 actions+=/haunt,use_off_gcd=1,if=!target.debuff.haunt.up|dot.haunt.remains<cast_time+latency+1
 actions+=/demon_soul,if=pet.alive
 actions+=/unstable_affliction,if=debuff.unstable_affliction.down
+actions+=/haunt,use_off_gcd=1,if=!target.debuff.haunt.up|dot.haunt.remains<cast_time+latency+3
 actions+=/run_action_list,name=aoe,if=active_enemies>1
-actions+=/run_action_list,name=st
+actions+=/run_action_list,name=st,if=active_enemies<2
 
 # Single Target Rotation
 actions.st+=/summon_felhunter,if=!pet.alive
-actions.st+=/group_curse,if=debuff.my_curse.down&curse_grouped
-actions.st+=/solo_curse,if=debuff.my_curse.down
-actions.st+=/corruption,if=debuff.corruption.remains<tick_time
-actions+=/haunt,use_off_gcd=1,if=!target.debuff.haunt.up|dot.haunt.remains<cast_time+latency+3
-actions.st+=/bane,if=debuff.my_bane.remains<15
+actions.st+=/group_curse,if=target.debuff.my_curse.down&curse_grouped
+actions.st+=/solo_curse,if=target.debuff.my_curse.down
+actions.st+=/corruption,if=target.debuff.corruption.remains<tick_time
+actions.st+=/bane,if=target.debuff.my_bane.remains<15
 actions.st+=/unstable_affliction,if=target.debuff.unstable_affliction.remains<tick_time&target.health.pct>25
 actions.st+=/drain_soul,if=target.health.pct<=25
 actions.st+=/shadowflame,if=target.distance<7
@@ -28,18 +31,19 @@ actions.st+=/demon_soul
 actions.st+=/fel_flame,if=buff.fel_spark.up|moving
 actions.st+=/shadow_bolt,if=target.health.pct > 25 & target.distance > 7 |debuff.shadow_embrace.down & target.health.pct > 25|target.distance<7&cooldown.shadowflame.remains>3
 actions.st+=/life_tap,if=mana.pct<10|glyph.life_tap.enabled&buff.life_tap.remains<5
-actions.st+=/call_action_list,name=aoe,if=active_enemies>2
 
 # AoE Rotation
-actions.aoe+=/corruption,if=target.debuff.corruption.remains<3,target_if=debuff.corruption.remains
+actions.aoe+=/corruption,if=target.debuff.corruption.remains<3
 actions.aoe+=/unstable_affliction,if=target.debuff.unstable_affliction.remains<3
-actions.aoe+=/bane_of_agony,if=debuff.bane_of_agony.remains<tick_time&!bane_priority.ticking
+
+#workaround: something wrong with "bane_priority" evaluation - target.debuff.bane_priority.down is always true.
+actions.aoe+=/bane_of_agony,if=debuff.bane_of_agony.remains<tick_time &!target.debuff.bane_of_doom.ticking &!target.debuff.bane_of_havoc.ticking
+
 actions.aoe+=/soulburn,if=cooldown.seed_of_corruption.remains<gcd&active_enemies>2
-actions.aoe+=/seed_of_corruption,if=buff.soulburn.up&active_enemies>2
-actions.aoe+=/seed_of_corruption,if=active_enemies>=6
+actions.aoe+=/seed_of_corruption,if=active_enemies>=6 | buff.soulburn.up & active_enemies>2
 actions.aoe+=/shadowflame,if=target.distance<7
 actions.aoe+=/shadow_bolt,cycle_targets=1
-actions.aoe+=/curse_of_the_elements,if=active_enemies>5&debuff.curse_of_the_elements.remains<3&!target.distance>5
+actions.aoe+=/curse_of_the_elements,if=talent.jinx.rank & (target.debuff.jinx_curse_elements.down and debuff.curse_of_the_elements.remains<3)
 
 # Soul Swap Logic (2 targets)
 actions.aoe+=/soul_swap,if=target.debuff.bane_of_agony.up&active_enemies=2

--- a/Cataclysm/APLs/WarlockDemonology.simc
+++ b/Cataclysm/APLs/WarlockDemonology.simc
@@ -14,7 +14,8 @@ actions+=/immolate,if=!ticking&debuff.immolate.remains<tick_time
 actions+=/corruption,if=!ticking&debuff.corruption<tick_time
 actions+=/volcanic_potion,if=buff.metamorphosis.up 
 actions+=/life_tap,if=mana.pct<55 & cooldown.metamorphosis.remains<10
-actions+=/synapse_springs
+#todo add evaluation of Impending doom talent. cooldown.metamorphosis.remains can be 90 in that case
+actions+=/synapse_springs,if=cooldown.metamorphosis.remains>61
 actions+=/metamorphosis,use_off_gcd=1
 actions+=/soulburn,if=soul_shard>1&buff.fel_intelligence.up&cooldown.demon_soul.remains<6&settings.pet_twisting
 actions+=/summon_felguard,if=buff.fel_intelligence.up&cooldown.demon_soul.remains<6&settings.pet_twisting

--- a/Cataclysm/APLs/WarlockDemonology.simc
+++ b/Cataclysm/APLs/WarlockDemonology.simc
@@ -9,11 +9,12 @@ actions.precombat+=/metamorphosis
 actions.precombat+=/demon_soul,if=pet.alive&settings.pet_twisting
 actions.precombat+=/soul_harvest,if=soul_shards<3
 
+actions+=/fel_flame, if=buff.fel_spark.up
 actions+=/immolate,if=!ticking&debuff.immolate.remains<tick_time
 actions+=/corruption,if=!ticking&debuff.corruption<tick_time
 actions+=/volcanic_potion,if=buff.metamorphosis.up 
 actions+=/life_tap,if=mana.pct<55 & cooldown.metamorphosis.remains<10
-actions+=/synapse_springs,if=cooldown.metamorphosis.remains>61
+actions+=/synapse_springs
 actions+=/metamorphosis,use_off_gcd=1
 actions+=/soulburn,if=soul_shard>1&buff.fel_intelligence.up&cooldown.demon_soul.remains<6&settings.pet_twisting
 actions+=/summon_felguard,if=buff.fel_intelligence.up&cooldown.demon_soul.remains<6&settings.pet_twisting
@@ -30,7 +31,7 @@ actions.sdr+=/bane_of_doom,if=!ticking&target.time_to_die>15
 actions.sdr+=/bane_of_agony,if=!ticking&target.time_to_die<30&!debuff.bane_of_doom.up
 actions.sdr+=/summon_infernal,if=settings.inferno_enabled&target.time_to_die>45&soul_shards=3
 actions.sdr+=/hand_of_guldan,use_off_gcd=1
-actions.sdr+=/shadowflame,if=!debuff.shadowflame.up&buff.fel_spark.up
+actions.sdr+=/shadowflame,if=target.distance<7
 actions.sdr+=/soulburn,if=soul_shard>1&settings.pet_twisting&!buff.fel_intelligence.up & buff.demon_soul_felguard.down
 actions.sdr+=/summon_felhunter,if=soul_shard>1&buff.soulburn.up&!buff.fel_intelligence.up&settings.pet_twisting&buff.demon_soul_felguard.down
 actions.sdr+=/summon_doomguard,if=buff.demonic_pact.up&buff.molten_core.stack>=1&cooldown.hand_of_gul_dan.remains<10
@@ -45,7 +46,7 @@ actions.nr+=/hand_of_guldan,use_off_gcd=1
 actions.nr+=/bane_of_doom,if=!ticking&target.time_to_die>30
 actions.nr+=/bane_of_agony,if=!ticking&target.time_to_die<30&!debuff.bane_of_doom.up
 actions.nr+=/corruption,if=!ticking
-actions.nr+=/shadowflame,if=!debuff.shadowflame.up&buff.fel_spark.up
+actions.nr+=/shadowflame,if=target.distance<7
 actions.nr+=/incinerate,if=buff.molten_core.up
 actions.nr+=/soul_fire,if=target.health.pct<25&buff.decimation.up
 actions.nr+=/shadow_bolt

--- a/Cataclysm/Warlock.lua
+++ b/Cataclysm/Warlock.lua
@@ -387,6 +387,12 @@ spec:RegisterAuras( {
         tick_time = 1,
         max_stack = 1,
     },
+    jinx_curse_elements = {
+        id = 86105,
+	copy = { 86105, 85547 },
+	duration = 4,
+        max_stack = 1,
+    },
     -- Damage taken from Shadow damage-over-time effects increased by $s3%.
     haunt = {
         id = 48181,


### PR DESCRIPTION
Affliction Warlock: 
Jinx talent added, AoE rotation restored, Bane of Agony restored (workaround), Synapse Springs added to rotation.
curse of the elements is correctly validated considering the talent.

Demo warlock: Fel Flame and shadow flame