### PR TITLE
fix: adjust Thunder Blast for protection warrior

### DIFF
--- a/TheWarWithin/WarriorProtection.lua
+++ b/TheWarWithin/WarriorProtection.lua
@@ -1771,6 +1771,7 @@ spec:RegisterAbilities( {
         spendType = "rage",
 
         talent = "thunder_clap",
+        nobuff = "thunder_blast",
         startsCombat = true,
         texture = 136105,
         bind = "thunder_blast",
@@ -1810,11 +1811,13 @@ spec:RegisterAbilities( {
         spendType = "rage",
 
         talent = "thunder_clap",
+        buff = "thunder_blast",
         startsCombat = true,
-        texture = 136105,
+        texture = 460957,
         bind = "thunder_clap",
 
         handler = function ()
+            removeStack( "thunder_blast" )
             applyDebuff( "target", "thunder_clap" )
             active_dot.thunder_clap = max( active_dot.thunder_clap, active_enemies )
             removeBuff( "show_of_force" )


### PR DESCRIPTION
Use the correct texture ID for Thunder Blast on protection warrior, and fix how the Thunder Blast buff is handled when casting both Thunder Clap and Thunder Blast.