### PR TITLE
fix: improve San'layn implementation for death knights

### DIFF
--- a/TheWarWithin/DeathKnightBlood.lua
+++ b/TheWarWithin/DeathKnightBlood.lua
@@ -1154,11 +1154,6 @@ local TriggerUmbilicusEternus = setfenv( function()
     applyBuff( "umbilicus_eternus" )
 end, state )
 
-local TriggerERW = setfenv( function()
-    gain( 1, "runes" )
-    gain( 5, "runic_power" )
-end, state )
-
 local BonestormShield = setfenv( function()
     addStack( "bone_shield" )
 end, state )
@@ -1788,27 +1783,6 @@ spec:RegisterAbilities( {
                 if buff.bone_shield.up then applyBuff( "piledriver", nil, buff.bone_shield.stack )
                 else removeBuff( "piledriver" ) end
             end
-        end,
-    },
-
-    -- Talent: Empower your rune weapon, gaining $s3% Haste and generating $s1 $LRune:Runes; and ${$m2/10} Runic Power instantly and every $t1 sec for $d.  $?s137006[  If you already know $@spellname47568, instead gain $392714s1 additional $Lcharge:charges; of $@spellname47568.][]
-    empower_rune_weapon = {
-        id = 47568,
-        cast = 0,
-        cooldown = 120,
-        gcd = "off",
-
-        talent = "empower_rune_weapon",
-        startsCombat = false,
-
-        handler = function ()
-            applyBuff( "empower_rune_weapon" )
-            gain( 1, "runes" )
-            gain( 5, "runic_power" )
-            state:QueueAuraExpiration( "empower_rune_weapon", TriggerERW, query_time + 5 )
-            state:QueueAuraExpiration( "empower_rune_weapon", TriggerERW, query_time + 10 )
-            state:QueueAuraExpiration( "empower_rune_weapon", TriggerERW, query_time + 15 )
-            state:QueueAuraExpiration( "empower_rune_weapon", TriggerERW, query_time + 20 )
         end,
     },
 

--- a/TheWarWithin/DeathKnightBlood.lua
+++ b/TheWarWithin/DeathKnightBlood.lua
@@ -1191,7 +1191,6 @@ spec:RegisterHook( "reset_precast", function ()
 
     if IsActiveSpell( 433899 ) or IsActiveSpell( 433895 ) then
         applyBuff( "vampiric_strike" )
-        class.abilities[ 433895 ] = class.abilities.heart_strike
     end
 
     if buff.bonestorm.up then

--- a/TheWarWithin/DeathKnightUnholy.lua
+++ b/TheWarWithin/DeathKnightUnholy.lua
@@ -542,7 +542,7 @@ me:RegisterAuras( {
     essence_of_the_blood_queen = {
         id = 433925,
         duration = 20.0,
-        max_stack = function() return 1 + ( talent.frenzied_bloodthirst.enabled and 2 or 0 ) end,
+        max_stack = function() return 5 + ( talent.frenzied_bloodthirst.enabled and 2 or 0 ) end,
     },
     festering_scythe = {
         id = 458123,

--- a/TheWarWithin/DeathKnightUnholy.lua
+++ b/TheWarWithin/DeathKnightUnholy.lua
@@ -1129,6 +1129,10 @@ end, state )
 local TriggerERW = setfenv( function()
     gain( 1, "runes" )
     gain( 5, "runic_power" )
+end, state)
+
+local TriggerInflictionOfSorrow = setfenv( function ()
+    applyBuff( "infliction_of_sorrow" )
 end, state )
 
 me:RegisterHook( "reset_precast", function ()
@@ -1228,6 +1232,10 @@ me:RegisterHook( "reset_precast", function ()
             state:QueueAuraExpiration( "empower_rune_weapon", TriggerERW, expires )
             expires = expires - 5
         end
+    end
+
+    if talent.infliction_of_sorrow.enabled and buff.gift_of_the_sanlayn.up then
+        state:QueueAuraExpiration( "gift_of_the_sanlayn", TriggerInflictionOfSorrow, buff.gift_of_the_sanlayn.expires )
     end
 
     if Hekili.ActiveDebug then Hekili:Debug( "Pet is %s.", pet.alive and "alive" or "dead" ) end
@@ -1502,7 +1510,6 @@ me:RegisterAbilities( {
 
                 if talent.infliction_of_sorrow.enabled and dot.virulent_plague.ticking then
                     dot.virulent_plague.expires = dot.virulent_plague.expires + 3
-                    applyBuff( "infliction_of_sorrow" ) -- TODO: Apply on Gift of the San'layn expiry?
                 end
 
                 removeBuff( "vampiric_strike" )

--- a/TheWarWithin/DeathKnightUnholy.lua
+++ b/TheWarWithin/DeathKnightUnholy.lua
@@ -1126,11 +1126,6 @@ local ExpireRunicCorruption = setfenv( function()
 end, state )
 
 
-local TriggerERW = setfenv( function()
-    gain( 1, "runes" )
-    gain( 5, "runic_power" )
-end, state)
-
 local TriggerInflictionOfSorrow = setfenv( function ()
     applyBuff( "infliction_of_sorrow" )
 end, state )
@@ -1222,15 +1217,6 @@ me:RegisterHook( "reset_precast", function ()
         local data = class.abilities[ action ]
         if data and data.cooldown == 0 and data.spendType == "runes" then
             setCooldown( action, 0 )
-        end
-    end
-
-    if buff.empower_rune_weapon.up then
-        local expires = buff.empower_rune_weapon.expires
-
-        while expires >= query_time do
-            state:QueueAuraExpiration( "empower_rune_weapon", TriggerERW, expires )
-            expires = expires - 5
         end
     end
 
@@ -1838,33 +1824,6 @@ me:RegisterAbilities( {
         end,
 
         bind = { "defile", "any_dnd" },
-    },
-
-    -- Talent: Empower your rune weapon, gaining $s3% Haste and generating $s1 $LRune:Runes;...
-    empower_rune_weapon = {
-        id = 47568,
-        cast = 0,
-        charges = function()
-            if spec.frost and talent.empower_rune_weapon.enabled then return 2 end
-        end,
-        cooldown = 120,
-        recharge = function()
-            if spec.frost and talent.empower_rune_weapon.enabled then return ( level > 55 and 105 or 120 ) end
-        end,
-        gcd = "off",
-
-        talent = "empower_rune_weapon",
-        startsCombat = false,
-
-        handler = function ()
-            applyBuff( "empower_rune_weapon" )
-            gain( 1, "runes" )
-            gain( 5, "runic_power" )
-            state:QueueAuraExpiration( "empower_rune_weapon", TriggerERW, query_time + 5 )
-            state:QueueAuraExpiration( "empower_rune_weapon", TriggerERW, query_time + 10 )
-            state:QueueAuraExpiration( "empower_rune_weapon", TriggerERW, query_time + 15 )
-            state:QueueAuraExpiration( "empower_rune_weapon", TriggerERW, query_time + 20 )
-        end,
     },
 
     -- Talent: Causes each of your Virulent Plagues to flare up, dealing $212739s1 Shadow da...


### PR DESCRIPTION
Improve the San'layn hero talents implementation from 11.0.5 for death knights, and catch up to some talent changes for death knights from 11.0.