### PR TITLE
RtB superchaged handler was multiplicated

### DIFF
--- a/TheWarWithin/RogueOutlaw.lua
+++ b/TheWarWithin/RogueOutlaw.lua
@@ -1259,7 +1259,6 @@ spec:RegisterAbilities( {
                 applyBuff( "take_your_cut" )
             end
 
-            if talent.supercharger.enabled then addStack( "supercharged_combo_points", nil, talent.supercharger.rank ) end
         end,
     },
 


### PR DESCRIPTION
We already have superchaged_combo_points handle for Roll the Bones starting from line 1243. This one is duplicated i guess