### PR TITLE
Restoration Shaman: Healing Helper Mode

### DIFF
--- a/TheWarWithin/Priorities/ShamanRestoration.simc
+++ b/TheWarWithin/Priorities/ShamanRestoration.simc
@@ -31,7 +31,7 @@ actions+=/frost_shock,moving=1
 actions.healing+=/downpour,if=buff.unleash_life.up|buff.downpour.up&buff.downpour.remains<2
 actions.healing+=/mana_tide_totem,if=mana.pct<85
 actions.healing+=/totemic_recall,if=prev_gcd.earthen_wall_totem
-actions.healing+=/earthen_wall_totem,if=
+actions.healing+=/earthen_wall_totem
 actions.healing+=/chain_heal,if=buff.high_tide.up
 actions.healing+=/run_action_list,name=unleash,if=buff.unleash_life.up
 actions.healing+=/surging_totem

--- a/TheWarWithin/Priorities/ShamanRestoration.simc
+++ b/TheWarWithin/Priorities/ShamanRestoration.simc
@@ -9,7 +9,7 @@ actions.precombat+=/potion
 actions+=/spiritwalkers_grace,moving=1,if=movement.distance>6
 # Interrupt of casts.
 actions+=/wind_shear
-actions+=/run_action_list,name=healing,if=settings.healing_mode
+actions+=/call_action_list,name=healing,strict=1,if=settings.healing_mode
 actions+=/potion
 actions+=/use_items
 actions+=/blood_fury
@@ -20,7 +20,7 @@ actions+=/bag_of_tricks
 actions+=/surging_totem,if=talent.acid_rain
 actions+=/healing_rain,if=!moving&talent.acid_rain
 actions+=/flame_shock,cycle_targets=1,if=active_enemies<3&refreshable
-actions+=/primordial_wave
+# actions+=/primordial_wave
 actions+=/lava_burst,if=(active_enemies=1|active_enemies=2&buff.lava_surge.up)&dot.flame_shock.remains>cast_time&cooldown_react
 actions+=/earth_elemental
 actions+=/lightning_bolt,if=spell_targets.chain_lightning<2|!talent.chain_lightning
@@ -33,7 +33,7 @@ actions.healing+=/mana_tide_totem,if=mana.pct<85
 actions.healing+=/totemic_recall,if=prev_gcd.earthen_wall_totem
 actions.healing+=/earthen_wall_totem
 actions.healing+=/chain_heal,if=buff.high_tide.up
-actions.healing+=/run_action_list,name=unleash,if=buff.unleash_life.up
+actions.healing+=/call_action_list,strict=1,name=unleash,if=buff.unleash_life.up
 actions.healing+=/surging_totem
 actions.healing+=/healing_rain
 actions.healing+=/earth_shield,if=active_dot.earth_shield<1+talent.elemental_orbit.rank&buff.earth_shield.up

--- a/TheWarWithin/Priorities/ShamanRestoration.simc
+++ b/TheWarWithin/Priorities/ShamanRestoration.simc
@@ -1,13 +1,15 @@
 actions.precombat+=/earthliving_weapon
-actions.precombat+=/water_shield,if=buff.water_shield.up+buff.earth_shield.up+buff.lightning_shield.up<1+talent.elemental_orbit.rank
-actions.precombat+=/lightning_shield,if=buff.water_shield.up+buff.earth_shield.up+buff.lightning_shield.up<1+talent.elemental_orbit.rank
-actions.precombat+=/earth_shield,if=buff.water_shield.up+buff.earth_shield.up+buff.lightning_shield.up<1+talent.elemental_orbit.rank
+actions.precombat+=/tidecallers_guard
+actions.precombat+=/water_shield,if=buff.water_shield.up+buff.earth_shield.up+buff.lightning_shield.up<1+talent.elemental_orbit.rank|(!buff.water_shield.up&settings.healing_mode)
+actions.precombat+=/lightning_shield,if=(buff.water_shield.up+buff.earth_shield.up+buff.lightning_shield.up<1+talent.elemental_orbit.rank)&settings.second_shield=lightning_shield
+actions.precombat+=/earth_shield,if=(buff.water_shield.up+buff.earth_shield.up+buff.lightning_shield.up<1+talent.elemental_orbit.rank)&settings.second_shield=earth_shield
 actions.precombat+=/earth_elemental
 actions.precombat+=/potion
 
 actions+=/spiritwalkers_grace,moving=1,if=movement.distance>6
 # Interrupt of casts.
 actions+=/wind_shear
+actions+=/run_action_list,name=healing,if=settings.healing_mode
 actions+=/potion
 actions+=/use_items
 actions+=/blood_fury
@@ -18,10 +20,29 @@ actions+=/bag_of_tricks
 actions+=/surging_totem,if=talent.acid_rain
 actions+=/healing_rain,if=!moving&talent.acid_rain
 actions+=/flame_shock,cycle_targets=1,if=active_enemies<3&refreshable
-# actions+=/primordial_wave
+actions+=/primordial_wave
 actions+=/lava_burst,if=(active_enemies=1|active_enemies=2&buff.lava_surge.up)&dot.flame_shock.remains>cast_time&cooldown_react
 actions+=/earth_elemental
 actions+=/lightning_bolt,if=spell_targets.chain_lightning<2|!talent.chain_lightning
 actions+=/chain_lightning,if=spell_targets.chain_lightning>1
 actions+=/flame_shock,moving=1
 actions+=/frost_shock,moving=1
+
+actions.healing+=/downpour,if=buff.unleash_life.up|buff.downpour.up&buff.downpour.remains<2
+actions.healing+=/mana_tide_totem,if=mana.pct<85
+actions.healing+=/totemic_recall,if=prev_gcd.earthen_wall_totem
+actions.healing+=/earthen_wall_totem,if=
+actions.healing+=/chain_heal,if=buff.high_tide.up
+actions.healing+=/run_action_list,name=unleash,if=buff.unleash_life.up
+actions.healing+=/surging_totem
+actions.healing+=/healing_rain
+actions.healing+=/earth_shield,if=active_dot.earth_shield<1+talent.elemental_orbit.rank&buff.earth_shield.up
+actions.healing+=/earth_shield,if=(!buff.earth_shield.up&settings.second_shield=earth_shield&talent.elemental_orbit.enabled)
+actions.healing+=/healing_stream_totem,if=totem.surging_totem.up&!totem.healing_stream_totem.up
+actions.healing+=/riptide,if=cooldown.riptide.charges=cooldown.riptide.charges_max
+actions.healing+=/unleash_life,if=talent.call_of_the_ancestors.enabled|cooldown.wellspring.remains<2|(cooldown.surging_totem.remains<3|buff.downpour.up&buff.downpour.remains>3)
+actions.healing+=/wellspring
+
+actions.unleash+=/downpour
+actions.unleash+=/wellspring
+actions.unleash+=/riptide

--- a/TheWarWithin/ShamanRestoration.lua
+++ b/TheWarWithin/ShamanRestoration.lua
@@ -430,7 +430,7 @@ spec:RegisterAbilities( {
             removeBuff( "swelling_rain" ) -- T30
             removeStack( "natures_swiftness" )
             removeStack( "ancestral_swiftness" )
-            removeStack ( "high_tide" )
+            removeStack( "high_tide" )
 
             if set_bonus.tier31_2pc > 0 then applyDebuff( "target", "tidal_reservoir" ) end
         end,
@@ -936,8 +936,11 @@ spec:RegisterAbilities( {
 
         handler = function ()
             summonTotem( "surging_totem" )
-            setCooldown( "downpour", 0 )
-            if talent.downpour.enabled then applyBuff( "downpour" ) end
+            
+            if talent.downpour.enabled then
+                setCooldown( "downpour", 0 )
+                applyBuff( "downpour" )
+            end
         end,
 
         bind = { "healing_rain", "downpour" }
@@ -966,8 +969,7 @@ spec:RegisterAbilities( {
         cooldown = function() return talent.call_of_the_elements.enabled and 120 or 180 end,
         gcd = "spell",
         school = "nature",
-        toggle = "cooldowns",
-
+        toggle = function() if settings.healing_mode then return "cooldowns" end end,
         talent = "totemic_recall",
         startsCombat = false,
 
@@ -1064,7 +1066,7 @@ spec:RegisterSetting( "experimental_msg", nil, {
 
 spec:RegisterSetting( "healing_mode", false, {
     name = "Healing Helper Mode",
-    desc = "Restoration Shaman currently has support for some basic healing maintenance with the totemic chain heal build. It will not necessarily tell you how to heal, but will assist with keeping healing rain / surging totem up, stop you from overcapping on riptide and healing stream totem, use unleash life on CD with good spells and maintain your earth shields.",
+    desc = "This setting turns healing mode on and off, as described above.",
     type = "toggle",
     width = "normal",
 } )

--- a/TheWarWithin/ShamanRestoration.lua
+++ b/TheWarWithin/ShamanRestoration.lua
@@ -208,7 +208,7 @@ spec:RegisterAuras( {
     -- https://wowhead.com/beta/spell=73920
     healing_rain = {
         id = 73920,
-        duration = 10,
+        duration = function () return 24 and talent.surging_totem.enabled or 10 end,
         max_stack = 1
     },
     master_of_the_elements = {
@@ -485,7 +485,7 @@ spec:RegisterAbilities( {
     -- A burst of water at your Healing Rain's location heals up to 5 injured allies within 12 yards for (275% of Spell power) and increases their maximum health by 10% for 6 sec.
     downpour = {
         id = 462603,
-        known = function() return talent.downpour.enabled and 73920 or nil end,
+        known = 73920,
         cast = 0,
         cooldown = function() return talent.surging_totem.enabled and 24 or 10 end,
         gcd = "off",
@@ -496,6 +496,7 @@ spec:RegisterAbilities( {
         startsCombat = false,
         texture = 1698701,
         buff = "downpour",
+        talent = "downpour",
 
         handler = function ()
             removeBuff( "downpour" )
@@ -649,11 +650,13 @@ spec:RegisterAbilities( {
         notalent = "surging_totem",
 
         handler = function ()
-            setCooldown( "downpour", 0 )
+            
             applyBuff( "healing_rain" )
 
-            if talent.downpour.enabled then applyBuff( "downpour" ) end
-
+            if talent.downpour.enabled then 
+                applyBuff( "downpour" )
+                setCooldown( "downpour", 0 )
+            end
             if set_bonus.tier30_4pc > 0 and active_dot.riptide > 0 then
                 applyBuff( "rainstorm", nil, active_dot.riptide )
                 applyBuff( "swelling_rain", nil, active_dot.riptide )

--- a/TheWarWithin/ShamanRestoration.lua
+++ b/TheWarWithin/ShamanRestoration.lua
@@ -328,6 +328,14 @@ spec:RegisterStateExpr( "recall_totem_2", function()
     return recallTotem2
 end )
 
+spec:RegisterStateExpr( "earth_shield", function()
+    return "earth_shield"
+end )
+
+spec:RegisterStateExpr( "lightning_shield", function()
+    return "lightning_shield"
+end )
+
 spec:RegisterHook( "reset_precast", function ()
     local mh, _, _, mh_enchant, oh, _, _, oh_enchant = GetWeaponEnchantInfo()
 
@@ -422,6 +430,7 @@ spec:RegisterAbilities( {
             removeBuff( "swelling_rain" ) -- T30
             removeStack( "natures_swiftness" )
             removeStack( "ancestral_swiftness" )
+            removeStack ( "high_tide" )
 
             if set_bonus.tier31_2pc > 0 then applyDebuff( "target", "tidal_reservoir" ) end
         end,
@@ -478,7 +487,7 @@ spec:RegisterAbilities( {
         id = 462603,
         known = function() return talent.downpour.enabled and 73920 or nil end,
         cast = 0,
-        cooldown = 10, -- ???
+        cooldown = function() return talent.surging_totem.enabled and 24 or 10 end,
         gcd = "off",
 
         spend = 0.03,
@@ -640,6 +649,7 @@ spec:RegisterAbilities( {
         notalent = "surging_totem",
 
         handler = function ()
+            setCooldown( "downpour", 0 )
             applyBuff( "healing_rain" )
 
             if talent.downpour.enabled then applyBuff( "downpour" ) end
@@ -926,6 +936,7 @@ spec:RegisterAbilities( {
 
         handler = function ()
             summonTotem( "surging_totem" )
+            setCooldown( "downpour", 0 )
             if talent.downpour.enabled then applyBuff( "downpour" ) end
         end,
 
@@ -955,6 +966,7 @@ spec:RegisterAbilities( {
         cooldown = function() return talent.call_of_the_elements.enabled and 120 or 180 end,
         gcd = "spell",
         school = "nature",
+        toggle = "cooldowns",
 
         talent = "totemic_recall",
         startsCombat = false,
@@ -1038,13 +1050,26 @@ spec:RegisterAbilities( {
 } )
 
 
-spec:RegisterSetting( "experimental_msg", nil, {
+--[[spec:RegisterSetting( "experimental_msg", nil, {
     type = "description",
     name = "|cFFFF0000WARNING|r:  Healer support in this addon is focused on DPS output only.  This is more useful for solo content or downtime when your healing output is less critical in a group/encounter.  Use at your own risk.",
     width = "full",
+} )--]]
+
+spec:RegisterSetting( "experimental_msg", nil, {
+    type = "description",
+    name = "Restoration Shaman currently has support for some basic healing maintenance with the totemic chain heal build. It will not necessarily tell you how to heal, but will assist with keeping healing rain / surging totem up, stop you from overcapping on riptide and healing stream totem, use unleash life on CD with good spells and maintain your earth shields.",
+    width = "full",
 } )
 
---[[spec:RegisterSetting( "second_shield", "earth_shield", {
+spec:RegisterSetting( "healing_mode", false, {
+    name = "Healing Helper Mode",
+    desc = "Restoration Shaman currently has support for some basic healing maintenance with the totemic chain heal build. It will not necessarily tell you how to heal, but will assist with keeping healing rain / surging totem up, stop you from overcapping on riptide and healing stream totem, use unleash life on CD with good spells and maintain your earth shields.",
+    type = "toggle",
+    width = "normal",
+} )
+
+spec:RegisterSetting( "second_shield", "earth_shield", {
     name = "|T136082:0|t Preferred 2nd shield",
     desc = "Specify which shield you want to use alongside water shield when you have talented into Elemental Orbit",
     type = "select",
@@ -1055,7 +1080,7 @@ spec:RegisterSetting( "experimental_msg", nil, {
         }
     end,
     width = "normal"
-} )--]]
+} )
 
 spec:RegisterRanges( "lightning_bolt", "flame_shock", "wind_shear", "primal_strike" )
 
@@ -1079,4 +1104,4 @@ spec:RegisterOptions( {
 } )
 
 
-spec:RegisterPack( "Restoration Shaman", 20240901, [[Hekili:nBv3UnUnt0NLGc4KGKv1soRZUfX5I2BAck2lQwGENKOLgztykrvsQ4gad9S)nKYwIK(NDX3n7IaK4mZXhE4mdpKjHjFnjUGOGKVenn6HPFEAuW0WOWOzjXQ3BGK4gs(gYk8d1Kk83)nivCbrr51DzXRjvKAnM3zCsHMljVvKJ4sIx2szQxQtw6SapoBkcQbYX)F(djXRPffqpiqMNeRb9HPp(Hzt)TUSVUg6Y(hIa)fvTMQxjbVKYq(j5AjidAeqoVAjrD3IFfic1Ag9nA9Q0TaPbL4RNc3wuoIu5AkWkUNwUyzBzzGDWG2M7mbnm6hKrxTwvRxKHepfENIWGAvaWGk8VewkxSKQceK6nNwf(08Jtj2C)Jwfd4pnOgUzY71HSymzdvqvBjSnGqMUsqYH7R46PGfH6Td(zdNbfuPIuNdppV71FPl7LAChkABuDz8YUSCIujdSjElTUa3tOWSJEqcJrALqkvbvs7GlzCErAzR4DNOOebXguB2rlPcWG3oOwPsLaRC5egZHeYQuEzQsqZ34SMOuz6(GGqR178R6ldt23li50ctoN1MHNRXDjpFZ95VNZGufrScuY(INg4Bqkudvuq(0SjcOuaY1KLmWufTkmcAfxuqrfVL8gyVimYBK0LTcPsZ5nUKUiC3oVirt6NS0FnzlkhCM62jfCvGLCdeqfUzKpR7CPkAfmjNZzf8T1Pcaz0wbNB6Y5G4soZiq0FIXouhcYxJRs6aQNI2T7Q9vuVu2S6L6Bs7ZHNRRCyw2jVGJ7z38jXVHtxiaBR2TeHMDzsSXmLw1Wf4aFjhnvVUakjTm11Dzc4FBXHWIUmjVcXrAv8k0badG6SEfOpz8x0AmvO2z(p414IzYFT)0fsNIFI4bqTEQPaZFt4)D7iHpCAc9kqE06L9yY7E9fZMvtz0H50UmgT)yoEfsRAnxKe)NWgkJMeBYyUpSVSGF8lM7h3tDYVF4JP9LCDGC06beuss8r2mDzp3Ln3Kqdg5A)Tw6lapYYkrHTnVvtFLOG20)DoPD1iLJMvAMMPz6qQEhlBMrepyJyWbZd0hTbn6O5HAUdQbhopupAJAWXZd0NSb56a6H8ZolQTJOhWWPhAKkNI7qVa9x0h(vCSay3qp38RHu)bJVJV2WkABtBiZVVpsMRVyx2tDzZ6YMOpWoydBvvhDnqsSnZ1fa9kn7sty7Txc2p)FSLUTYUP)iLT4wGNL7Y2T7KzImY(yB9USBnzoJ5U5q0GbVbPRj)4UF8sgZw1za3Z(3Fe5JNTbCrpBt)iQFlFfApDrNjlH6CHJraZ))vay1XYxXlTHAZ5olpOJSWo50JB95tF3CmEVKlhk9B33)oUbJvNUJZd39eW5pGCQ3Q2LD3(jnV3RoM4eVz10mdnqUWBxTmCTw0bl3FY0Opfdg))KPtBUp6ENlF2D(36MUd)K8)c]] )
+spec:RegisterPack( "Restoration Shaman", 20240916, [[Hekili:vJ1sVnUnq4FlgfWBcsQAKZZTiohAV0nOypuVa9MKOLOTjIKOlfv8gad9BVZq9IKIsRtrxu0ljYCgoV4mFC4e4h8LGvjejn4ZlUAXnx9r)788xCZd(3hSs(2EAWQ9K4xiBHpYjzWF)dAHKlisgpVkA1osgjh55TuojbLvbVued8fSADjlv(P8G1UuWT3ChW7EAmS8D3eSAhljHwZlTioyfY7pE19)41x9ZvrFzhTk6pjc4pm5ogQqbFdlfudjgTKcV9cAmpBnrEXYFIseYDPSxz5Bdpqj7bl9zx8jzj0ysAkvueUTKisCZ2bW4fHf7y00KlzBwUUCZgp9f9k3FHArLITxmLTDNmhTLocp6FHKKsZLE0uAg8FsAixSMj9eK8xoE8SzU0X8cQucYPWBhLKIcmJNqp3TrBRv0Wp77TLFEVjwaMsEsZgxAlj32SUr8FR9Ql(PS1oH6MP9CvzYZDuH1k2Zem5bs6lQ0objMEzghZvx6Jon8TsMEjScjjpM(0Dvp)dFkhccIY9YQi(MQOysHSWtxShykRhml9vfL5H1)kmfe3Lyj8YMShuzoZO0fqRh0VszbnKjPzf6lUoLZtc3ukEZyvWdPIxa5QV6gMGQ4xFr0rlKc40blineczBiFtOuWIFXqNfLITOjl5G1GotZbnjMLekimdRU1)W1rENvhYNp1E2KcrliMYJF5Y43ItPHsIylvwuFqHm(knKMtZy0IhVEUGUrql2rwNAgcfSmUiHb(2bYRgKsjVscxxkGtgmD3uIl9pE0ALfZRZZXTHUpfYWpFEcx6PzREcAg4jfpHjjHswgDEmNNMWpKhkOGe1TGXsJnqqwZtvgiaxNM2ge8I3bAjSJRhxC84SMWPfjDPAr6Bk2N8h7iPTOXGUGd(Sn9(IZM0aGtmCShUQQdqVmpLsk2bAEdgwpEuTAlBi8R5cnr5hx4s6WLIKq86L(StCjV9XYhF4wx7qXhlgoHWcaCdaqYRHBJtQX6O5q2dgMq(CjGHCHcXfN1ry83Do)oiCRSxWpDTfN4inrSXIGUKJrnRlg0Rth1l1UIOPablb0jnnS)CxxHCkAR5EzRDEkxImFeZHMJWfjNpvSaWfPKmnCo8dpJqjAfZQ)Y1Ug7uLThpZrz2Iq41Sgwgc1JfJsimJ8vxYupjqdugtQvW47OH1y9CrrR3F8yNwoaqbfaIz(2(cmOFOo6MEDllxFQvRpDTZiDVw1blACfnWcx0037qQnrTGvVc3fc0ABc(k)GvhiceHRiyLQ)ww2EUaUFFdh6Z9dj0nKYu5hQIe0)QeUYmPkQGNb8rkL8mONiyb4SiholGgb(DwoqY3hAw(x55GYu0)G91BG4KChR3Esa0pZ)RN3lWf)BlW7DlqluFlXArDOWRE(tQOhkYBGqK6COkcXQWOtWk1x4Zt6Apd(XNvp(PM5GvdF1aSwTIc(LajCYPZ9G3oyX81iZ9RSkgA6Jkye8zrdBQTk6IQiNOsDeC0CBv0JqevXYeODvrhpcbQQOznsAGUNdPwoBem68EhwFxOdEZOo4zJPNVN(45MUHbsCv0smxWu29E2akG3D7)Z8oDLALsR5v3niFVV1pR8371zT(vaMCiH3SxNR0vjnE6UDRbQusBiBLp6e2wfMw0BpT07QkDQ52oUu7(HB73Uv3ztxUorByAObgDVnD5H1jGPeNm1BqRA9IQVNUUZ5t(0OxkwT5vdBgwp3NMnni3W4gzRKOh0zuV1ol((iYxmzFnJq04TrYH18Kr687uROM7UA1YW8VYWYkOPB(2wMgu7aSGtVkwX70DnQWNnT3XRdD31OslZWBBNO3XHNH6mO074vHJ1aPYHNQ7sT0YMMOqfnEH6P0PznWZeDBwJ00DL509DQy(63py2tQDPD3QEbPYlVrVWP3khGa30LOle46pdRFfSfWO9iMuM0DA10dNrLAxOKafz3lu)SNo5MGC2VXPbe1ERtli7uxsvdM2fMBhDLftgxl2pkRPUrSF0wtb51nQlx4DTmzo6lNaqDAvFwyVJs)rAoFmq8PlOb0I6ubDeQjKTbUVRs4UOv)WDCa03mdS2AU54dJ6M3gWV(a6AssnlJSMdND4BYo(STHLQ7yW6Ehuw0x7BmPU224gzEDQIWUz2P40CUD9Us)CdvM(7OTo)7hVKCQXWPJloR7uFK3LPzOgZquzap8p1aGOJVDdpDKvIwvw1dtnec0zMMr8zXvNSm6h14ay52ELSFIzxFRwk9uq7RbtTVs0sZyosPChh0WVrFHLYuRf83)]] )


### PR DESCRIPTION
### RestoSham Healing Mode
Adds a spec option that modifies the rotation to help with basic healing rotation maintenance. This feature is opt-in (disabled by default).

- Note: All healing spells will not tell you **_who_** to cast on, that is beyond the scope of the addon and you will need to make those decisions yourself
- Forcefully maintain water shield at all times, and earth shield > lightning shield on yourself when using elemental orbit
- Maintain earth shield on an ally
- Support for earthen > recall > earthen totem combo
- Indicates super buffed chain heal
- Maintain Surging Totem (or healing rain)
- Do not cap on Riptide or Heal Stream charges
- Use unleash life, combo with Downpour > Wellspring > Riptide
- Use downpour if it's about to expire
- Cast wellspring if nothing else to do
- Mana tide totem when under 85% mana
- Continue on with standard resto DPS rotation

![image](https://github.com/user-attachments/assets/36ab49cf-599b-40c0-b843-64c85d86cee7)


### Other Rsham fixes/changes
- Downpour CD stuff
- added the new shield imbue, Tidecaller's Guard
- Spec option to choose which 2nd shield you want when specced into elemental orbit talent