### PR TITLE
fix: temporary fix for `health.percent` being nil

### DIFF
--- a/TheWarWithin/WarriorProtection.lua
+++ b/TheWarWithin/WarriorProtection.lua
@@ -1272,16 +1272,17 @@ spec:RegisterAbilities( {
 
             local dmg_required = ( ( settings.last_stand_amount or 10 ) * 0.01 ) * health.max * ( solo and 0.5 or 1 )
             local hp_required = ( settings.last_stand_health or 10 )
+            local hp = health.percent or 10
 
             if settings.last_stand_condition then
                 if incoming_damage_5s < dmg_required then return false, format( "incoming_damage_5s[%.2f] < dmg_required[%.2f] setting", incoming_damage_5s, dmg_required ) end
-                if health.percent > hp_required then return false, format( "health.percent[%.2f] > hp_required[%.2f] setting", health.percent, hp_required ) end
+                if hp > hp_required then return false, format( "health.percent[%.2f] > hp_required[%.2f] setting", hp, hp_required ) end
                 return true
             end
 
             if incoming_damage_5s >= dmg_required or hp <= hp_required then return true end
             if incoming_damage_5s < dmg_required then return false, format( "incoming_damage_5s[%.2f] < dmg_required[%.2f] setting", incoming_damage_5s, dmg_required ) end
-            if health.percent > hp_required then return false, format( "health.percent[%.2f] > hp_required[%.2f] setting", health.percent, hp_required ) end
+            if hp > hp_required then return false, format( "health.percent[%.2f] > hp_required[%.2f] setting", hp, hp_required ) end
             return false
         end,
 


### PR DESCRIPTION
Re-add local definition of `hp` that uses a default value in case `health.percent` is nil, and use it instead of `health.percent` in Last Stand's `usable` function.

XXX Need to track down why `health.percent` is nil.

This fixes a bug I introduced with some other changes that didn't get fully tested due to my settings.

It's unclear why `health.percent` can't be used in this function, possibly because it's being called fairly early on? I think it's better to move all of these usability conditions out of the addon and into the priority, much like how `{ibf,rt,vb}_damage` are defined in `DeathKnightBlood.lua` but are used in the priorities directly.