### PR TITLE
Idea / Proposal for caching stuff?

### DIFF
--- a/TheWarWithin/HunterBeastMastery.lua
+++ b/TheWarWithin/HunterBeastMastery.lua
@@ -1252,6 +1252,7 @@ spec:RegisterHook( "reset_precast", function()
                 last_cotw_tick = tick  -- Update the last processed tick
             end
         end
+    else last_cotw_tick = nil -- reset after buff goes away to prep for next cast
     end
 
     if now - action.resonating_arrow.lastCast < 6 then applyBuff( "resonating_arrow", 10 - ( now - action.resonating_arrow.lastCast ) ) end

--- a/TheWarWithin/HunterBeastMastery.lua
+++ b/TheWarWithin/HunterBeastMastery.lua
@@ -1261,7 +1261,6 @@ spec:RegisterHook( "reset_precast", function()
 end )
 
 
-
 local trapUnits = { "target", "focus" }
 local trappableClassifications = {
     rare = true,

--- a/TheWarWithin/HunterBeastMastery.lua
+++ b/TheWarWithin/HunterBeastMastery.lua
@@ -1244,9 +1244,8 @@ spec:RegisterHook( "reset_precast", function()
     if buff.call_of_the_wild.up then
         local tick, expires = buff.call_of_the_wild.applied, buff.call_of_the_wild.expires
 
-        -- Loop through the possible 5 ticks
         for i = 1, 5 do
-            tick = tick + 4  -- Increment tick by 4 seconds
+            tick = tick + 4
 
             -- Only queue the event if it's a new tick and within the valid range
             if tick > query_time and tick < expires and tick ~= last_cotw_tick then
@@ -1256,13 +1255,9 @@ spec:RegisterHook( "reset_precast", function()
         end
     end
 
-    if now - action.resonating_arrow.lastCast < 6 then
-        applyBuff( "resonating_arrow", 10 - ( now - action.resonating_arrow.lastCast ) )
-    end
+    if now - action.resonating_arrow.lastCast < 6 then applyBuff( "resonating_arrow", 10 - ( now - action.resonating_arrow.lastCast ) ) end
 
-    if barbed_shot_grace_period > 0 and cooldown.barbed_shot.remains > 0 then
-        reduceCooldown( "barbed_shot", barbed_shot_grace_period )
-    end
+    if barbed_shot_grace_period > 0 and cooldown.barbed_shot.remains > 0 then reduceCooldown( "barbed_shot", barbed_shot_grace_period ) end
 end )
 
 

--- a/TheWarWithin/HunterBeastMastery.lua
+++ b/TheWarWithin/HunterBeastMastery.lua
@@ -17,7 +17,6 @@ local GetSpellCount = C_Spell.GetSpellCastCount
 local spec = Hekili:NewSpecialization( 253, true )
 
 
-
 spec:RegisterResource( Enum.PowerType.Focus, {
     barbed_shot = {
         resource = "focus",

--- a/TheWarWithin/HunterBeastMastery.lua
+++ b/TheWarWithin/HunterBeastMastery.lua
@@ -17,6 +17,7 @@ local GetSpellCount = C_Spell.GetSpellCastCount
 local spec = Hekili:NewSpecialization( 253, true )
 
 
+
 spec:RegisterResource( Enum.PowerType.Focus, {
     barbed_shot = {
         resource = "focus",
@@ -300,6 +301,7 @@ spec:RegisterPvpTalents( {
     wild_kingdom        = 5441, -- (356707) Call in help from one of your dismissed Cunning pets for 10 sec. Your current pet is dismissed to rest and heal 30% of maximum health.
 } )
 
+local barbed_shot_duration = 12 + ( talent.savagery.enabled and 2 or 0 )
 
 -- Auras
 spec:RegisterAuras( {
@@ -374,7 +376,14 @@ spec:RegisterAuras( {
     -- https://wowhead.com/beta/spell=217200
     barbed_shot = {
         id = 246152,
-        duration = function() return 8 + ( talent.savagery.enabled and 2 or 0 ) end,
+        duration = function()
+            -- Recalculate duration only if it has changed
+            local current_duration = 12 + ( talent.savagery.enabled and 2 or 0 )
+            if current_duration ~= barbed_shot_duration then
+                barbed_shot_duration = current_duration
+            end
+            return barbed_shot_duration
+        end,
         tick_time = 2,
         mechanic = "bleed",
         type = "Ranged",
@@ -382,7 +391,7 @@ spec:RegisterAuras( {
     },
     barbed_shot_2 = {
         id = 246851,
-        duration = function () return spec.auras.barbed_shot.duration end,
+        duration = barbed_shot_duration,
         tick_time = 2,
         mechanic = "bleed",
         type = "Ranged",
@@ -390,7 +399,7 @@ spec:RegisterAuras( {
     },
     barbed_shot_3 = {
         id = 246852,
-        duration = function () return spec.auras.barbed_shot.duration end,
+        duration = barbed_shot_duration,
         tick_time = 2,
         mechanic = "bleed",
         type = "Ranged",
@@ -398,7 +407,7 @@ spec:RegisterAuras( {
     },
     barbed_shot_4 = {
         id = 246853,
-        duration = function () return spec.auras.barbed_shot.duration end,
+        duration = barbed_shot_duration,
         tick_time = 2,
         mechanic = "bleed",
         type = "Ranged",
@@ -406,7 +415,7 @@ spec:RegisterAuras( {
     },
     barbed_shot_5 = {
         id = 246854,
-        duration = function () return spec.auras.barbed_shot.duration end,
+        duration = barbed_shot_duration,
         tick_time = 2,
         mechanic = "bleed",
         type = "Ranged",
@@ -414,7 +423,7 @@ spec:RegisterAuras( {
     },
     barbed_shot_6 = {
         id = 284255,
-        duration = function () return spec.auras.barbed_shot.duration end,
+        duration = barbed_shot_duration,
         tick_time = 2,
         mechanic = "bleed",
         type = "Ranged",
@@ -422,7 +431,7 @@ spec:RegisterAuras( {
     },
     barbed_shot_7 = {
         id = 284257,
-        duration = function () return spec.auras.barbed_shot.duration end,
+        duration = barbed_shot_duration,
         tick_time = 2,
         mechanic = "bleed",
         type = "Ranged",
@@ -430,7 +439,7 @@ spec:RegisterAuras( {
     },
     barbed_shot_8 = {
         id = 284258,
-        duration = function () return spec.auras.barbed_shot.duration end,
+        duration = barbed_shot_duration,
         tick_time = 2,
         mechanic = "bleed",
         type = "Ranged",
@@ -438,7 +447,7 @@ spec:RegisterAuras( {
     },
     barbed_shot_dot = {
         id = 217200,
-        duration = function () return spec.auras.barbed_shot.duration end,
+        duration = barbed_shot_duration,
         tick_time = 2,
         mechanic = "bleed",
         type = "Ranged",
@@ -731,7 +740,7 @@ spec:RegisterAuras( {
     -- https://wowhead.com/beta/spell=272790
     frenzy = {
         id = 272790,
-        duration = function () return azerite.feeding_frenzy.enabled and 9 or spec.auras.barbed_shot.duration end,
+        duration = barbed_shot_duration,
         max_stack = 3,
         generate = function ()
             local fr = buff.frenzy
@@ -1047,7 +1056,7 @@ spec:RegisterAuras( {
     -- https://wowhead.com/beta/spell=257946
     thrill_of_the_hunt = {
         id = 257946,
-        duration = function () return spec.auras.barbed_shot.duration end,
+        duration = barbed_shot_duration,
         max_stack = 3,
         copy = 312365
     },

--- a/TheWarWithin/HunterBeastMastery.lua
+++ b/TheWarWithin/HunterBeastMastery.lua
@@ -1232,7 +1232,6 @@ end, state )
 local last_cotw_tick = nil
 
 spec:RegisterHook( "reset_precast", function()
-
     if debuff.tar_trap.up then
         debuff.tar_trap.expires = debuff.tar_trap.applied + 30
     end
@@ -1243,8 +1242,7 @@ spec:RegisterHook( "reset_precast", function()
 
     -- Handle Call of the Wild (updated version with last_cotw_tick caching)
     if buff.call_of_the_wild.up then
-        local tick = buff.call_of_the_wild.applied
-        local expires = buff.call_of_the_wild.expires
+        local tick, expires = buff.call_of_the_wild.applied, buff.call_of_the_wild.expires
 
         -- Loop through the possible 5 ticks
         for i = 1, 5 do


### PR DESCRIPTION
Not necessarily ready to be a real PR, just looking for input.

### Part 1 - Caching duration of an aura which is re-used
Does doing this make sense to reduce overhead across many iterations? The only time the duration would change is during a talent change, so this could maybe be reduced even further?

If it does make sense, would you be interesting in larger scale refactoring of this type where it can be done relatively easily? I'd be happy to pick away at it over time.

( Also ignore the numbers not matching, I am using the anniversary patch numbers in this example but on the current live file.)

### Part 2 - caching last tick during reset_precast events

cache previous tick to avoid recalculation?

(ignore the beast cleave thing, same as above, anniversary patch vs live file, not relevant to the idea)