### PR TITLE
Druid, Rsham, General UI

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug-Report-Form.yml
+++ b/.github/ISSUE_TEMPLATE/Bug-Report-Form.yml
@@ -48,7 +48,7 @@ body:
         Please supply your character information by completing the following steps.
         * Log into your WoW character.
         * Type `/hekili` and press Enter.
-        * Open the Issue Reporting section (left panel).
+        * Open the `Snapshots (Troubleshooting)` section (left panel).
         * Copy all of the text from the text box.
         * Paste the text to Pastebin.
         * Provide the Pastebin link here.

--- a/Hekili.lua
+++ b/Hekili.lua
@@ -46,7 +46,7 @@ ns.PTR = buildNum > 110000
 
 ns.Patrons = "|cFFFFD100Current Status|r\n\n"
     .. "All existing specializations are currently supported, though healer priorities are experimental and focused on rotational DPS only.\n\n"
-    .. "If you find odd recommendations or other issues, please follow the |cFFFFD100Issue Reporting|r link below and submit all the necessary information to have your issue investigated.\n\n"
+    .. "If you find odd recommendations or other issues, please follow the |cFFFFD100Issue Reports|r link below and submit all the necessary information to have your issue investigated.\n\n"
     .. "Please do not submit tickets for routine priority updates (i.e., from SimulationCraft).  I will routinely update those when they are published.  Thanks!"
 
 do

--- a/Options.lua
+++ b/Options.lua
@@ -9972,7 +9972,7 @@ do
                         type = "description",
                         name = function ()
                             return "|cFF00CCFFTHANK YOU TO OUR SUPPORTERS!|r\n\n" .. ns.Patrons .. "\n\n" ..
-                                "Please see the |cFFFFD100Issue Reporting (Snapshots)|r link for information about reporting bugs.\n\n"
+                                "Please see the |cFFFFD100Snapshots (Troubleshooting)|r link for information about reporting bugs.\n\n"
                         end,
                         fontSize = "medium",
                         order = 6,
@@ -10104,7 +10104,7 @@ do
                                 "1. My keybinds aren't showing up right\n- |cFF00CCFFThis can happen with macros or stealth bars sometimes. You can manually tell the addon what keybind to use in the|r |cFFFFD100Abilities|r |cFF00CCFFsection. Find the spell from the dropdown and use the|r |cFFFFD100Override Keybind|r |cFF00CCFFbox. Same can be done with trinkets under|r |cFFFFD100Gear and Items|r.\n\n" .. 
                                 "2. I don't recognize this spell! What is it?\n- |cFF00CCFFIf you're a Frost Mage it may be your Water Elemental pet spell, Freeze. Otherwise, it's probably a trinket. You can press |cFFFFD100alt-shift-p|r to pause the addon and hover over the icon to see what it is!|r\n\n" .. 
                                 "3. How do I disable a certain ability or trinket?\n- |cFF00CCFFHead over to |cFFFFD100Abilities|r or |cFFFFD100Gear and Items|r, find it in the dropdown list, and disable it.\n\n|r" .. 
-                                "\nI made it to the bottom but I still have an issue!\n- |cFF00CCFFHead on over to|r |cFFFFD100Issue Reporting|r |cFF00CCFFfor more detailed instructions.",
+                                "\nI made it to the bottom but I still have an issue!\n- |cFF00CCFFHead on over to|r |cFFFFD100Snapshots (Troubleshooting)|r |cFF00CCFFfor more detailed instructions.",
                                 order = 4.1,
                                 fontSize = "medium",
                                 width = "full",
@@ -10121,7 +10121,7 @@ do
                     },
                     a5 = {
                         type = "description",
-                        name = "You can submit questions, concerns, and ideas via the link found in the |cFFFFD100Issue Reporting|r section.\n\n" ..
+                        name = "You can submit questions, concerns, and ideas via the link found in the |cFFFFD100Snapshots (Troubleshooting)|r section.\n\n" ..
                             "If you disagree with the addon's recommendations, the |cFFFFD100Snapshot|r feature allows you to capture a log of the addon's decision-making taken at the exact moment specific recommendations are shown.  " ..
                             "When you submit your question, be sure to take a snapshot (not a screenshot!), place the text on Pastebin, and include the link when you submit your issue ticket.",
                         order = 5.1,

--- a/TheWarWithin/DruidBalance.lua
+++ b/TheWarWithin/DruidBalance.lua
@@ -301,6 +301,11 @@ spec:RegisterAuras( {
         duration = 12.0,
         max_stack = 1,
     },
+    blooming_infusion_regrowth = {
+        id = 429438,
+        duration = 12.0,
+        max_stack = 1,
+    },
     -- Autoattack damage increased by $w4%.  Immune to Polymorph effects.  Movement speed increased by $113636s1% and falling damage reduced.
     -- https://wowhead.com/beta/spell=768
     cat_form = {
@@ -2578,7 +2583,7 @@ spec:RegisterAbilities( {
     -- Heals a friendly target for $s1 and another ${$o2*$<mult>} over $d.$?s231032[ Initial heal has a $231032s1% increased chance for a critical effect if the target is already affected by Regrowth.][]$?s24858|s197625[ Usable while in Moonkin Form.][]$?s33891[    |C0033AA11Tree of Life: Instant cast.|R][]
     regrowth = {
         id = 8936,
-        cast = 1.5,
+        cast = function() return buff.blooming_infusion_regrowth.up and 0 or 1.5 end,
         cooldown = 0,
         gcd = "spell",
         school = "nature",

--- a/TheWarWithin/DruidFeral.lua
+++ b/TheWarWithin/DruidFeral.lua
@@ -1272,8 +1272,8 @@ local SinfulHysteriaHandler = setfenv( function ()
 end, state )
 
 
-local IncarnationComboPointPeriodic = setfenv( function()
-    gain( 1, "combo_point" )
+local ComboPointPeriodic = setfenv( function()
+    gain( 1, "combo_points" )
 end, state )
 
 spec:RegisterHook( "reset_precast", function ()
@@ -1300,7 +1300,8 @@ spec:RegisterHook( "reset_precast", function ()
     end
 
     if prev_gcd[1].feral_frenzy and now - action.feral_frenzy.lastCast < gcd.execute and combo_points.current < 5 then
-        gain( 5, "combo_points" )
+        -- combo_points.current = 5
+        gain( 5, "combo_points", false )
     end
 
     -- opener_done = nil
@@ -1316,7 +1317,7 @@ spec:RegisterHook( "reset_precast", function ()
         for i = 1.5, expires - query_time, 1.5 do
             tick = query_time + i
             if tick < expires then
-                state:QueueAuraEvent( "incarnation_combo_point_perodic", IncarnationComboPointPeriodic, tick, "AURA_TICK" )
+                state:QueueAuraEvent( "incarnation_combo_point_perodic", ComboPointPeriodic, tick, "AURA_TICK" )
             end
         end
     end
@@ -1326,9 +1327,10 @@ spec:RegisterHook( "reset_precast", function ()
     end
 end )
 
-spec:RegisterHook( "gain", function( amt, resource )
+spec:RegisterHook( "gain", function( amt, resource, overflow )
+    if overflow == nil then overflow = true end -- nil is yes
     if amt > 0 and resource == "combo_points" then
-        if combo_points.deficit < amt then -- excess points
+        if combo_points.deficit < amt and overflow then -- excess points
         local combo_points_to_store = amt - combo_points.deficit
             if buff.overflowing_power.stack > ( 3 - combo_points_to_store ) or buff.bs_inc.down then -- unable to store them all
                 applyBuff( "coiled_to_spring" )
@@ -1610,7 +1612,7 @@ spec:RegisterAbilities( {
             if buff.cat_form.down then shift( "cat_form" ) end
             applyBuff( "berserk" )
             for i = 1.5, spec.auras.berserk.duration, 1.5 do
-                state:QueueAuraEvent( "incarnation_combo_point_periodic", IncarnationComboPointPeriodic, query_time + i, "AURA_TICK" )
+                state:QueueAuraEvent( "incarnation_combo_point_periodic", ComboPointPeriodic, query_time + i, "AURA_TICK" )
             end
         end,
 
@@ -1797,7 +1799,7 @@ spec:RegisterAbilities( {
         end,
 
         handler = function ()
-            gain( 5, "combo_points" )
+            gain( 5, "combo_points", false )
             applyDebuff( "target", "feral_frenzy" )
             if buff.bs_inc.up and talent.berserk_frenzy.enabled then applyDebuff( "target", "frenzied_assault" ) end
             if set_bonus.tier31_2pc > 0 then applyBuff( "smoldering_frenzy" ) end
@@ -1988,7 +1990,7 @@ spec:RegisterAbilities( {
             setCooldown( "prowl", 0 )
 
             for i = 1.5, spec.auras.incarnation.duration, 1.5 do
-                state:QueueAuraEvent( "incarnation_combo_point_periodic", IncarnationComboPointPeriodic, query_time + i, "AURA_TICK" )
+                state:QueueAuraEvent( "incarnation_combo_point_periodic", ComboPointPeriodic, query_time + i, "AURA_TICK" )
             end
 
         end,

--- a/TheWarWithin/DruidGuardian.lua
+++ b/TheWarWithin/DruidGuardian.lua
@@ -1059,7 +1059,7 @@ end )
 
 spec:RegisterHook( "runHandler_startCombat", function()
     if talent.killing_strikes.enabled then applyBuff( "ravage_upon_combat") end
-    ursocRageSpend = 0 -- reset upon entering combat
+    -- ursocRageSpend = 0 -- reset upon entering combat
 end )
 
 spec:RegisterHook( "spend", function( amt, resource )

--- a/TheWarWithin/ShamanRestoration.lua
+++ b/TheWarWithin/ShamanRestoration.lua
@@ -549,7 +549,7 @@ spec:RegisterAbilities( {
 
     -- Sears the target with fire, causing 3,099 Fire damage and then an additional 19,919 Fire damage over 18 sec. Flame Shock can be applied to a maximum of 6 targets.
     flame_shock = {
-        id = 188389,
+        id = 470411,
         cast = 0,
         cooldown = 6,
         gcd = "spell",


### PR DESCRIPTION
### UI
Correct the misnamed `Snapshots (Troubleshooting)` tab in various places

### Resto Sham
- Fix `flame_shock` ID

### Feral Druid
- Fix `feral_frenzy` combo point forecasting

### Guardian Druid
- comment out unused variable, targeted for later revisit

### Balance Druid
- Add the other part of Blooming infusion as `blooming_infusion_regrowth`