### PR TITLE
fix: properly account for Vivacious Vivification for monk

### DIFF
--- a/TheWarWithin/MonkBrewmaster.lua
+++ b/TheWarWithin/MonkBrewmaster.lua
@@ -1740,14 +1740,18 @@ spec:RegisterAbilities( {
     -- Causes a surge of invigorating mists, healing the target for $<healing>$?s274586[ and all allies with your Renewing Mist active for $425804s1, reduced beyond $274586s1 allies][].
     vivify = {
         id = 116670,
-        cast = 1.3,
+        cast = function() return buff.vivacious_vivification.up and 0 or 1.5 end,
         cooldown = 0.0,
         gcd = "spell",
 
-        spend = 30,
+        spend = function() return buff.vivacious_vivification.up and 7.5 or 30 end,
         spendType = 'energy',
 
         startsCombat = false,
+
+        handler = function ()
+            removeBuff( "vivacious_vivification" )
+        end,
     },
 
     -- For the next 30 sec, your Mastery is increased by 10%. Additionally, Keg Smash cooldown is reset instantly and enemies hit by Keg Smash take 8% increased damage from you for 10 sec, stacking up to 4 times.

--- a/TheWarWithin/MonkMistweaver.lua
+++ b/TheWarWithin/MonkMistweaver.lua
@@ -1117,7 +1117,7 @@ spec:RegisterAbilities( {
 
     vivify = {
         id = 116670,
-        cast = 1.5,
+        cast = function() return buff.vivacious_vivification.up and 0 or 1.5 end,
         cooldown = 0,
         gcd = function()
             return buff.soothing_mist.up and "totem" or "spell"
@@ -1125,7 +1125,7 @@ spec:RegisterAbilities( {
 
         spend = function()
             if buff.tea_of_serenity_v.up then return 0 end
-            return 0.03 * ( buff.mana_tea.up and 0.5 or 1 )
+            return 0.03 * ( buff.mana_tea.up and 0.5 or 1 ) * ( buff.vivacious_vivification.up and 0.25 or 1 )
         end,
         spendType = "mana",
 

--- a/TheWarWithin/MonkWindwalker.lua
+++ b/TheWarWithin/MonkWindwalker.lua
@@ -2032,8 +2032,8 @@ spec:RegisterAbilities( {
         gcd = "spell",
         school = "nature",
 
-        spend = 0.038,
-        spendType = "mana",
+        spend = function() return buff.vivacious_vivification.up and 2 or 8 end,
+        spendType = "energy",
 
         startsCombat = false,
 


### PR DESCRIPTION
The Vivacious Vivification monk class talent makes the next Vivify instant and reduces its cost by 75%. Properly remove the buff when Vivify is cast and add functions for "cast" and "spend" to account for the buff.