### PR TITLE
Update interrupt filter for TWW Season 1

### DIFF
--- a/Options.lua
+++ b/Options.lua
@@ -8484,7 +8484,7 @@ do
 
                         filterCasts  ={
                             type = "toggle",
-                            name = format( "%s Filter M+ Interrupts (DF Season 4)", NewFeature ),
+                            name = format( "%s Filter M+ Interrupts (TWW Season 1)", NewFeature ),
                             desc = format( "If checked, low-priority enemy casts will be ignored when your target may use an ability that should be interrupted.\n\n"
                                 .. "Example:  In Everbloom, Earthshaper Telu's |W%s|w will be ignored and |W%s|w will be interrupted.", ( GetSpellInfo( 168040 ) or "Nature's Wrath" ),
                                 ( GetSpellInfo( 427459 ) or "Toxic Bloom" ) ),

--- a/Options.lua
+++ b/Options.lua
@@ -729,632 +729,254 @@ do
 
                 filterCasts = true,
                 castFilters = {
-                    [75713] = {
-                        desc = "Shadowmoon Burial Grounds - Shadowmoon Bone-Mender",
-                        [152818] = "Shadow Mend",
-                    },
-                    [76057] = {
-                        desc = "Shadowmoon Burial Grounds - Carrion Worm",
-                        [153395] = "Body Slam",
-                    },
-                    [75459] = {
-                        desc = "Shadowmoon Burial Grounds - Plagued Bat",
-                        [153524] = "Plague Spit",
-                    },
-                    [76446] = {
-                        desc = "Shadowmoon Burial Grounds - Shadowmoon Dominator",
-                        [156776] = "Rending Voidlash",
-                    },
-                    [81820] = {
-                        desc = "The Everbloom - Everbloom Mender",
-                        [164887] = "Healing Waters",
-                        [164965] = "Choking Vines",
-                    },
-                    [81819] = {
-                        desc = "The Everbloom - Everbloom Naturalist",
-                        [164965] = "Choking Vines",
-                    },
-                    [81985] = {
-                        desc = "The Everbloom - Everbloom Cultivator",
-                        [165213] = "Enraged Growth",
-                    },
-                    [83892] = {
-                        desc = "The Everbloom - Life Warden Gola",
-                        [168082] = "Revitalize",
-                    },
-                    [84957] = {
-                        desc = "The Everbloom - Putrid Pyromancer",
-                        [169839] = "Pyroblast",
-                    },
-                    [97197] = {
-                        desc = "Halls of Valor - Valarjar Purifier",
-                        [192563] = "Cleansing Flames",
-                    },
-                    [95769] = {
-                        desc = "Darkheart Thicket - Mindshattered Screecher",
-                        [200630] = "Unnerving Screech",
-                    },
-                    [100527] = {
-                        desc = "Darkheart Thicket - Dreadfire Imp",
-                        [201399] = "Dread Inferno",
-                    },
-                    [91006] = {
-                        desc = "Neltharion's Lair - Rockback Gnasher",
-                        [202181] = "Stone Gaze",
-                    },
-                    [101991] = {
-                        desc = "Darkheart Thicket - Nightmare Dweller",
-                        [204243] = "Tormenting Eye",
-                    },
-                    [104274] = {
-                        desc = "Court of Stars - Baalgar the Watchful",
-                        [207980] = "Disintegration Beam",
-                    },
-                    [104247] = {
-                        desc = "Court of Stars - Duskwatch Arcanist",
-                        [209410] = "Nightfall Orb",
-                    },
-                    [104270] = {
-                        desc = "Court of Stars - Guardian Construct",
-                        [209413] = "Suppress",
-                        [225100] = "Charging Station",
-                    },
-                    [104295] = {
-                        desc = "Court of Stars - Blazing Imp",
-                        [211401] = "Drifting Embers",
-                    },
-                    [104300] = {
-                        desc = "Court of Stars - Shadow Mistress",
-                        [211470] = "Bewitch",
-                    },
-                    [95834] = {
-                        desc = "Halls of Valor - Valarjar Mystic",
-                        [215433] = "Holy Radiance",
-                    },
-                    [100532] = {
-                        desc = "Darkheart Thicket - Bloodtainted Burster",
-                        [225562] = "Blood Metamorphosis",
-                    },
-                    [102788] = {
-                        desc = "Black Rook Hold - Felspite Dominator",
-                        [227913] = "Felfrenzy",
-                    },
-                    [122986] = {
-                        desc = "Atal'Dazar - Wild Skyscreamer",
-                        [255041] = "Terrifying Screech",
-                    },
-                    [128434] = {
-                        desc = "Atal'Dazar - Feasting Skyscreamer",
-                        [255041] = "Terrifying Screech",
-                    },
-                    [129788] = {
-                        desc = "Freehold - Irontide Bonesaw",
-                        [257397] = "Healing Balm",
-                    },
-                    [126919] = {
-                        desc = "Freehold - Irontide Stormcaller",
-                        [257736] = "Thundering Squall",
-                    },
-                    [129600] = {
-                        desc = "Freehold - Bilge Rat Brinescale",
-                        [257784] = "Frost Blast",
-                    },
-                    [122965] = {
-                        desc = "Atal'Dazar - Vol'kaal",
-                        [259572] = "Noxious Stench",
-                    },
-                    [133379] = {
-                        desc = "Temple of Sethraliss - Adderis",
-                        [263365] = "A Peal of Thunder",
-                    },
-                    [131812] = {
-                        desc = "Waycrest Manor - Heartsbane Soulcharmer",
-                        [263959] = "Soul Volley",
-                    },
-                    [131685] = {
-                        desc = "Waycrest Manor - Runic Disciple",
-                        [264390] = "Spellbind",
-                    },
-                    [131821] = {
-                        desc = "Waycrest Manor - Faceless Maiden",
-                        [264407] = "Horrific Visage",
-                    },
-                    [131492] = {
-                        desc = "The Underrot - Devout Blood Priest",
-                        [265089] = "Dark Reconstitution",
-                        [265091] = "Gift of G'huun",
-                    },
-                    [135049] = {
-                        desc = "Waycrest Manor - Dreadwing Raven",
-                        [265346] = "Pallid Glare",
-                    },
-                    [133912] = {
-                        desc = "The Underrot - Bloodsworn Defiler",
-                        [265433] = "Withering Curse",
-                        [265523] = "Summon Spirit Drain Totem",
-                    },
-                    [134112] = {
-                        desc = "Waycrest Manor - Matron Christiane",
-                        [265876] = "Ruinous Volley",
-                    },
-                    [135365] = {
-                        desc = "Waycrest Manor - Matron Alma",
-                        [265876] = "Ruinous Volley",
-                    },
-                    [133835] = {
-                        desc = "The Underrot - Feral Bloodswarmer",
-                        [266106] = "Sonic Screech",
-                    },
-                    [134284] = {
-                        desc = "The Underrot - Fallen Deathspeaker",
-                        [266209] = "Wicked Frenzy",
-                        [272183] = "Raise Dead",
-                    },
-                    [131864] = {
-                        desc = "Waycrest Manor - Gorak Tul",
-                        [266225] = "Darkened Lightning",
-                    },
-                    [137830] = {
-                        desc = "Waycrest Manor - Pallid Gorger",
-                        [271174] = "Retch",
-                    },
-                    [134024] = {
-                        desc = "Waycrest Manor - Devouring Maggot",
-                        [278444] = "Infest",
-                    },
-                    [142587] = {
-                        desc = "Waycrest Manor - Devouring Maggot",
-                        [278444] = "Infest",
-                    },
-                    [133685] = {
-                        desc = "The Underrot - Befouled Spirit",
-                        [278755] = "Harrowing Despair",
-                    },
-                    [122969] = {
-                        desc = "Atal'Dazar - Zanchuli Witch-Doctor",
-                        [279118] = "Unstable Hex",
-                    },
-                    [170044] = {
-                        desc = "Maldraxxus - Venthyr Apprentice",
-                        [345202] = "Absolution",
-                    },
-                    [185529] = {
-                        desc = "Brackenhide Hollow - Bracken Warscourge",
-                        [367500] = "Hideous Cackle",
-                    },
-                    [193178] = {
-                        desc = "The Azure Span - Blightfur",
-                        [367500] = "Hideous Cackle",
-                    },
-                    [195135] = {
-                        desc = "Brackenhide Hollow - Bracken Warscourge",
-                        [367500] = "Hideous Cackle",
-                    },
-                    [186191] = {
-                        desc = "Brackenhide Hollow - Decay Speaker",
-                        [367503] = "Withering Burst",
-                        [382474] = "Decay Surge",
-                    },
-                    [184132] = {
-                        desc = "Uldaman - Earthen Warder",
-                        [369365] = "Curse of Stone",
-                    },
-                    [184301] = {
-                        desc = "Uldaman - Cavern Seeker",
-                        [369411] = "Sonic Burst",
-                    },
-                    [186420] = {
-                        desc = "Uldaman - Earthen Weaver",
-                        [369465] = "Hail of Stone",
-                    },
-                    [184580] = {
-                        desc = "Uldaman - Olaf",
-                        [369602] = "Defensive Bulwark",
-                    },
-                    [204046] = {
-                        desc = "Valdrakken - Olaf",
-                        [369602] = "Defensive Bulwark",
-                    },
-                    [184022] = {
-                        desc = "Uldaman - Stonevault Geomancer",
-                        [369675] = "Chain Lightning",
-                    },
-                    [186658] = {
-                        desc = "Uldaman - Stonevault Geomancer",
-                        [369675] = "Chain Lightning",
-                    },
-                    [189265] = {
-                        desc = "Neltharus - Qalashi Bonetender",
-                        [372223] = "Mending Clay",
-                    },
-                    [189470] = {
-                        desc = "Neltharus - Lava Flare",
-                        [372538] = "Melt",
-                    },
-                    [186220] = {
-                        desc = "Brackenhide Hollow - Brackenhide Shaper",
-                        [372711] = "Infuse Corruption",
-                    },
-                    [188067] = {
-                        desc = "Ruby Life Pools - Flashfrost Chillweaver",
-                        [372743] = "Ice Shield",
-                    },
-                    [189886] = {
-                        desc = "Ruby Life Pools - Blazebound Firestorm",
-                        [373017] = "Roaring Blaze",
-                    },
-                    [193462] = {
-                        desc = "The Nokhud Offensive - Batak",
-                        [373395] = "Bloodcurdling Shout",
-                    },
-                    [199717] = {
-                        desc = "The Nokhud Offensive - Nokhud Defender",
-                        [373395] = "Bloodcurdling Shout",
-                    },
-                    [190342] = {
-                        desc = "Halls of Infusion - Containment Apparatus",
-                        [374045] = "Expulse",
-                    },
-                    [190345] = {
-                        desc = "Halls of Infusion - Primalist Geomancer",
-                        [374066] = "Earth Shield",
-                    },
-                    [190348] = {
-                        desc = "Halls of Infusion - Primalist Ravager",
-                        [374080] = "Blasting Gust",
-                    },
-                    [190340] = {
-                        desc = "Halls of Infusion - Refti Defender",
-                        [374339] = "Demoralizing Shout",
-                    },
-                    [186226] = {
-                        desc = "Brackenhide Hollow - Fetid Rotsinger",
-                        [374544] = "Burst of Decay",
-                    },
-                    [190362] = {
-                        desc = "Halls of Infusion - Dazzling Dragonfly",
-                        [374563] = "Dazzle",
-                    },
-                    [190368] = {
-                        desc = "Halls of Infusion - Flamecaller Aymi",
-                        [374699] = "Cauterize",
-                        [374706] = "Pyretic Burst",
-                    },
-                    [191164] = {
-                        desc = "The Azure Vault - Arcane Tender",
-                        [375596] = "Erratic Growth",
-                    },
-                    [196115] = {
-                        desc = "The Azure Vault - Arcane Tender",
-                        [375596] = "Erratic Growth",
-                    },
-                    [190377] = {
-                        desc = "Halls of Infusion - Primalist Icecaller",
-                        [376171] = "Refreshing Tides",
-                    },
-                    [189901] = {
-                        desc = "Neltharus - Warlord Sargha",
-                        [376780] = "Magma Shield",
-                    },
-                    [190407] = {
-                        desc = "Halls of Infusion - Aqua Rager",
-                        [377341] = "Tidal Divergence",
-                    },
-                    [192333] = {
-                        desc = "Algeth'ar Academy - Alpha Eagle",
-                        [377389] = "Call of the Flock",
-                    },
-                    [190405] = {
-                        desc = "Halls of Infusion - Infuser Sariya",
-                        [377402] = "Aqueous Barrier",
-                    },
-                    [187155] = {
-                        desc = "The Azure Vault - Rune Seal Keeper",
-                        [377488] = "Icy Bindings",
-                    },
-                    [184335] = {
-                        desc = "Uldaman - Infinite Agent",
-                        [377500] = "Hasten",
-                    },
-                    [186125] = {
-                        desc = "Brackenhide Hollow - Tricktotem",
-                        [377950] = "Greater Healing Rapids",
-                    },
-                    [192788] = {
-                        desc = "Neltharus - Qalashi Thaumaturge",
-                        [378282] = "Molten Core",
-                    },
-                    [184300] = {
-                        desc = "Uldaman - Ebonstone Golem",
-                        [381593] = "Thunderous Clap",
-                    },
-                    [185528] = {
-                        desc = "Brackenhide Hollow - Trickclaw Mystic",
-                        [382249] = "Earth Bolt",
-                    },
-                    [185656] = {
-                        desc = "Brackenhide Hollow - Filth Caller",
-                        [382474] = "Decay Surge",
-                    },
-                    [187315] = {
-                        desc = "Brackenhide Hollow - Disease Slasher",
-                        [382787] = "Decay Claws",
-                    },
-                    [194467] = {
-                        desc = "Brackenhide Hollow - Brackenhide Slasher",
-                        [382787] = "Decay Claws",
-                    },
-                    [193944] = {
-                        desc = "Neltharus - Qalashi Lavamancer",
-                        [382791] = "Molten Barrier",
-                    },
-                    [189464] = {
-                        desc = "Neltharus - Qalashi Irontorch",
-                        [384161] = "Mote of Combustion",
-                    },
-                    [190207] = {
-                        desc = "Ruby Life Pools - Primalist Cinderweaver",
-                        [384194] = "Cinderbolt",
-                    },
-                    [191847] = {
-                        desc = "The Nokhud Offensive - Nokhud Plainstomper",
-                        [384365] = "Disruptive Shout",
-                    },
-                    [192800] = {
-                        desc = "The Nokhud Offensive - Nokhud Lancemaster",
-                        [384365] = "Disruptive Shout",
-                    },
-                    [197650] = {
-                        desc = "Ohn'ahran Plains - Tarolekk, the Stomper",
-                        [384365] = "Disruptive Shout",
-                    },
-                    [186116] = {
-                        desc = "Brackenhide Hollow - Gutshot",
-                        [384633] = "Master's Call",
-                    },
-                    [186339] = {
-                        desc = "The Nokhud Offensive - Teera",
-                        [384808] = "Guardian Wind",
-                    },
-                    [186246] = {
-                        desc = "Brackenhide Hollow - Fleshripper Vulture",
-                        [385029] = "Screech",
-                    },
-                    [194894] = {
-                        desc = "The Nokhud Offensive - Primalist Stormspeaker",
-                        [386015] = "Summon Squall",
-                        [386024] = "Tempest",
-                        [386025] = "Tempest",
-                    },
-                    [186741] = {
-                        desc = "The Azure Vault - Arcane Elemental",
-                        [386546] = "Waking Bane",
-                    },
-                    [195696] = {
-                        desc = "The Nokhud Offensive - Primalist Thunderbeast",
-                        [387125] = "Thunderstrike",
-                    },
-                    [195927] = {
-                        desc = "The Nokhud Offensive - Soulharvester Galtmaa",
-                        [387411] = "Death Bolt Volley",
-                    },
-                    [195928] = {
-                        desc = "The Nokhud Offensive - Soulharvester Duuren",
-                        [387411] = "Death Bolt Volley",
-                    },
-                    [195929] = {
-                        desc = "The Nokhud Offensive - Soulharvester Tumen",
-                        [387411] = "Death Bolt Volley",
-                    },
-                    [195930] = {
-                        desc = "The Nokhud Offensive - Soulharvester Mandakh",
-                        [387411] = "Death Bolt Volley",
-                    },
-                    [196102] = {
-                        desc = "The Azure Vault - Conjured Lasher",
-                        [387564] = "Mystic Vapors",
-                    },
-                    [195877] = {
-                        desc = "The Nokhud Offensive - Risen Mystic",
-                        [387596] = "Swift Wind",
-                    },
-                    [196203] = {
-                        desc = "Algeth'ar Academy - Ethereal Restorer",
-                        [387955] = "Celestial Shield",
-                    },
-                    [196044] = {
-                        desc = "Algeth'ar Academy - Unruly Textbook",
-                        [388392] = "Monotonous Lecture",
-                    },
-                    [196045] = {
-                        desc = "Algeth'ar Academy - Corrupted Manafiend",
-                        [388862] = "Surge",
-                        [388863] = "Mana Void",
-                    },
-                    [197985] = {
-                        desc = "Ruby Life Pools - Flame Channeler",
-                        [392451] = "Flashfire",
-                    },
-                    [197535] = {
-                        desc = "Ruby Life Pools - High Channeler Ryvati",
-                        [392924] = "Shock Blast",
-                    },
-                    [189235] = {
-                        desc = "Neltharus - Overseer Lahar",
-                        [395427] = "Burning Roar",
-                    },
-                    [199037] = {
-                        desc = "Halls of Infusion - Primalist Shocktrooper",
-                        [395694] = "Elemental Focus",
-                    },
-                    [59555] = {
-                        desc = "Temple of the Jade Serpent - Haunting Sha",
-                        [395859] = "Haunting Scream",
-                    },
-                    [59546] = {
-                        desc = "Temple of the Jade Serpent - The Talking Fish",
-                        [395872] = "Sleepy Soliloquy",
-                    },
-                    [59552] = {
-                        desc = "Temple of the Jade Serpent - The Crybaby Hozen",
-                        [396018] = "Fit of Rage",
-                    },
-                    [59544] = {
-                        desc = "Temple of the Jade Serpent - The Nodding Tiger",
-                        [396073] = "Cat Nap",
-                    },
-                    [196548] = {
-                        desc = "Algeth'ar Academy - Ancient Branch",
-                        [396640] = "Healing Touch",
-                    },
-                    [196576] = {
-                        desc = "Algeth'ar Academy - Spellbound Scepter",
-                        [396812] = "Mystic Blast",
-                    },
-                    [193373] = {
-                        desc = "The Nokhud Offensive - Nokhud Thunderfist",
-                        [397394] = "Deadly Thunder",
-                    },
-                    [200126] = {
-                        desc = "Temple of the Jade Serpent - Fallen Waterspeaker",
-                        [397889] = "Tidal Burst",
-                    },
-                    [200137] = {
-                        desc = "Temple of the Jade Serpent - Depraved Mistweaver",
-                        [397914] = "Defiling Mist",
-                    },
-                    [75979] = {
-                        desc = "Shadowmoon Burial Grounds - Exhumed Spirit",
-                        [398206] = "Death Blast",
-                    },
-                    [204206] = {
-                        desc = "Dawn of the Infinite - Horde Farseer",
-                        [407891] = "Healing Wave",
-                    },
-                    [45912] = {
-                        desc = "The Vortex Pinnacle - Wild Vortex",
-                        [410870] = "Cyclone",
-                    },
-                    [205363] = {
-                        desc = "Dawn of the Infinite - Time-Lost Waveshaper",
-                        [411300] = "Fish Bolt Volley",
-                    },
-                    [205727] = {
-                        desc = "Dawn of the Infinite - Time-Lost Rocketeer",
-                        [412233] = "Rocket Bolt Volley",
-                    },
-                    [205337] = {
-                        desc = "Dawn of the Infinite - Infinite Timebender",
-                        [412378] = "Dizzying Sands",
-                    },
-                    [205158] = {
-                        desc = "Dawn of the Infinite - Spurlok, Timesworn Sentinel",
-                        [412922] = "Binding Grasp",
-                    },
-                    [138187] = {
-                        desc = "The Underrot - Grotesque Horror",
-                        [413044] = "Dark Echoes",
-                    },
-                    [201223] = {
-                        desc = "Dawn of the Infinite - Infinite Twilight Magus",
-                        [413607] = "Corroding Volley",
-                    },
-                    [206066] = {
-                        desc = "Dawn of the Infinite - Timestream Leech",
-                        [415437] = "Enervate",
-                    },
-                    [206140] = {
-                        desc = "Dawn of the Infinite - Coalesced Time",
-                        [415770] = "Infinite Bolt Volley",
-                    },
-                    [199000] = {
-                        desc = "Dawn of the Infinite - Chrono-Lord Deios",
-                        [416139] = "Temporal Breath",
-                    },
-                    [199748] = {
-                        desc = "Dawn of the Infinite - Timeline Marauder",
-                        [417481] = "Displace Chronosequence",
-                    },
-                    [208698] = {
-                        desc = "Dawn of the Infinite - Infinite Riftmage",
-                        [418200] = "Infinite Burn",
+                    [40167] = {
+                    desc = "Grim Batol - Twilight Beguiler",
+                        [76711] = "Sear Mind",
+                    },
+                    [129370] = {
+                        desc = "Siege of Boralus - Irontide Waveshaper",
+                        [256957] = "Watertight Shell",
+                    },
+                    [141284] = {
+                        desc = "Siege of Boralus - Kul Tiran Wavetender",
+                        [256957] = "Watertight Shell",
+                    },
+                    [144071] = {
+                        desc = "Siege of Boralus - Irontide Waveshaper",
+                        [256957] = "Watertight Shell",
+                    },
+                    [129367] = {
+                        desc = "Siege of Boralus - Bilge Rat Tempest",
+                        [272571] = "Choking Waters",
+                    },
+                    [128969] = {
+                        desc = "Siege of Boralus - Ashvane Commander",
+                        [275826] = "Bolstering Shout",
+                    },
+                    [164517] = {
+                        desc = "Mists of Tirna Scithe - Tred'ova",
+                        [322450] = "Consumption",
+                        [337235] = "Parasitic Pacification",
+                    },
+                    [164921] = {
+                        desc = "Mists of Tirna Scithe - Drust Harvester",
+                        [322938] = "Harvest Essence",
+                    },
+                    [165919] = {
+                        desc = "The Necrotic Wake - Skeletal Marauder",
+                        [324293] = "Rasping Scream",
+                    },
+                    [171095] = {
+                        desc = "The Necrotic Wake - Grisly Colossus",
+                        [324293] = "Rasping Scream",
+                    },
+                    [166275] = {
+                        desc = "Mists of Tirna Scithe - Mistveil Shaper",
+                        [324776] = "Bramblethorn Coat",
+                    },
+                    [166299] = {
+                        desc = "Mists of Tirna Scithe - Mistveil Tender",
+                        [324914] = "Nourish the Forest",
+                    },
+                    [167111] = {
+                        desc = "Mists of Tirna Scithe - Spinemaw Staghorn",
+                        [326046] = "Stimulate Resistance",
+                        [340544] = "Stimulate Regeneration",
+                    },
+                    [165872] = {
+                        desc = "The Necrotic Wake - Flesh Crafter",
+                        [327130] = "Repair Flesh",
+                    },
+                    [166302] = {
+                        desc = "The Necrotic Wake - Corpse Harvester",
+                        [334748] = "Drain Fluids",
+                    },
+                    [173016] = {
+                        desc = "The Necrotic Wake - Corpse Collector",
+                        [334748] = "Drain Fluids",
+                        [338353] = "Goresplatter",
+                    },
+                    [173044] = {
+                        desc = "The Necrotic Wake - Stitching Assistant",
+                        [334748] = "Drain Fluids",
+                    },
+                    [165222] = {
+                        desc = "The Necrotic Wake - Zolramus Bonemender",
+                        [335143] = "Bonemend",
+                    },
+                    [207939] = {
+                        desc = "Priory of the Sacred Flame - Baron Braunpyke",
+                        [423051] = "Burning Light",
+                    },
+                    [207946] = {
+                        desc = "Priory of the Sacred Flame - Captain Dailcry",
+                        [424419] = "Battle Cry",
+                    },
+                    [211289] = {
+                        desc = "Priory of the Sacred Flame - Taener Duelmal",
+                        [424420] = "Cinderblast",
+                    },
+                    [208745] = {
+                        desc = "Darkflame Cleft - The Candle King",
+                        [426145] = "Paranoid Mind",
+                    },
+                    [212389] = {
+                        desc = "The Stonevault - Cursedheart Invader",
+                        [426283] = "Arcing Void",
+                    },
+                    [212403] = {
+                        desc = "The Stonevault - Cursedheart Invader",
+                        [426283] = "Arcing Void",
+                    },
+                    [212412] = {
+                        desc = "Darkflame Cleft - Sootsnout",
+                        [426295] = "Flaming Tether",
+                    },
+                    [208747] = {
+                        desc = "Darkflame Cleft - The Darkness",
+                        [427157] = "Call Darkspawn",
+                    },
+                    [206697] = {
+                        desc = "Priory of the Sacred Flame - Devout Priest",
+                        [427356] = "Greater Heal",
                     },
                     [83893] = {
                         desc = "The Everbloom - Earthshaper Telu",
                         [427460] = "Toxic Bloom",
                     },
-                    [40943] = {
-                        desc = "Throne of the Tides - Gilgoblin Aquamage",
-                        [429176] = "Aquablast",
+                    [213338] = {
+                        desc = "The Stonevault - Forgebound Mender",
+                        [429109] = "Restoring Metals",
                     },
-
-                    [187771] = {
-                        desc = "Vault of the Incarnates - Kadros Icewrath",
-                        [372315] = "Frost Spike",
+                    [224962] = {
+                        desc = "The Stonevault - Cursedforge Mender",
+                        [429109] = "Restoring Metals",
                     },
-                    [187768] = {
-                        desc = "Vault of the Incarnates - Dathea Stormlash",
-                        [372394] = "Lightning Bolt",
+                    [214350] = {
+                        desc = "The Stonevault - Turned Speaker",
+                        [429545] = "Censoring Gear",
                     },
-                    [190686] = {
-                        desc = "Vault of the Incarnates - Frozen Destroyer",
-                        [374623] = "Frost Binds",
+                    [223469] = {
+                        desc = "The Ringing Deeps - Voidtouched Speaker",
+                        [429545] = "Censoring Gear",
                     },
-                    [191232] = {
-                        desc = "Vault of the Incarnates - Drakonid Stormbringer",
-                        [375653] = "Static Jolt",
+                    [214421] = {
+                        desc = "The Rookery - Coalescing Void Diffuser",
+                        [430805] = "Arcing Void",
                     },
-                    [191206] = {
-                        desc = "Vault of the Incarnates - Primalist Mage",
-                        [375716] = "Ice Barrage",
+                    [213892] = {
+                        desc = "The Dawnbreaker - Nightfall Shadowmage",
+                        [431309] = "Ensnaring Shadows",
                     },
-                    [194647] = {
-                        desc = "Vault of the Incarnates - Thunder Caller",
-                        [384273] = "Storm Bolt",
+                    [228540] = {
+                        desc = "The Dawnbreaker - Nightfall Shadowmage",
+                        [431309] = "Ensnaring Shadows",
                     },
-                    [194990] = {
-                        desc = "Vault of the Incarnates - Stormseeker Acolyte",
-                        [385553] = "Storm Bolt",
+                    [213893] = {
+                        desc = "The Dawnbreaker - Nightfall Darkcaster",
+                        [431333] = "Tormenting Beam",
                     },
-                    [199233] = {
-                        desc = "Vault of the Incarnates - Flamescale Captain",
-                        [396040] = "Pyroblast",
+                    [225605] = {
+                        desc = "The Dawnbreaker - Nightfall Darkcaster",
+                        [431333] = "Tormenting Beam",
                     },
-                    [199703] = {
-                        desc = "Aberrus, the Shadowed Crucible - Magma Mystic",
-                        [397386] = "Lava Bolt",
+                    [228539] = {
+                        desc = "The Dawnbreaker - Nightfall Darkcaster",
+                        [431333] = "Tormenting Beam",
                     },
-                    [202971] = {
-                        desc = "Aberrus, the Shadowed Crucible - Null Glimmer",
-                        [404754] = "Blasting Scream",
+                    [212793] = {
+                        desc = "The Rookery - Void Ascendant",
+                        [432959] = "Void Volley",
                     },
-                    [201288] = {
-                        desc = "Aberrus, the Shadowed Crucible - Sundered Champion",
-                        [406911] = "Brutal Cauterization",
+                    [216364] = {
+                        desc = "Ara-Kara, City of Echoes - Blood Overseer",
+                        [433841] = "Venom Volley",
                     },
-                    [205619] = {
-                        desc = "Aberrus, the Shadowed Crucible - Sarek Cinderbreath",
-                        [406911] = "Brutal Cauterization",
+                    [216293] = {
+                        desc = "Ara-Kara, City of Echoes - Trilling Attendant",
+                        [434793] = "Resonant Barrage",
                     },
-                    [202969] = {
-                        desc = "Aberrus, the Shadowed Crucible - Empty Recollection",
-                        [411302] = "Cosmic Volley",
+                    [217531] = {
+                        desc = "Ara-Kara, City of Echoes - Ixin",
+                        [434802] = "Horrifying Shrill",
                     },
-                    [210290] = {
-                        desc = "Amirdrassil, the Dream's Hope - Firelands Flameguard",
-                        [425381] = "Blazing Pulse",
+                    [217533] = {
+                        desc = "Ara-Kara, City of Echoes - Atik",
+                        [436322] = "Poison Bolt",
                     },
-                    [211904] = {
-                        desc = "Amirdrassil, the Dream's Hope - Tainted Treant",
-                        [425816] = "Blazing Pollen",
+                    [218671] = {
+                        desc = "Cinderbrew Meadery - Venture Co. Pyromaniac",
+                        [437721] = "Boiling Flames",
                     },
-                    [210423] = {
-                        desc = "Amirdrassil, the Dream's Hope - Keeper of the Dream",
-                        [425995] = "Tranquility",
+                    [220141] = {
+                        desc = "Cinderbrew Meadery - Royal Jelly Purveyor",
+                        [440687] = "Honey Volley",
                     },
-                    [208459] = {
-                        desc = "Amirdrassil, the Dream's Hope - Fiery Treant",
-                        [426524] = "Fiery Flourish",
+                    [214673] = {
+                        desc = "Cinderbrew Meadery - Flavor Scientist",
+                        [441627] = "Rejuvenating Honey",
+                    },
+                    [222964] = {
+                        desc = "Cinderbrew Meadery - Flavor Scientist",
+                        [441627] = "Rejuvenating Honey",
+                    },
+                    [220599] = {
+                        desc = "Ara-Kara, City of Echoes - Bloodstained Webmage",
+                        [442210] = "Silken Restraints",
+                    },
+                    [223844] = {
+                        desc = "City of Threads - Covert Webmancer",
+                        [442536] = "Grimweave Blast",
+                        [452162] = "Mending Web",
+                    },
+                    [224732] = {
+                        desc = "City of Threads - Covert Webmancer",
+                        [442536] = "Grimweave Blast",
+                        [452162] = "Mending Web",
+                    },
+                    [220195] = {
+                        desc = "City of Threads - Sureki Silkbinder",
+                        [443430] = "Silk Binding",
+                    },
+                    [220196] = {
+                        desc = "City of Threads - Herald of Ansurek",
+                        [443433] = "Twist Thoughts",
+                    },
+                    [221760] = {
+                        desc = "Priory of the Sacred Flame - Risen Mage",
+                        [444743] = "Fireball Volley",
+                    },
+                    [221979] = {
+                        desc = "The Stonevault - Void Bound Howler",
+                        [445207] = "Piercing Wail",
+                    },
+                    [220401] = {
+                        desc = "City of Threads - Pale Priest",
+                        [448047] = "Web Wrap",
+                    },
+                    [223253] = {
+                        desc = "Ara-Kara, City of Echoes - Bloodstained Webmage",
+                        [448248] = "Revolting Volley",
+                    },
+                    [212453] = {
+                        desc = "The Stonevault - Ghastly Voidsoul",
+                        [449455] = "Howling Fear",
+                    },
+                    [214762] = {
+                        desc = "The Dawnbreaker - Nightfall Commander",
+                        [450756] = "Abyssal Howl",
+                    },
+                    [213932] = {
+                        desc = "The Dawnbreaker - Sureki Militant",
+                        [451097] = "Silken Shell",
+                    },
+                    [224219] = {
+                        desc = "Grim Batol - Twilight Earthcaller",
+                        [451871] = "Mass Tremor",
+                    },
+                    [135241] = {
+                        desc = "Siege of Boralus - Bilge Rat Pillager",
+                        [454440] = "Stinky Vomit",
                     },
                 },
 


### PR DESCRIPTION
Updated the interrupt filter with TWW Season 1. Spells taken from Quazii's spreadsheet:

https://docs.google.com/spreadsheets/d/1UvpHuRCzj56DI7nheQWOtMC4sCsY0fBtUaBYHh-Y5gQ/edit?gid=0#gid=0

Attached the script to generate the LUA table as well for your reference. 

[generate_spell_id_table.zip](https://github.com/user-attachments/files/16997754/generate_spell_id_table.zip)
