### PR TITLE
fix(rogue): effective_combo_points evaluated correctly when at 0 CP

### DIFF
--- a/TheWarWithin/RogueAssassination.lua
+++ b/TheWarWithin/RogueAssassination.lua
@@ -241,7 +241,7 @@ end )
 spec:RegisterStateExpr( "effective_combo_points", function ()
     local c = combo_points.current or 0
 
-    if buff.supercharged_combo_points.up then
+    if c > 0 and buff.supercharged_combo_points.up then
         c = c + ( talent.forced_induction.enabled and 3 or 2 )
     end
 

--- a/TheWarWithin/RogueOutlaw.lua
+++ b/TheWarWithin/RogueOutlaw.lua
@@ -737,7 +737,7 @@ end )
 spec:RegisterStateExpr( "effective_combo_points", function ()
     local c = combo_points.current or 0
 
-    if buff.supercharged_combo_points.remains then
+    if c > 0 and buff.supercharged_combo_points.up then
         c = c + ( talent.forced_induction.enabled and 3 or 2 )
     end
 

--- a/TheWarWithin/RogueSubtlety.lua
+++ b/TheWarWithin/RogueSubtlety.lua
@@ -585,10 +585,8 @@ spec:RegisterStateExpr( "effective_combo_points", function ()
     local c = combo_points.current or 0
     if not talent.coup_de_grace.enabled and not talent.supercharger.enabled and not covenant.kyrian then return c end
 
-    if talent.supercharger.enabled and buff.supercharged_combo_points.up then
-        if talent.forced_induction.enabled then c = c + 3
-        else c = c + 2
-        end
+    if c > 0 and buff.supercharged_combo_points.up then
+        c = c + ( talent.forced_induction.enabled and 3 or 2 )
     end -- todo: Find out if these stack like this or not? coup de gace and supercharge
 
     if talent.coup_de_grace.enabled and this_action == "coup_de_grace" and buff.coup_de_grace.up then c = c + 5 end


### PR DESCRIPTION
Supercharged combo points are currently evaluated incorrectly when at 0 CP. If supercharge is up, but we have 0 CP, it still adds supercharged to the total count, resulting in i. e. 0 + 2 = 2 when we really dont have any useable combo points. Supercharged CP should only be added when real CP are > 0.