### PR TITLE
Refactor Arms Warrior APL: Remove raid events, fix typo

### DIFF
--- a/TheWarWithin/Priorities/WarriorArms.simc
+++ b/TheWarWithin/Priorities/WarriorArms.simc
@@ -26,7 +26,7 @@ actions+=/ancestral_call,if=debuff.colossus_smash.up
 ## actions+=/invoke_external_buff,name=power_infusion,if=debuff.colossus_smash.up&fight_remains>=135|variable.execute_phase&buff.avatar.up|fight_remains<=25
 actions+=/run_action_list,name=colossus_aoe,strict=1,if=talent.demolish&active_enemies>2
 actions+=/run_action_list,name=colossus_execute,cycle_targets=1,strict=1,if=talent.demolish&variable.execute_phase
-actions+=/run_action_list,name=colossus_sweep,srtict=1,if=talent.demolish&active_enemies=2&!variable.execute_phase
+actions+=/run_action_list,name=colossus_sweep,strict=1,if=talent.demolish&active_enemies=2&!variable.execute_phase
 actions+=/run_action_list,name=colossus_st,strict=1,if=talent.demolish
 actions+=/run_action_list,name=slayer_aoe,strict=1,if=!talent.demolish&active_enemies>2
 actions+=/run_action_list,name=slayer_execute,cycle_targets=1,strict=1,if=!talent.demolish&variable.execute_phase
@@ -37,7 +37,7 @@ actions.colossus_st+=/rend,if=dot.rend.remains<=gcd
 actions.colossus_st+=/thunderous_roar
 actions.colossus_st+=/champions_spear
 actions.colossus_st+=/ravager,if=cooldown.colossus_smash.remains<=gcd
-actions.colossus_st+=/avatar,if=raid_event.adds.in>15
+actions.colossus_st+=/avatar,if=active_enemies=1
 actions.colossus_st+=/colossus_smash
 actions.colossus_st+=/warbreaker
 actions.colossus_st+=/mortal_strike
@@ -206,6 +206,6 @@ actions.trinkets+=/use_item,slot=trinket2,if=!variable.trinket_2_buffs&(trinket.
 actions.trinkets+=/use_item,slot=main_hand,if=!equipped.fyralath_the_dreamrender&(!variable.trinket_1_buffs|trinket.1.cooldown.remains)&(!variable.trinket_2_buffs|trinket.2.cooldown.remains)
 
 # Variables
-actions.variables+=/variable,name=st_planning,value=active_enemies=1&(raid_event.adds.in>15|!raid_event.adds.exists)
-actions.variables+=/variable,name=adds_remain,value=active_enemies>=2&(!raid_event.adds.exists|raid_event.adds.exists&raid_event.adds.remains>5)
+actions.variables+=/variable,name=st_planning,value=active_enemies=1
+actions.variables+=/variable,name=adds_remain,value=active_enemies>=2
 actions.variables+=/variable,name=execute_phase,value=(talent.massacre.enabled&target.health.pct<35)|target.health.pct<20

--- a/TheWarWithin/Priorities/WarriorFury.simc
+++ b/TheWarWithin/Priorities/WarriorFury.simc
@@ -17,7 +17,7 @@ actions.precombat+=/variable,name=trinket_2_manual,value=trinket.2.is.algethar_p
 
 actions+=/pummel,if=target.debuff.casting.react
 actions+=/charge,if=time<=0.5|movement.distance>5
-actions+=/heroic_leap,if=(raid_event.movement.distance>25&raid_event.movement.in>45)
+actions+=/heroic_leap,if=movement.distance>25
 actions+=/potion
 actions+=/call_action_list,name=variables
 actions+=/call_action_list,name=trinkets
@@ -142,7 +142,7 @@ actions.trinkets+=/use_item,slot=trinket2,if=!variable.trinket_2_buffs&(trinket.
 actions.trinkets+=/use_item,slot=main_hand,if=!equipped.fyralath_the_dreamrender&(!variable.trinket_1_buffs|trinket.1.cooldown.remains)&(!variable.trinket_2_buffs|trinket.2.cooldown.remains)
 
 # Variables
-actions.variables+=/variable,name=st_planning,value=active_enemies=1&(raid_event.adds.in>15|!raid_event.adds.exists)
-actions.variables+=/variable,name=adds_remain,value=active_enemies>=2&(!raid_event.adds.exists|raid_event.adds.exists&raid_event.adds.remains>5)
+actions.variables+=/variable,name=st_planning,value=active_enemies=1
+actions.variables+=/variable,name=adds_remain,value=active_enemies>=2
 actions.variables+=/variable,name=execute_phase,value=(talent.massacre.enabled&target.health.pct<35)|target.health.pct<20
 actions.variables+=/variable,name=on_gcd_racials,value=buff.recklessness.down&buff.avatar.down&rage<80&buff.bloodbath.down&buff.crushing_blow.down&buff.sudden_death.down&!cooldown.bladestorm.ready&(!cooldown.execute.ready|!variable.execute_phase)


### PR DESCRIPTION
- Updated variable definitions and action conditions to use in-game observable conditions instead of raid events
- Corrected "srtict" to "strict" in colossus_sweep action list call
- Simplified st_planning and adds_remain variables