### PR TITLE
Restoration Druid Rework

### DIFF
--- a/TheWarWithin/DruidBalance.lua
+++ b/TheWarWithin/DruidBalance.lua
@@ -2583,7 +2583,7 @@ spec:RegisterAbilities( {
 
     rebirth ={
         id = 20484,
-        cast = function() return buff.natures_swiftness.up and 0 or 2 * haste end,
+        cast = function() return buff.natures_swiftness.up and 0 or 2 end,
         cooldown = 0,
         gcd = "spell",
 

--- a/TheWarWithin/DruidBalance.lua
+++ b/TheWarWithin/DruidBalance.lua
@@ -2874,7 +2874,7 @@ spec:RegisterAbilities( {
 
 
     starsurge = {
-        id = function() return state.spec.balance and 78674 or 197626 end,
+        id = 78674,
         cast = 0,
         cooldown = function() return state.spec.balance and 0 or ( talent.starlight_conduit.enabled and 6 or 10 ) end,
         gcd = "spell",

--- a/TheWarWithin/DruidBalance.lua
+++ b/TheWarWithin/DruidBalance.lua
@@ -2037,7 +2037,7 @@ spec:RegisterAbilities( {
     -- Talent: Tosses the enemy target into the air, disorienting them but making them invulnerable for up to $d. Only one target can be affected by your Cyclone at a time.
     cyclone = {
         id = 33786,
-        cast = function() return 1.7 * ( buff.heart_of_the_wild.up and 0.7 or 1 ) end,
+        cast = function() return 1.7 * ( buff.heart_of_the_wild.up and 0.7 or 1 ) * haste end,
         cooldown = 0,
         gcd = "spell",
         school = "nature",
@@ -2074,7 +2074,7 @@ spec:RegisterAbilities( {
     -- Roots the target in place for $d. Damage may cancel the effect.$?s33891[    |C0033AA11Tree of Life: Instant cast.|R][]
     entangling_roots = {
         id = 339,
-        cast = function () return pvptalent.owlkin_adept.enabled and buff.owlkin_frenzy.up and 0.85 or 1.7 end,
+        cast = function () return pvptalent.owlkin_adept.enabled and buff.owlkin_frenzy.up and 0.85 or 1.7 * haste end,
         cooldown = 0,
         gcd = "spell",
 
@@ -2256,7 +2256,7 @@ spec:RegisterAbilities( {
     -- Talent: Forces the enemy target to sleep for up to $d.  Any damage will awaken the target.  Only one target can be forced to hibernate at a time.  Only works on Beasts and Dragonkin.
     hibernate = {
         id = 2637,
-        cast = function() return 1.5 * ( buff.heart_of_the_wild.up and 0.7 or 1 ) end,
+        cast = function() return 1.5 * ( buff.heart_of_the_wild.up and 0.7 or 1 ) * haste end,
         cooldown = 0,
         gcd = "spell",
         school = "nature",
@@ -2583,7 +2583,7 @@ spec:RegisterAbilities( {
 
     rebirth ={
         id = 20484,
-        cast = function() return buff.natures_swiftness.up and 0 or 2 end,
+        cast = function() return buff.natures_swiftness.up and 0 or 2 * haste end,
         cooldown = 0,
         gcd = "spell",
 
@@ -2597,7 +2597,7 @@ spec:RegisterAbilities( {
     -- Heals a friendly target for $s1 and another ${$o2*$<mult>} over $d.$?s231032[ Initial heal has a $231032s1% increased chance for a critical effect if the target is already affected by Regrowth.][]$?s24858|s197625[ Usable while in Moonkin Form.][]$?s33891[    |C0033AA11Tree of Life: Instant cast.|R][]
     regrowth = {
         id = 8936,
-        cast = function() return buff.blooming_infusion_regrowth.up and 0 or 1.5 end,
+        cast = function() return buff.blooming_infusion_regrowth.up and 0 or 1.5 * haste end,
         cooldown = 0,
         gcd = "spell",
         school = "nature",

--- a/TheWarWithin/DruidBalance.lua
+++ b/TheWarWithin/DruidBalance.lua
@@ -2086,6 +2086,7 @@ spec:RegisterAbilities( {
 
         handler = function ()
             applyDebuff( "target", "entangling_roots" )
+            removeBuff( "natures_swiftness" )
         end,
     },
 
@@ -2578,6 +2579,19 @@ spec:RegisterAbilities( {
         end,
 
         copy = 102547
+    },
+
+    rebirth ={
+        id = 20484,
+        cast = function() return buff.natures_swiftness.up and 0 or 2 * haste end,
+        cooldown = 0,
+        gcd = "spell",
+
+        -- readyTime = there is a brez available .. API for this?
+
+        handler = function ()
+            removeBuff( "natures_swiftness" )
+        end
     },
 
     -- Heals a friendly target for $s1 and another ${$o2*$<mult>} over $d.$?s231032[ Initial heal has a $231032s1% increased chance for a critical effect if the target is already affected by Regrowth.][]$?s24858|s197625[ Usable while in Moonkin Form.][]$?s33891[    |C0033AA11Tree of Life: Instant cast.|R][]

--- a/TheWarWithin/DruidFeral.lua
+++ b/TheWarWithin/DruidFeral.lua
@@ -1,3 +1,4 @@
+
 -- DruidFeral.lua
 -- July 2024
 
@@ -2057,8 +2058,7 @@ spec:RegisterAbilities( {
     mangle = {
         id = 33917,
         cast = 0,
-        cooldown = function () return ( buff.berserk_bear.up and talent.berserk_ravage.enabled and 0 or 6 ) end,
-        hasteCD = true,
+        cooldown = function () return ( buff.berserk_bear.up and talent.berserk_ravage.enabled and 0 or 6 ) * haste end,
         gcd = "spell",
         school = "physical",
 

--- a/TheWarWithin/DruidFeral.lua
+++ b/TheWarWithin/DruidFeral.lua
@@ -1848,6 +1848,7 @@ spec:RegisterAbilities( {
             if talent.ravage.enabled then removeBuff( "ravage" ) end
             if talent.bloodtalons.enabled then removeStack( "bloodtalons" ) end
             if talent.sabertooth.enabled then applyDebuff( "target", "sabertooth" ) end
+            if state.spec.restoration and talent.master_shapeshifter.enabled and combo_points.current == 5 then gain( 175000, "mana") end
 
             if buff.apex_predator.up or buff.apex_predators_craving.up then
                 applyBuff( "predatory_swiftness" )
@@ -2037,6 +2038,7 @@ spec:RegisterAbilities( {
 
         handler = function ()
             applyDebuff( "target", "maim", combo_points.current )
+            if state.spec.restoration and talent.master_shapeshifter.enabled and combo_points.current == 5 then gain( 175000, "mana") end
             spend( combo_points.current, "combo_points" )
 
             removeBuff( "iron_jaws" )
@@ -2491,6 +2493,7 @@ spec:RegisterAbilities( {
         handler = function ()
             applyDebuff( "target", "rip" )
             debuff.rip.pmultiplier = persistent_multiplier
+            if state.spec.restoration and talent.master_shapeshifter.enabled and combo_points.current == 5 then gain( 175000, "mana") end
             spend( combo_points.current, "combo_points" )
 
             if talent.bloodtalons.enabled then removeStack( "bloodtalons" ) end

--- a/TheWarWithin/DruidFeral.lua
+++ b/TheWarWithin/DruidFeral.lua
@@ -2602,6 +2602,29 @@ spec:RegisterAbilities( {
         end,
     },
 
+    starsurge = {
+        id = 197626,
+        cast = 0,
+        cooldown = function() return 10 - ( 4 * talent.starlight_conduit.rank ) end,
+        gcd = "spell",
+
+        spend = function () return ( talent.starlight_conduit.enabled and 0.003 or 0.006 ) end,
+        spendType = "mana",
+
+        startsCombat = true,
+        texture = 135730,
+        talent = "starsurge",
+
+        handler = function ()
+            gain( 0.3 * health.max, "health" )
+            if talent.master_shapeshifter.enabled then gain( 43750, "mana" ) end
+            if talent.call_of_the_elder_druid.enabled and debuff.oath_of_the_elder_druid.down then
+                applyBuff( "heart_of_the_wild", 15 )
+                applyDebuff( "player", "oath_of_the_elder_druid" )
+            end
+        end,
+    },
+
     -- Talent: Shift into Bear Form and let loose a wild roar, increasing the movement speed of all friendly players within $A1 yards by $s1% for $d.
     stampeding_roar = {
         id = 106898,

--- a/TheWarWithin/DruidFeral.lua
+++ b/TheWarWithin/DruidFeral.lua
@@ -1876,9 +1876,9 @@ spec:RegisterAbilities( {
     frenzied_regeneration = {
         id = 22842,
         cast = 0,
-        charges = function () return talent.innate_resolve.enabled and 2 or nil end,
+        charges = function () if talent.innate_resolve.enabled then return 2 end end,
         cooldown = function () return 36 * ( buff.berserk.up and talent.berserk_persistence.enabled and 0 or 1 ) * ( 1 - 0.2 * talent.reinvigoration.rank ) end,
-        recharge = function () return talent.innate_resolve.enabled and ( 36 * ( buff.berserk.up and talent.berserk_persistence.enabled and 0 or 1 ) ) or nil end,
+        recharge = function () if talent.innate_resolve.enabled then return ( 36 * ( buff.berserk.up and talent.berserk_persistence.enabled and 0 or 1 ) ) end end,
         gcd = "spell",
         school = "physical",
 
@@ -2057,7 +2057,8 @@ spec:RegisterAbilities( {
     mangle = {
         id = 33917,
         cast = 0,
-        cooldown = function () return ( buff.berserk_bear.up and talent.berserk_ravage.enabled and 0 or 6 ) * haste end,
+        cooldown = function () return ( buff.berserk_bear.up and talent.berserk_ravage.enabled and 0 or 6 ) end,
+        hasteCD = true,
         gcd = "spell",
         school = "physical",
 

--- a/TheWarWithin/DruidFeral.lua
+++ b/TheWarWithin/DruidFeral.lua
@@ -1848,7 +1848,7 @@ spec:RegisterAbilities( {
             if talent.ravage.enabled then removeBuff( "ravage" ) end
             if talent.bloodtalons.enabled then removeStack( "bloodtalons" ) end
             if talent.sabertooth.enabled then applyDebuff( "target", "sabertooth" ) end
-            if state.spec.restoration and talent.master_shapeshifter.enabled and combo_points.current == 5 then gain( 175000, "mana") end
+            if state.spec.restoration and talent.master_shapeshifter.enabled and combo_points.current == 5 then gain( 175000, "mana" ) end
 
             if buff.apex_predator.up or buff.apex_predators_craving.up then
                 applyBuff( "predatory_swiftness" )
@@ -2038,7 +2038,7 @@ spec:RegisterAbilities( {
 
         handler = function ()
             applyDebuff( "target", "maim", combo_points.current )
-            if state.spec.restoration and talent.master_shapeshifter.enabled and combo_points.current == 5 then gain( 175000, "mana") end
+            if state.spec.restoration and talent.master_shapeshifter.enabled and combo_points.current == 5 then gain( 175000, "mana" ) end
             spend( combo_points.current, "combo_points" )
 
             removeBuff( "iron_jaws" )
@@ -2493,7 +2493,7 @@ spec:RegisterAbilities( {
         handler = function ()
             applyDebuff( "target", "rip" )
             debuff.rip.pmultiplier = persistent_multiplier
-            if state.spec.restoration and talent.master_shapeshifter.enabled and combo_points.current == 5 then gain( 175000, "mana") end
+            if state.spec.restoration and talent.master_shapeshifter.enabled and combo_points.current == 5 then gain( 175000, "mana" ) end
             spend( combo_points.current, "combo_points" )
 
             if talent.bloodtalons.enabled then removeStack( "bloodtalons" ) end

--- a/TheWarWithin/DruidGuardian.lua
+++ b/TheWarWithin/DruidGuardian.lua
@@ -1336,11 +1336,9 @@ spec:RegisterAbilities( {
         id = 22842,
         cast = 0,
         charges = function () if talent.innate_resolve.enabled then return 2 end end,
-        cooldown = function () return 36 * ( buff.berserk.up and talent.berserk_persistence.enabled and 0 or 1 ) * ( 1 - 0.1 * talent.reinvigoration.rank ) end,
-        recharge = function () if talent.innate_resolve.enabled then return 36 * ( buff.berserk.up and talent.berserk_persistence.enabled and 0 or 1 ) * ( 1 - 0.1 * talent.reinvigoration.rank ) end end,
-        gcd = "spell",
+        cooldown = function () return 36 * ( buff.berserk.up and talent.berserk_persistence.enabled and 0 or 1 ) * ( 1 - 0.1 * talent.reinvigoration.rank ) * haste end,
+        recharge = function () if talent.innate_resolve.enabled then return 36 * ( buff.berserk.up and talent.berserk_persistence.enabled and 0 or 1 ) * ( 1 - 0.1 * talent.reinvigoration.rank ) end end, gcd = "spell",
         school = "physical",
-        hasteCD = true,
 
         spend = function()
             if talent.empowered_shapeshifting.enabled and buff.cat_form.up then return 40, "energy" end
@@ -1387,10 +1385,9 @@ spec:RegisterAbilities( {
     growl = {
         id = 6795,
         cast = 0,
-        cooldown = function () return ( buff.berserk_bear.up and talent.berserk_ravage.enabled and 0 or 8 ) end,
+        cooldown = function () return ( buff.berserk_bear.up and talent.berserk_ravage.enabled and 0 or 8 ) * haste end,
         gcd = "off",
         school = "physical",
-        hasteCD = true,
 
         startsCombat = true,
 
@@ -1574,10 +1571,9 @@ spec:RegisterAbilities( {
     mangle = {
         id = 33917,
         cast = 0,
-        cooldown = function () return ( buff.berserk_bear.up and talent.berserk_ravage.enabled and 0 or 6 ) end,
+        cooldown = function () return ( buff.berserk_bear.up and talent.berserk_ravage.enabled and 0 or 6 ) * haste end,
         gcd = "spell",
         school = "physical",
-        hasteCD = true,
 
         spend = function() return ( -10 - ( buff.gore.up and 4 or 0 ) - ( 5 * talent.soul_of_the_forest.rank ) ) * ( buff.furious_regeneration.up and 1.15 or 1 ) end,
         spendType = "rage",
@@ -2071,9 +2067,9 @@ spec:RegisterAbilities( {
     survival_instincts = {
         id = 61336,
         cast = 0,
-        charges = function() if talent.improved_survival_instincts.enabled then return 2 end end,
+        charges = function() return talent.improved_survival_instincts.enabled and 2 or nil end,
         cooldown = function () return ( essence.vision_of_perfection.enabled and 0.87 or 1 ) * ( 1 - 0.12 * talent.survival_of_the_fittest.rank ) * 180 end,
-        recharge = function () if talent.improved_survival_instincts.enabled then return ( ( essence.vision_of_perfection.enabled and 0.87 or 1 ) * ( 1 - 0.12 * talent.survival_of_the_fittest.rank ) * 180 ) end end,
+        recharge = function () return talent.improved_survival_instincts.enabled and ( ( essence.vision_of_perfection.enabled and 0.87 or 1 ) * ( 1 - 0.12 * talent.survival_of_the_fittest.rank ) * 180 ) or nil end,
         gcd = "off",
         school = "physical",
 
@@ -2156,8 +2152,7 @@ spec:RegisterAbilities( {
         known = 106832,
         suffix = "(Bear)",
         cast = 0,
-        cooldown = function () return 6 * ( buff.berserk_bear.up and talent.berserk_ravage.enabled and 0.5 or 1 ) end,
-        hasteCD = true,
+        cooldown = function () return 6 * ( buff.berserk_bear.up and talent.berserk_ravage.enabled and 0.5 or 1 ) * haste end,
         gcd = "spell",
         school = function() return talent.lunar_calling.enabled and "arcane" or "physical" end,
 

--- a/TheWarWithin/DruidGuardian.lua
+++ b/TheWarWithin/DruidGuardian.lua
@@ -1524,7 +1524,7 @@ spec:RegisterAbilities( {
             removeBuff( "gory_fur" )
             removeBuff( "guardian_of_elune" )
             if set_bonus.tier30_4pc > 0 then addStack( "indomitable_guardian" ) end
-            if state.spec.restoration and talent.master_shapeshifter.enabled then gain( 43750, "mana") end
+            if state.spec.restoration and talent.master_shapeshifter.enabled then gain( 43750, "mana" ) end
         end,
     },
 

--- a/TheWarWithin/DruidGuardian.lua
+++ b/TheWarWithin/DruidGuardian.lua
@@ -1336,10 +1336,11 @@ spec:RegisterAbilities( {
         id = 22842,
         cast = 0,
         charges = function () if talent.innate_resolve.enabled then return 2 end end,
-        cooldown = function () return 36 * ( buff.berserk.up and talent.berserk_persistence.enabled and 0 or 1 ) * ( 1 - 0.1 * talent.reinvigoration.rank ) * haste end,
-        recharge = function () if talent.innate_resolve.enabled then return 36 * ( buff.berserk.up and talent.berserk_persistence.enabled and 0 or 1 ) * ( 1 - 0.1 * talent.reinvigoration.rank ) * haste end end,
+        cooldown = function () return 36 * ( buff.berserk.up and talent.berserk_persistence.enabled and 0 or 1 ) * ( 1 - 0.1 * talent.reinvigoration.rank ) end,
+        recharge = function () if talent.innate_resolve.enabled then return 36 * ( buff.berserk.up and talent.berserk_persistence.enabled and 0 or 1 ) * ( 1 - 0.1 * talent.reinvigoration.rank ) end end,
         gcd = "spell",
         school = "physical",
+        hasteCD = true,
 
         spend = function()
             if talent.empowered_shapeshifting.enabled and buff.cat_form.up then return 40, "energy" end
@@ -1386,9 +1387,10 @@ spec:RegisterAbilities( {
     growl = {
         id = 6795,
         cast = 0,
-        cooldown = function () return ( buff.berserk_bear.up and talent.berserk_ravage.enabled and 0 or 8 ) * haste end,
+        cooldown = function () return ( buff.berserk_bear.up and talent.berserk_ravage.enabled and 0 or 8 ) end,
         gcd = "off",
         school = "physical",
+        hasteCD = true,
 
         startsCombat = true,
 
@@ -1572,9 +1574,10 @@ spec:RegisterAbilities( {
     mangle = {
         id = 33917,
         cast = 0,
-        cooldown = function () return ( buff.berserk_bear.up and talent.berserk_ravage.enabled and 0 or 6 ) * haste end,
+        cooldown = function () return ( buff.berserk_bear.up and talent.berserk_ravage.enabled and 0 or 6 ) end,
         gcd = "spell",
         school = "physical",
+        hasteCD = true,
 
         spend = function() return ( -10 - ( buff.gore.up and 4 or 0 ) - ( 5 * talent.soul_of_the_forest.rank ) ) * ( buff.furious_regeneration.up and 1.15 or 1 ) end,
         spendType = "rage",
@@ -2068,9 +2071,9 @@ spec:RegisterAbilities( {
     survival_instincts = {
         id = 61336,
         cast = 0,
-        charges = function() return talent.improved_survival_instincts.enabled and 2 or nil end,
+        charges = function() if talent.improved_survival_instincts.enabled then return 2 end end,
         cooldown = function () return ( essence.vision_of_perfection.enabled and 0.87 or 1 ) * ( 1 - 0.12 * talent.survival_of_the_fittest.rank ) * 180 end,
-        recharge = function () return talent.improved_survival_instincts.enabled and ( ( essence.vision_of_perfection.enabled and 0.87 or 1 ) * ( 1 - 0.12 * talent.survival_of_the_fittest.rank ) * 180 ) or nil end,
+        recharge = function () if talent.improved_survival_instincts.enabled then return ( ( essence.vision_of_perfection.enabled and 0.87 or 1 ) * ( 1 - 0.12 * talent.survival_of_the_fittest.rank ) * 180 ) end end,
         gcd = "off",
         school = "physical",
 
@@ -2153,7 +2156,8 @@ spec:RegisterAbilities( {
         known = 106832,
         suffix = "(Bear)",
         cast = 0,
-        cooldown = function () return 6 * ( buff.berserk_bear.up and talent.berserk_ravage.enabled and 0.5 or 1 ) * haste end,
+        cooldown = function () return 6 * ( buff.berserk_bear.up and talent.berserk_ravage.enabled and 0.5 or 1 ) end,
+        hasteCD = true,
         gcd = "spell",
         school = function() return talent.lunar_calling.enabled and "arcane" or "physical" end,
 

--- a/TheWarWithin/DruidGuardian.lua
+++ b/TheWarWithin/DruidGuardian.lua
@@ -1524,6 +1524,7 @@ spec:RegisterAbilities( {
             removeBuff( "gory_fur" )
             removeBuff( "guardian_of_elune" )
             if set_bonus.tier30_4pc > 0 then addStack( "indomitable_guardian" ) end
+            if state.spec.restoration and talent.master_shapeshifter.enabled then gain( 43750, "mana") end
         end,
     },
 

--- a/TheWarWithin/DruidGuardian.lua
+++ b/TheWarWithin/DruidGuardian.lua
@@ -1996,6 +1996,29 @@ spec:RegisterAbilities( {
         end,
     },
 
+    starsurge = {
+        id = 197626,
+        cast = 0,
+        cooldown = function() return 10 - ( 4 * talent.starlight_conduit.rank ) end,
+        gcd = "spell",
+
+        spend = function () return ( talent.starlight_conduit.enabled and 0.003 or 0.006 ) end,
+        spendType = "mana",
+
+        startsCombat = true,
+        texture = 135730,
+        talent = "starsurge",
+
+        handler = function ()
+            gain( 0.3 * health.max, "health" )
+            if talent.master_shapeshifter.enabled then gain( 43750, "mana" ) end
+            if talent.call_of_the_elder_druid.enabled and debuff.oath_of_the_elder_druid.down then
+                applyBuff( "heart_of_the_wild", 15 )
+                applyDebuff( "player", "oath_of_the_elder_druid" )
+            end
+        end,
+    },
+
     -- Talent: Let loose a wild roar, increasing the movement speed of all friendly players within $A1 yards by $s1% for $d.
     stampeding_roar = {
         id = 106898,

--- a/TheWarWithin/DruidRestoration.lua
+++ b/TheWarWithin/DruidRestoration.lua
@@ -8,6 +8,7 @@ local Hekili = _G[ addon ]
 local class, state = Hekili.Class, Hekili.State
 
 local spec = Hekili:NewSpecialization( 105 )
+local strformat = string.format
 
 spec:RegisterResource( Enum.PowerType.Mana )
 spec:RegisterResource( Enum.PowerType.Energy )
@@ -202,7 +203,7 @@ spec:RegisterAuras( {
         max_stack = 12
     },
     call_of_the_elder_druid = {
-        id = 338643,
+        id = 426790,
         duration = 60,
         max_stack = 1,
         copy = "oath_of_the_elder_druid"
@@ -210,12 +211,16 @@ spec:RegisterAuras( {
     cenarion_ward = {
         id = 102351,
         duration = 30,
-        max_stack = 1
+        max_stack = 1,
+        dot = "buff",
+        friendly = true
     },
     cenarion_ward_hot = {
         id = 102352,
         duration = 8,
         tick_time = function() return mod_liveliness_hot( 2 ) end,
+        dot = "buff",
+        friendly = true,
         max_stack = 1
     },
     -- [393381] During Incarnation: Tree of Life, you summon a Grove Guardian every $393418t sec. The cooldown of Incarnation: Tree of Life is reduced by ${$s1/-1000}.1 sec when Grove Guardians fade.
@@ -230,15 +235,18 @@ spec:RegisterAuras( {
         duration = 15,
         max_stack = 1
     },
+    cultivation = {
+        id = 200389,
+        duration = 6,
+        dot = "buff",
+        friendly = true,
+        max_stack = 1
+    },
     efflorescence = {
-        id = 81262,
+        id = 145205,
         duration = 30,
         tick_time = function() return mod_liveliness_hot( 2 ) end,
-        pandemic = true,
         max_stack = 1,
-
-        -- Affected by:
-        -- disentanglement[233673] #1: { 'type': APPLY_AURA, 'subtype': ADD_PCT_MODIFIER, 'points': -40.0, 'target': TARGET_UNIT_CASTER, 'modifies': POWER_COST, }
     },
     flourish = {
         id = 197721,
@@ -248,7 +256,7 @@ spec:RegisterAuras( {
     grove_guardians = {
         id = 102693,
         duration = 15,
-        max_stack = 3,
+        max_stack = 5,
         generate = function( t )
             local expires = action.grove_guardians.lastCast + 15
 
@@ -276,40 +284,50 @@ spec:RegisterAuras( {
     harmony_of_the_grove = {
         id = 428737,
         duration = 15,
+        max_stack = 3
+    },
+    -- The actual incarn buff
+    incarnation = {
+        id = 117679,
+        duration = 30,
         max_stack = 1
     },
+    -- This is the form
     incarnation_tree_of_life = {
         id = 33891,
-        duration = 30,
+        duration = 3600,
         max_stack = 1,
-        copy = "incarnation"
+        copy = "tree_of_life_form"
     },
     ironbark = {
         id = 102342,
         duration = function() return talent.regenerative_heartwood.enabled and 16 or 12 end,
         max_stack = 1
     },
+    -- talent = double lifebloom. Both spellID and actual buff spellID change.
     lifebloom = {
         id = 33763,
         duration = 15,
-        tick_time = function() return mod_liveliness_hot( 1 ) end,
+        tick_time = function() return haste * mod_liveliness_hot( 1 ) end,
         max_stack = 1,
         dot = "buff",
-        copy = 290754
+        friendly = true,
     },
     lifebloom_2 = {
         id = 188550,
         duration = 15,
-        tick_time = function() return mod_liveliness_hot( 1 ) end,
+        tick_time = function() return haste * mod_liveliness_hot( 1 ) end,
         max_stack = 1,
-        dot = "buff"
+        dot = "buff",
+        friendly = true,
+        copy = "lifebloom"
     },
     natures_swiftness = {
         id = 132158,
         duration = 3600,
         max_stack = 1,
         onRemove = function()
-            setCooldown( "natures_swiftness", 60 )
+            setCooldown( "natures_swiftness", spec.abilities.natures_swiftness.cooldown )
         end,
     },
     natures_vigil = {
@@ -323,22 +341,33 @@ spec:RegisterAuras( {
         duration = 60,
         max_stack = 1,
     },
+    reforestation = {
+        id = 392360,
+        duration = 3600,
+        max_stack = 3,
+    },
     regrowth = {
         id = 8936,
         duration = function() return 12 + 3 * talent.thriving_vegetation.rank end,
-        tick_time = function() return mod_liveliness_hot( 2 ) end,
+        tick_time = function() return haste * mod_liveliness_hot( 2 ) end,
+        dot = "buff",
+        friendly = true,
         max_stack = 1
     },
     rejuvenation = {
         id = 774,
-        duration = 12,
-        tick_time = function() return mod_liveliness_hot( 3 ) end,
+        duration = function() return 12 + 3 * talent.improved_rejuvenation.rank end,
+        tick_time = function() return haste * mod_liveliness_hot( 3 ) end,
+        dot = "buff",
+        friendly = true,
         max_stack = 1
     },
     rejuvenation_germination = {
         id = 155777,
-        duration = 12,
-        tick_time = function() return mod_liveliness_hot( 3 ) end,
+        duration = function () return spec.auras.rejuvenation.duration end,
+        tick_time = function() return haste * mod_liveliness_hot( 3 ) end,
+        dot = "buff",
+        friendly = true,
         max_stack = 1
     },
     renewing_bloom = {
@@ -347,25 +376,68 @@ spec:RegisterAuras( {
         tick_time = function() return mod_liveliness_hot( 1 ) end,
         max_stack = 1
     },
+    soul_of_the_forest = {
+        id = 114108,
+        duration = 15,
+        max_stack = 1,
+    },
+    spring_blossoms = {
+        id = 207386,
+        duration = 6,
+        dot = "buff",
+        friendly = true,
+        max_stack = 1,
+    },
     tranquility = {
         id = 740,
         duration = function() return 8 * haste end,
-        max_stack = 1,
+        generate = function( t )
+            if buff.casting.up and buff.casting.v1 == 740 then
+                t.applied  = buff.casting.applied
+                t.duration = buff.casting.duration
+                t.expires  = buff.casting.expires
+                t.stack    = 1
+                t.caster   = "player"    
+                return
+            end
+
+            t.applied  = 0
+            t.duration = spec.auras.tranquility.duration
+            t.expires  = 0
+            t.stack    = 0
+            t.caster   = "nobody"
+        end,
+        tick_time = function() return ( 8 * haste ) / 5 end,  -- Interval between each tick based on haste
+        max_stack = 1
     },
     tranquility_hot = {
         id = 157982,
         duration = 8,
         tick_time = function() return mod_liveliness_hot( 2 ) end,
-        max_stack = 1
+        max_stack = 5
     },
     wild_growth = {
         id = 48438,
         duration = 7,
         tick_time = function() return mod_liveliness_hot( 1 ) end,
+        dot = "buff",
+        friendly = true,
         max_stack = 1
+    },
+    wild_synthesis = {
+        id = 400534,
+        duration = 3600,
+        max_stack = 3
     },
 } )
 
+spec:RegisterPet( "treants",
+    54983,
+    "grove_guardians",
+    15,
+    54983 )
+
+spec:RegisterTotem( "treants", 54983 )
 
 spec:RegisterStateFunction( "break_stealth", function ()
     removeBuff( "shadowmeld" )
@@ -379,6 +451,7 @@ end )
 spec:RegisterStateFunction( "unshift", function()
     if conduit.tireless_pursuit.enabled and ( buff.cat_form.up or buff.travel_form.up ) then applyBuff( "tireless_pursuit" ) end
 
+    removeBuff( "tree_of_life_form" )
     removeBuff( "cat_form" )
     removeBuff( "bear_form" )
     removeBuff( "travel_form" )
@@ -392,6 +465,7 @@ end )
 spec:RegisterStateFunction( "shift", function( form )
     if conduit.tireless_pursuit.enabled and ( buff.cat_form.up or buff.travel_form.up ) then applyBuff( "tireless_pursuit" ) end
 
+    removeBuff( "tree_of_life_form" )
     removeBuff( "cat_form" )
     removeBuff( "bear_form" )
     removeBuff( "travel_form" )
@@ -405,7 +479,7 @@ spec:RegisterStateFunction( "shift", function( form )
         applyBuff( "celestial_guardian" )
     end
 
-    if talent.call_of_the_elder_druid.enabled and debuff.oath_of_the_elder_druid.down then
+    if form == "bear_form" or form == "cat_form" and talent.call_of_the_elder_druid.enabled and debuff.oath_of_the_elder_druid.down then
         applyBuff( "heart_of_the_wild", 15 )
         applyDebuff( "player", "oath_of_the_elder_druid" )
     end
@@ -424,14 +498,6 @@ spec:RegisterHook( "runHandler", function( ability )
     end
 end )
 
-spec:RegisterStateExpr( "lunar_eclipse", function ()
-    return eclipse.wrath_counter
-end )
-
-spec:RegisterStateExpr( "solar_eclipse", function ()
-    return eclipse.starfire_counter
-end )
-
 
 -- Tier 30
 spec:RegisterGear( "tier30", 202518, 202516, 202515, 202514, 202513 )
@@ -442,6 +508,67 @@ spec:RegisterGear( "tier31", 207252, 207253, 207254, 207255, 207257, 217193, 217
 -- (2) You and your Grove Guardian's Nourishes now heal $s1 additional allies within $423618r yds at $s2% effectiveness.
 -- (4) Consuming Clearcasting now causes your Regrowth to also cast Nourish onto a nearby injured ally at $s1% effectiveness, preferring those with your heal over time effects.
 
+local TranquilityTickHandler = setfenv( function()
+
+    addStack( "tranquility_hot" )
+    if talent.dreamstate.enabled then
+        for ability, _ in pairs( class.abilities ) do
+            reduceCooldown( ability, 4 )
+        end
+    end
+
+end, state )
+
+local ComboPointPeriodic = setfenv( function()
+    gain( 1, "combo_points" )
+end, state )
+
+local TreantSpawnPeriodic = setfenv( function()
+    summonPet( "treants", 15 )
+    addStack( "grove_guardians" ) -- Just for tracking.
+    if talent.harmony_of_the_grove.enabled then addStack( "harmony_of_the_grove" ) end
+end, state )
+
+
+spec:RegisterHook( "reset_precast", function ()
+
+    if buff.casting.up and buff.casting.v1 == 740 then
+
+        local tickInterval = spec.auras.tranquility.tick_time
+        local tick, expires = buff.casting.applied, buff.casting.expires
+
+        for i = 1, 4 do
+            tick = tick + tickInterval
+            if tick > query_time and tick < expires then
+                state:QueueAuraEvent( "tranquility_tick", TranquilityTickHandler, tick, "AURA_TICK" )
+            end
+        end
+
+    end
+
+    if buff.heart_of_the_wild.up then
+        local tick, expires = buff.heart_of_the_wild.applied, buff.heart_of_the_wild.expires
+        for i = 2, expires - query_time, 2 do
+            tick = query_time + i
+            if tick < expires then
+                state:QueueAuraEvent( "incarnation_combo_point_perodic", ComboPointPeriodic, tick, "AURA_TICK" )
+            end
+        end
+    end
+
+    if buff.incarnation.up then
+        local tick, expires = buff.incarnation.applied, buff.incarnation.expires
+        for i = 10, expires - query_time, 10 do
+            tick = query_time + i
+            if tick < expires then
+                state:QueueAuraEvent( "tree_of_life_treant_spawn", TreantSpawnPeriodic, tick, "AURA_TICK" )
+            end
+        end
+    end
+
+
+
+end )
 
 -- Abilities
 spec:RegisterAbilities( {
@@ -460,7 +587,7 @@ spec:RegisterAbilities( {
         texture = 132137,
 
         handler = function ()
-            applyBuff( "cenarion_ward" )
+            active_dot.cenarion_ward = active_dot.cenarion_ward + 1
         end,
     },
 
@@ -479,6 +606,7 @@ spec:RegisterAbilities( {
         texture = 134222,
 
         handler = function ()
+            applyBuff( "efflorescence" )
         end,
     },
 
@@ -496,6 +624,7 @@ spec:RegisterAbilities( {
         toggle = "cooldowns",
 
         handler = function ()
+            applyBuff( "flourish" )
             if buff.cenarion_ward.up then buff.cenarion_ward.expires = buff.cenarion_ward.expires + 8 end
             if buff.grove_tending.up then buff.grove_tending.expires = buff.grove_tending.expires + 8 end
             if buff.lifebloom_2.up then buff.lifebloom_2.expires = buff.lifebloom_2.expires + 8 end
@@ -513,7 +642,7 @@ spec:RegisterAbilities( {
     grove_guardians = {
         id = 102693,
         cast = 0.0,
-        cooldown = 20,
+        cooldown = function () return 20 - 3 * talent.early_spring.rank end,
         recharge = 20,
         charges = 3,
         icd = 0.5,
@@ -525,15 +654,10 @@ spec:RegisterAbilities( {
         talent = "grove_guardians",
         startsCombat = false,
 
-        -- Effects:
-        -- #0: { 'type': DUMMY, 'subtype': NONE, 'target': TARGET_UNIT_TARGET_ALLY, }
-        -- #1: { 'type': SUMMON, 'subtype': NONE, 'points': 1.0, 'value': 54983, 'schools': ['physical', 'holy', 'fire', 'arcane'], 'value1': 5734, 'target': TARGET_DEST_CASTER, }
-
         handler = function()
-            class.abilities.swiftmend.handler()
-            if talent.wild_synthesis.enabled then class.abilities.wild_growth.handler() end
-            applyBuff( "grove_guardians" ) -- Just for tracking.
-            if talent.harmony_of_the_grove.enabled then applyBuff( "harmony_of_the_grove" ) end
+            summonPet( "treants", 15 )
+            addStack( "grove_guardians" ) -- Just for tracking.
+            if talent.harmony_of_the_grove.enabled then addStack( "harmony_of_the_grove" ) end
         end,
     },
 
@@ -541,7 +665,7 @@ spec:RegisterAbilities( {
     incarnation = {
         id = 33891,
         cast = 0,
-        cooldown = 180,
+        cooldown = function() return buff.tree_of_life_form.up and 0 or 180 end,
         gcd = "spell",
 
         talent = "incarnation",
@@ -551,7 +675,14 @@ spec:RegisterAbilities( {
         toggle = "cooldowns",
 
         handler = function ()
-            applyBuff( "incarnation_tree_of_life" )
+            if buff.incarnation.down then
+                applyBuff( "incarnation" )
+                if talent.cenarius_guidance.enabled then for i = 10, 30, 10 do
+                        state:QueueAuraEvent( "tree_of_life_treant_spawn", TreantSpawnPeriodic, queryTime + i , "AURA_TICK" )
+                    end
+                end
+            end
+            shift( "incarnation_tree_of_life" )
         end,
 
         copy = "incarnation_tree_of_life"
@@ -601,7 +732,7 @@ spec:RegisterAbilities( {
     ironbark = {
         id = 102342,
         cast = 0,
-        cooldown = 90,
+        cooldown = function() return 90 - ( talent.improved_ironbark.enabled and 20 or 0 ) end,
         gcd = "off",
 
         talent = "ironbark",
@@ -617,7 +748,7 @@ spec:RegisterAbilities( {
 
     -- Heals the target for 7,866 over 15 sec. When Lifebloom expires or is dispelled, the target is instantly healed for 4,004. May be active on one target at a time. Lifebloom counts for 2 stacks of Mastery: Harmony.
     lifebloom = {
-        id = 188550,
+        id = function() return talent.undergrowth.enabled and 188550 or 33763 end,
         cast = 0,
         cooldown = 0,
         gcd = "spell",
@@ -630,9 +761,10 @@ spec:RegisterAbilities( {
         texture = 134206,
 
         handler = function ()
-            if active_dot.lifebloom_2 > 0 then applyBuff( "lifebloom" )
-            elseif active_dot.lifebloom > 0 then applyBuff( "lifebloom_2" ) end
+            active_dot.lifebloom = min( active_dot.lifebloom + 1, 1 + ( 1 * talent.undergrowth.rank ) )
         end,
+
+        copy = { 188550, 33763 }
     },
 
     -- Cures harmful effects on the friendly target, removing all Magic, Curse, and Poison effects.
@@ -668,7 +800,7 @@ spec:RegisterAbilities( {
         id = 132158,
         cast = 0,
         charges = function() if talent.twinleaf.enabled then return 2 end end,
-        cooldown = 60,
+        cooldown = function() return 60 - 12 * talent.passing_seasons.rank end,
         recharge = function() if talent.twinleaf.enabled then return 60 end end,
         gcd = "off",
 
@@ -686,7 +818,7 @@ spec:RegisterAbilities( {
     -- Heals a friendly target for 6,471. Receives triple bonus from Mastery: Harmony.
     nourish = {
         id = 50464,
-        cast = 2,
+        cast = function() return 2 * haste * ( talent.wild_synthesis.enabled and ( 1 - 0.34 * buff.wild_synthesis.stack ) or 1 ) end,
         cooldown = 0,
         gcd = "spell",
 
@@ -698,6 +830,7 @@ spec:RegisterAbilities( {
         texture = 236162,
 
         handler = function ()
+            removeBuff( "wild_synthesis" )
         end,
     },
 
@@ -728,20 +861,24 @@ spec:RegisterAbilities( {
     -- Heals a friendly target for 4,267 and another 1,284 over 12 sec. Tree of Life: Instant cast.
     regrowth = {
         id = 8936,
-        cast = function() return ( buff.incarnation.up or buff.clearcasting.up ) and 0 or 1.5 * ( talent.wildwood_roots.enabled and ( 1 - 0.05 * buff.abundance.stack ) or 0 ) end,
+        cast = function() return ( buff.tree_of_life_form or buff.blooming_infusion_regrowth.up ) and 0 or 1.5 * ( talent.wildwood_roots.enabled and ( 1 - 0.05 * buff.abundance.stack ) or 1 ) * haste end,
         cooldown = 0,
         gcd = "spell",
 
-        spend = 0.10,
+        spend = function() return buff.clearcasting.up and 0 or 0.10 * ( talent.abundance.enabled and ( 1 - 0.08 * buff.abundance.stack ) or 1 ) end,
         spendType = "mana",
 
         startsCombat = false,
         texture = 136085,
 
         handler = function ()
-            removeBuff( "abundance" )
+            removeBuff( "natures_swiftness" )
             removeBuff( "clearcasting" )
-            applyBuff( "regrowth" )
+            active_dot.regrowth = active_dot.regrowth + 1 + ( talent.power_of_the_archdruid.enabled and buff.power_of_the_archdruid.up and 2 or 0 )
+            if talent.soul_of_the_forest.enabled then removeBuff( "soul_of_the_forest" ) end
+            if talent.forestwalk.enabled then applyBuff( "forestwalk" ) end
+            if talent.wild_synthesis.enabled then addStack( "wild_synthesis" ) end
+            if talent.blooming_infusion.enabled then removeBuff( "blooming_infusion_regrowth" ) end
         end,
     },
 
@@ -752,7 +889,7 @@ spec:RegisterAbilities( {
         cooldown = 0,
         gcd = "spell",
 
-        spend = function() return ( buff.incarnation.up and 0.7 or 1 ) * 0.021 end,
+        spend = function() return ( buff.tree_of_life_form.up and 0.7 or 1 ) * 0.021 end,
         spendType = "mana",
 
         talent = "rejuvenation",
@@ -760,7 +897,18 @@ spec:RegisterAbilities( {
         texture = 136081,
 
         handler = function ()
-            applyBuff( "rejuvenation" )
+            -- Main Rejuv buff
+            if talent.germination.enabled then
+                if buff.rejuvenation.down or buff.rejuvenation.remains < buff.rejuvenation_germination.remains then 
+                    applyBuff( "rejuvenation" )
+
+                elseif buff.germination.remains < buff.rejuvenation.remains then applyBuff( "rejuvenation_germination" )
+                end
+            else applyBuff( "rejuvenation" )
+            end
+
+            if talent.soul_of_the_forest.enabled then removeBuff( "soul_of_the_forest" ) end
+            active_dot.rejuvenation = active_dot.rejuvenation + 1 + ( talent.power_of_the_archdruid.enabled and buff.power_of_the_archdruid.up and 2 or 0 )
         end,
     },
 
@@ -779,6 +927,61 @@ spec:RegisterAbilities( {
 
         handler = function ()
             gain( 0.3 * health.max, "health" )
+        end,
+    },
+
+    starfire = {
+        id = 197628,
+        cast = function ()
+            if buff.blooming_infusion.up then return 0 end
+            return haste * 2.25
+        end,
+        cooldown = 0,
+        gcd = "spell",
+
+        spend = 0.06,
+        spendType = "mana",
+
+        startsCombat = true,
+        texture = 135753,
+        talent = "starfire",
+
+
+        handler = function ()
+            if buff.moonkin_form.down and buff.treant_form.down and buff.tree_of_life_form.down then
+                if talent.fluid_form.enabled then
+                    shift( "moonkin_form" )
+                else unshift()
+                end
+            end
+
+            if talent.blooming_infusion.enabled then removeBuff( "blooming_infusion" ) end
+
+            if talent.master_shapeshifter.enabled then gain( 43750, "mana" ) end
+        end,
+
+    },
+
+    starsurge = {
+        id = 197626,
+        cast = 0,
+        cooldown = function() return 10 - ( 4 * talent.starlight_conduit.rank ) end,
+        gcd = "spell",
+
+        spend = function () return ( talent.starlight_conduit.enabled and 0.003 or 0.006 ) end,
+        spendType = "mana",
+
+        startsCombat = true,
+        texture = 135730,
+        talent = "starsurge",
+
+        handler = function ()
+            gain( 0.3 * health.max, "health" )
+            if talent.master_shapeshifter.enabled then gain( 43750, "mana" ) end
+            if talent.call_of_the_elder_druid.enabled and debuff.oath_of_the_elder_druid.down then
+                applyBuff( "heart_of_the_wild", 15 )
+                applyDebuff( "player", "oath_of_the_elder_druid" )
+            end
         end,
     },
 
@@ -817,6 +1020,17 @@ spec:RegisterAbilities( {
                 elseif buff.renewing_bloom.up then removeBuff( "renewing_bloom" )
                 else removeBuff( "rejuvenation" ) end
             end
+
+            if talent.reforestation.enabled then
+                if buff.reforestation.stack == 3 then
+                    removeBuff( "reforestation" )
+                    applyBuff( "incarnation", ( 10 + 3 * talent.potent_enchantments.rank ) )
+                    shift( "tree_of_life_form" )
+                else addStack( "reforestation" )
+                end
+            end
+
+            if talent.soul_of_the_forest.enabled then applyBuff( "soul_of_the_forest" ) end
         end,
     },
 
@@ -843,7 +1057,7 @@ spec:RegisterAbilities( {
     -- Heals all allies within 40 yards for 8,560 over 6.6 sec. Each heal heals the target for another 199 over 8 sec, stacking. Healing increased by 100% when not in a raid.
     tranquility = {
         id = 740,
-        cast = function() return 8 * haste end,
+        cast = 8,
         channeled = true,
         cooldown = 180,
         gcd = "spell",
@@ -858,7 +1072,16 @@ spec:RegisterAbilities( {
         toggle = "defensives",
 
         start = function()
-            applyBuff( "tranquility" )
+            TranquilityTickHandler()
+
+            local tickTime = query_time
+            -- Schedule the next 4 ticks of Tranquility.
+            for i = 1, 4 do
+                tickTime = tickTime + spec.auras.tranquility.tick_time
+                if tickTime <= query_time + spec.auras.tranquility.duration then
+                    state:QueueAuraEvent( "tranquility_tick", TranquilityTickHandler, tickTime, "AURA_TICK" )
+                end
+            end
         end,
     },
 
@@ -877,8 +1100,48 @@ spec:RegisterAbilities( {
         texture = 236153,
 
         handler = function ()
-            applyBuff( "wild_growth" )
+            if talent.soul_of_the_forest.enabled then removeBuff( "soul_of_the_forest" ) end
+            active_dot.wild_growth = active_dot.wild_growth + 5 + ( talent.improved_wild_growth.enabled and 1 or 0 ) + ( buff.tree_of_life_form.up and 2 or 0 )
+
         end,
+    },
+
+    wrath = {
+        id = 5176,
+        cast = function ()
+            if buff.blooming_infusion.up or buff.tree_of_life_form.up then return 0 end
+            return haste * 1.5
+        end,
+        cooldown = 0,
+        gcd = "spell",
+
+        spend = 0.002,
+        spendType = "mana",
+
+        startsCombat = true,
+        texture = 535045,
+
+        velocity = 20,
+
+        energize_amount = function() return action.wrath.spend * -1 end,
+
+        handler = function ()
+
+            if buff.moonkin_form.down and buff.treant_form.down and buff.tree_of_life_form.down then
+                if talent.fluid_form.enabled then
+                    shift( "moonkin_form" )
+                else unshift()
+                end
+            end
+
+            if talent.blooming_infusion.enabled then removeBuff( "blooming_infusion" ) end
+            removeBuff( "gathering_starstuff" )
+
+            removeBuff( "dawning_sun" )
+            if talent.master_shapeshifter.enabled then gain( 43750, "mana" ) end
+        end,
+
+        copy = { "solar_wrath", 5176 }
     },
 } )
 
@@ -892,10 +1155,10 @@ spec:RegisterOptions( {
     aoe = 3,
     cycle = false,
 
-    nameplates = true,
-    nameplateRange = 10,
-    rangeFilter = false,
+    nameplates = false,
 
+    rangeFilter = false,
+    healing_mode = false,
     damage = true,
     damageDots = true,
     damageExpiration = 6,
@@ -903,12 +1166,26 @@ spec:RegisterOptions( {
     package = "Restoration Druid",
 } )
 
-
 spec:RegisterSetting( "experimental_msg", nil, {
     type = "description",
-    name = "|cFFFF0000WARNING|r:  Healer support in this addon is focused on DPS output only.  This is more useful for solo content or downtime when your healing output is less critical in a group/encounter.  Use at your own risk.",
+    name = strformat( "Restoration Druid supports healing maintenance by recommending key abilities. It will suggest maintaining %s, keeping at least one %s active, maintaining %s, using %s after a %s, and alerting you when %s can activate %s.",
+        Hekili:GetSpellLinkWithTexture( spec.abilities.lifebloom.id ),
+        Hekili:GetSpellLinkWithTexture( spec.abilities.rejuvenation.id ),
+        Hekili:GetSpellLinkWithTexture( spec.abilities.efflorescence.id ),
+        Hekili:GetSpellLinkWithTexture( spec.abilities.wild_growth.id ),
+        Hekili:GetSpellLinkWithTexture( spec.abilities.swiftmend.id ),
+        Hekili:GetSpellLinkWithTexture( spec.abilities.swiftmend.id ),
+        Hekili:GetSpellLinkWithTexture( spec.abilities.incarnation.id ) ),
+    width = "full",
+    fontSize = "medium"
+} )
+
+spec:RegisterSetting( "healing_mode", false, {
+    name = "Healing Helper Mode",
+    desc = "If checked, healing abilities may be recommended using the default priority package.",
+    type = "toggle",
     width = "full",
 } )
 
 
-spec:RegisterPack( "Restoration Druid", 20240908, [[Hekili:1IvAVnUnt4FlglGGDoCLptsHT)q7lkAdqx8I6fy)MoSeTfHLLuPKsAam0V9oK6IIhwoztbA3KypCoFMhoCSMy9nRT(UziRVo1C6CZNmFCm8llNn3AB2BjiRTjUEhDpa)sK7j4F)luAwmXndhhv48)i5yFQiVfg76tvvACoXdeZA7UCCy2FezTtL(NT4rq2eKN1xNyUWABa23hvklk1ZA7VJCdrKcNecoMGZWO0chxccS4)F797J9Ytr(foXrHVnU45INPQ(EZNU3CYDfo0F(4px489ae4Iy4))v3ScNFlMCc(w)4chp6FNfGJoK2E6hUFMjCQVfaw57UGT)oMkI12qCAwklnH27MhMb)6xzPnxpAwaIJJ5HH27CtdS2IIC3fI8T(fRmiI5LAhIKIihbJki1mQuTFYwpiGreSR12bfo7Y3VFCcj(1WX5jfogfo1FyAGRF8RNqH(W30AMi3SCck1(f8bCiv9Z)uvFaYLKzhV3olaz)ko0NAIfFQMaQT2W5pLsv9YpvvNeZ(jO3h0Q3ma5fLnM4EenUsGcNZNRumaDS3dijMAtZiyVmkAOXcK8i7YF3MIBkrp2LToWzPM(X3JPB1CTLPQ4jTQyyLFkvNyziAy4fhhc5MifIqqNCXrqR2McNLMfo3x4md(XnqZsPN5b2KGZtTpa99UrEczObnckR7gbhXfsXrVeFeXeknbdbbRMpXui8AA0YJ2Jji(4LG2dO9aQOmaqMl5akBCg(eO2yBFmIfnlQ(sMZHpbyMxq(2v6Rnx79MxiCoMosP1vQ3mrJ3CkoUF3rWpMmvJrMQTIsn3liBue6eJgCvHZJCPeqpP5GQyArKk5hpX9a7lv4dpOjq0t3a09anzL4JPoo1NktlCDyQqUDJxwOqT1cE(1xHlLeiGZk75Q5Rv6vY0fC(sl3sZhLMtVPY290U80GoUgTTTH1xxZzt3NcSFB)hKFNBk2tP6eTDvLsVhFiiZUJEw2d5TomdbNi47W)1b1qniajihEJveFYKHvAn(AOWAYCnd2H9IpTl2ojghLbF96MUsbixJcUTWz68sZmS7h3vta)0CwS2rtgDpYCThCJWbh1KnP5ESh9kBM66Ey4ytz6uax)kobzZMW4gMeJu3Oi2Nau72rO)P7TjjaAbQMvdvP4M2AbZciW4huZ(H7X7ggTkSmsvheI3oFb(grWZf5QhvFzEcb9I9bp)XtAU5TgnjYjTUHgPhAETLeXzc60y)Ei5nvKq5WfROIO2f0pBWa5bqywHRbCHzDUXpUAkcrx9If5z9iYQAOsvcU87uFZ(fgw5s3FQcLiDfAn4OP3SIHGdSuvYfiKGetE9txGMtZXpQQqvF0sa1ORanEPk9sn3tkoJtBoGZk1POEJd5wpvtUOFOI2MhfDw0jo6mDDhm4iDdJO)EWRclRgmjnIZ1XBknwsTK7rKypCmms7oW74Dsj2(zAjTwX(YYHRvEfxtGTUmYuIi(pHBFznLWf787sCgcv)qCeknTxkZj6FFMikQjd2nhTs7W502i5Nb10DXmVok7p(aVLoJQbEBOD(qVIqKz)kXT6FPhxZYstnjwUesab5xosmWVqLu9GX01Vat(vEOTrUjPbXagH4I9lBAPGbOpNAHDiiiqL2LcK2HoW4NCJ8zCL3dp3oJrqJtP3jfHgZX(7sokokAN9LipSANz7VWAtU6NrR)TkxufSxfWYLq28fejL(P1R3cQMV6sIO7wYA7FCkjMKrtzZkXuugB2(Kgx8mtr7XHak9lfoF(56INlTy64Mk(TR)jX8UAPKs(QfRozEhE)Av7nr5HyPpTNO5mGKTlwJ)tBxKg)N2zVxuTpOZl4mgO4HEp)LVuxwOQqy3n3r3AZAitaCHhUonA4txiAjNcq4g5BxFCkFQTN)6PM8oTuA(6mdVkA2w27)OLBd79FoL5jakCx5(WwprtX98zPB95061ILOIk)sy6PgQD)bNp3)wV2S08(zM303MUoFEqF74AuhmC5Td315sHYue3nsgY3gTzHrFpKHZm1tk2RD4mamjnVJwp8g9iDV)B1JFor0dgc69brhGPyqrQ3v0MjvqiLB3KtvSDbXXLqXCuGlGNOAxgExP36oGQ)uCxpI6tz77WRzfpRMB2cKUWIDgD(CNv6SA(sPGcNOQumCixX485YPf28KPrTMwpXCKXq(zgwVOd8OsWBNo)85H1)bV83mFfN81k(25ccTHtOrJOHD572m4fBZ0B18kQBMosmK7mM0D1tsTEIOCTt5(HaR6gzEZurdDHwIH91LpYyGI3vAmSBRYAa63dDGuAIb37lW55dmn0udwnXuu5801de51nQGBlmngQAxe6tTZ0(vREWq5EhKc7lrfoupxOrnUeq7YBsOPTP(L33aV6wmDvk66jJ0ut1LDL6PRXtGhRyBak9fjvONoNILgkYWBiveLsSxzj)J2T29P4QQEDimMPOBA1m6n9Dy0QCR1Y(1pe7WsJHAXWTTQYVKwkP2GcKRtqiYhmRumqa)BKFhKs9XjjDpTXGRDwK3zrN9UuQlvvNwAkeZ0BX5gtFC1a1meoDAt7u0FNJGb0AhxNGoa3Jdfen)eEjxEwqmXA7F6E0naFeZEkN1)(d]] )
+spec:RegisterPack( "Restoration Druid", 20241110, [[Hekili:1MvFVTnVr8plbdqZoV4j53sYGTb626aEkW6aECbE(pjlBrhZzzjd9sYcGH(SV7ifLiPiTDs7aABAepE8UF3R8OVN)p8xgfwq8)(q3HJ988ChmC0WrJ9xw8(rI)YJHB2h(c8Fscpa)7VtYlsZclOPjvR(hzL0iKK3JtdJqoLNwMTbiZF56sACXVL4V2e7hozeq7rYg)V75oXF5oAueHtljFJ)sK2h88EWZ9VwTA57z0T)58Qv7iHX0KxQwDinIuTkV84X0SIQVv9ng9Up)GR39vRWF(eSV)yhbKrk83)Eyr1Q)zA2by1O0QvBWFVyhWR82D)4dJWt7h7aw)hHzW)qrs8xgtZlYrLd2g8JVZGmss46ysK)Fd(CgTGKrdrDE72b57cJsF7ajoAq5XQvNovTI99JzPVfR(P8suTdcpSUmFhSK)YWniY6VmlCpXVaanRNvpqnstJHJkzWM0Kxt3tck2rcYpsbAYhKroestauBw1QXU8d9gqRdJjjfg3r9XuTQpN6T0x2veOWNPTsiymYkcs3YyXB04iuChPjUnQd9OMSd)jJSnJaOfqm)ajjKSxEVA1IQvpdsSdsI4WNxTYZLjAoSnVj9W60GJP0Kcyzy1jSvkOhaLkniIsy8PHb3vTA4y(X0t9ZQC6wqlz6QcNCu3YyRBCH2g73GMi2t3SN5)6OVzyBdz8eIjIJdkcZEHawK83OhjbmV1Bzu0hqX33eteuGoJaSpwd23MMfKq(Vf4Yn2GJG3cynRJqH1MyXyvSllmFhESY2mfRfI0mjyGoG)iBrv1OLHCn1Ssm1I4KxMSLMr08FUsXzIWLbG)JzKxdEzt0aVbGOeaG0bH3eEwVscahWduc3FYJB2QJxOhGW3xjrb1sJuWIzT5rBrcyG95GvnfWZ1aGk5xmdjXSi8K1Ch3uN)radSSsokbGtCfytuAXauQhOlQN1ip6cKmt4QudW81uGvbKjKsuNE2cSEin9Q8s0r3HcNJMyZ6mesol1MCTesaWukQdcbNUdEYKHsSvUdv)RWB8Cw6PMn0GdGnlT0PiGOlQhDd9WZWEvp7bpgISGZ7jbe01huYQNd6yEjOMSt3EDWRYx2SZKNE5QRlVPNE6wbLBjzPBOPL5bRbPtwi7KTFK1KwZylIONLsCnk2CUMz0J4)l52NksjC2iF1eNXG1hAAJKNFXuME6vaS7I1GGQy0SM2a0ZAJHrcbqYhteDXoEBPSnua6kbmUWyie4XM0oNV8IfGspZ(v63QN8SvFKcwM6AbyLaKDzeSDVcwxGyl5MAlUPIh5)u(k8Dr83r()5hHj7nyIzvBK2bVch)EbqxK89(VtW23ji8bmXqBYIZoMULSoon9G0b)L4431ktiD2n7GFWnTVDoQ4fryzHAwqKgQ2axMebimCdGc1ACDuRq8VOeEMUPnPvljXBVwTYO8IxK4tjXVdoy54PBOruHet2Unof8f3qsWBhQWJ)fuiQieVM2xrQ81VpLYEzI55AEfcP3wCGKej7Q97F9R2XMmcxlz9Fl9D8onbMxs1bTViTxl4b5hqrUGrrl8jqD1LHFUzplb)inOPilmjN3zaGrWfxlYiKZ1RSKmRXQVe)w47qKmsr1kHAfUfGeiFUeOP06a29tZASa(iY2WY427b3G77lHscRHcbYcMi0uq1Ac4QKHnAPrLURE367TxFwQ5bL7A3EmGLPeW3GxPVqJn5x2Y(CsrbohGb1zYcWzli3UaOv8FjaNdaFAab8zHis(zWD8Nt(nE3A7vh)mhrzoja2)HCtxw5NJ1htz)8S3areNG3ROj8OzUis9YHncMr3OwAlRmXQrPUAU9ADgoAlThAVT6E1cAhdvZ8DAMntxsA69UUA7dqGVlR5BXWzGZmJcTr(sjnkeZ6ParTTn0L3YzQB0PUZ6Xyh9)Q635Z1tJTs4MUz3LVwNLdXEAgdnP9KTlJyRk3Nh4E0AJIwue75B0U)i8F4x6RTZCREUQ6BZn)MkNb)n4UIAP4ly1kWggnpFuL6qqU5J57sHRkKfsJ4cd6VIfdbvEnRYiV9t8(eRjVWcvctIyxz(bi5sb7E60CC0ejKbsUkHz71ZAQu(PBE1RTk0vN0WELMZYcw(vgwcO5Rqvs8RSrM7(Sl4i(wywcwMYF5VDah6nczJ5EmyliSrupO6BmgTLgd(G)PQv)6X6QVXpX8bnw87M)x0XDZu1b8ntMamVNUDUPQeg3ed(SUJM9au22NI8xB7lr(RkTrGC)gLAHo3yyE)sBxV3H7XcuZRBAazNXEpK5qhi7Jlen15)4BLxh)JVpTQZC1gmR3ZRKp3ZIH60PodYrbnVo)cK0Uf8WD1ZAIVtNUC56ftDFyK7TxQe9Pt3CPIZ9v8h51mUxjlphIKQD40TUXIjoxA20shJOk6fphPdWBOIGkkbIBrTs1SN(1Orp6OX3h1fagJXihJf5w4v7czSTmjwXkIjLxa95qhxWFc5Ex37A(kIaQ)v9NVtNFgdF7DnVA3SXUTosN5T66F6KYR0nB80okf9OjtrVEsgJtN4daAXZUocon3ZTVtp5XanFII7rnH3nC8Pt9e)Im93oEMe9cgF3ynIwiru)(OAZhfVJmzlgENLbJF7W(6QSYKVUxmCS5E601o4YpLZQTPGUyO(bDMqIExkkVVZngEQaNEQHkZbx)lKoOdmXC3VKIlNpW1XInyMNRoZLtxFJEEDNA3TjUo9m98s2H2rwxA2JogFkPoQ95sf2ZEUqhHFj4T39XHAcBepMYTUdEshU4Ko3RVfBQn0TtmTWFcKydpWJrzPdlSNoh9L6PNH3PJrSdWELM8pB0Q6RRyY6PKWyKHOPzJWk9kz0QfR5DLRFQSdtD6z1hUnuT7JJ0buB8c6ANavuwzMzOHa5N94dKu6s5K6uN25MRTxKpOrN9udOivBNM6QPZyvC4QokViqltQBSgt2jnYwjOuFAUZ8AyNys8M4wZyZzjnK4vZcZ863gfPUYqhwWH8tf4yFO79BeiXG2)KcuNJfBc5IhS205nD2kdOVP)PUJTNXpJJ02exBM7SUgjMx)DsFtAU33zXY2FHNZ5MophDmmz(5Jyc(1naDtAIKWjYyRmx9LHLf7sZWxczF4o6EkBka()V]] )

--- a/TheWarWithin/DruidRestoration.lua
+++ b/TheWarWithin/DruidRestoration.lua
@@ -8,7 +8,6 @@ local Hekili = _G[ addon ]
 local class, state = Hekili.Class, Hekili.State
 
 local spec = Hekili:NewSpecialization( 105 )
-local strformat = string.format
 
 spec:RegisterResource( Enum.PowerType.Mana )
 spec:RegisterResource( Enum.PowerType.Energy )
@@ -203,7 +202,7 @@ spec:RegisterAuras( {
         max_stack = 12
     },
     call_of_the_elder_druid = {
-        id = 426790,
+        id = 338643,
         duration = 60,
         max_stack = 1,
         copy = "oath_of_the_elder_druid"
@@ -211,16 +210,12 @@ spec:RegisterAuras( {
     cenarion_ward = {
         id = 102351,
         duration = 30,
-        max_stack = 1,
-        dot = "buff",
-        friendly = true
+        max_stack = 1
     },
     cenarion_ward_hot = {
         id = 102352,
         duration = 8,
         tick_time = function() return mod_liveliness_hot( 2 ) end,
-        dot = "buff",
-        friendly = true,
         max_stack = 1
     },
     -- [393381] During Incarnation: Tree of Life, you summon a Grove Guardian every $393418t sec. The cooldown of Incarnation: Tree of Life is reduced by ${$s1/-1000}.1 sec when Grove Guardians fade.
@@ -235,18 +230,15 @@ spec:RegisterAuras( {
         duration = 15,
         max_stack = 1
     },
-    cultivation = {
-        id = 200389,
-        duration = 6,
-        dot = "buff",
-        friendly = true,
-        max_stack = 1
-    },
     efflorescence = {
-        id = 145205,
+        id = 81262,
         duration = 30,
         tick_time = function() return mod_liveliness_hot( 2 ) end,
+        pandemic = true,
         max_stack = 1,
+
+        -- Affected by:
+        -- disentanglement[233673] #1: { 'type': APPLY_AURA, 'subtype': ADD_PCT_MODIFIER, 'points': -40.0, 'target': TARGET_UNIT_CASTER, 'modifies': POWER_COST, }
     },
     flourish = {
         id = 197721,
@@ -256,7 +248,7 @@ spec:RegisterAuras( {
     grove_guardians = {
         id = 102693,
         duration = 15,
-        max_stack = 5,
+        max_stack = 3,
         generate = function( t )
             local expires = action.grove_guardians.lastCast + 15
 
@@ -280,54 +272,44 @@ spec:RegisterAuras( {
         duration = 9,
         max_stack = 1,
         copy = 279793 -- Azerite.
-    },4
+    },
     harmony_of_the_grove = {
         id = 428737,
         duration = 15,
-        max_stack = 3
-    },
-    -- The actual incarn buff
-    incarnation = {
-        id = 117679,
-        duration = 30,
         max_stack = 1
     },
-    -- This is the form
     incarnation_tree_of_life = {
         id = 33891,
-        duration = 3600,
+        duration = 30,
         max_stack = 1,
-        copy = "tree_of_life_form"
+        copy = "incarnation"
     },
     ironbark = {
         id = 102342,
         duration = function() return talent.regenerative_heartwood.enabled and 16 or 12 end,
         max_stack = 1
     },
-    -- talent = double lifebloom. Both spellID and actual buff spellID change.
     lifebloom = {
         id = 33763,
         duration = 15,
-        tick_time = function() return haste * mod_liveliness_hot( 1 ) end,
+        tick_time = function() return mod_liveliness_hot( 1 ) end,
         max_stack = 1,
         dot = "buff",
-        friendly = true,
+        copy = 290754
     },
     lifebloom_2 = {
         id = 188550,
         duration = 15,
-        tick_time = function() return haste * mod_liveliness_hot( 1 ) end,
+        tick_time = function() return mod_liveliness_hot( 1 ) end,
         max_stack = 1,
-        dot = "buff",
-        friendly = true,
-        copy = "lifebloom"
+        dot = "buff"
     },
     natures_swiftness = {
         id = 132158,
         duration = 3600,
         max_stack = 1,
         onRemove = function()
-            setCooldown( "natures_swiftness", spec.abilities.natures_swiftness.cooldown )
+            setCooldown( "natures_swiftness", 60 )
         end,
     },
     natures_vigil = {
@@ -341,33 +323,22 @@ spec:RegisterAuras( {
         duration = 60,
         max_stack = 1,
     },
-    reforestation = {
-        id = 392360,
-        duration = 3600,
-        max_stack = 3,
-    },
     regrowth = {
         id = 8936,
         duration = function() return 12 + 3 * talent.thriving_vegetation.rank end,
-        tick_time = function() return haste * mod_liveliness_hot( 2 ) end,
-        dot = "buff",
-        friendly = true,
+        tick_time = function() return mod_liveliness_hot( 2 ) end,
         max_stack = 1
     },
     rejuvenation = {
         id = 774,
-        duration = function() return 12 + 3 * talent.improved_rejuvenation.rank end,
-        tick_time = function() return haste * mod_liveliness_hot( 3 ) end,
-        dot = "buff",
-        friendly = true,
+        duration = 12,
+        tick_time = function() return mod_liveliness_hot( 3 ) end,
         max_stack = 1
     },
     rejuvenation_germination = {
         id = 155777,
-        duration = function () return spec.auras.rejuvenation.duration end,
-        tick_time = function() return haste * mod_liveliness_hot( 3 ) end,
-        dot = "buff",
-        friendly = true,
+        duration = 12,
+        tick_time = function() return mod_liveliness_hot( 3 ) end,
         max_stack = 1
     },
     renewing_bloom = {
@@ -376,68 +347,25 @@ spec:RegisterAuras( {
         tick_time = function() return mod_liveliness_hot( 1 ) end,
         max_stack = 1
     },
-    soul_of_the_forest = {
-        id = 114108,
-        duration = 15,
-        max_stack = 1,
-    },
-    spring_blossoms = {
-        id = 207386,
-        duration = 6,
-        dot = "buff",
-        friendly = true,
-        max_stack = 1,
-    },
     tranquility = {
         id = 740,
         duration = function() return 8 * haste end,
-        generate = function( t )
-            if buff.casting.up and buff.casting.v1 == 740 then
-                t.applied  = buff.casting.applied
-                t.duration = buff.casting.duration
-                t.expires  = buff.casting.expires
-                t.stack    = 1
-                t.caster   = "player"    
-                return
-            end
-
-            t.applied  = 0
-            t.duration = spec.auras.tranquility.duration
-            t.expires  = 0
-            t.stack    = 0
-            t.caster   = "nobody"
-        end,
-        tick_time = function() return ( 8 * haste ) / 5 end,  -- Interval between each tick based on haste
-        max_stack = 1
+        max_stack = 1,
     },
     tranquility_hot = {
         id = 157982,
         duration = 8,
         tick_time = function() return mod_liveliness_hot( 2 ) end,
-        max_stack = 5
+        max_stack = 1
     },
     wild_growth = {
         id = 48438,
         duration = 7,
         tick_time = function() return mod_liveliness_hot( 1 ) end,
-        dot = "buff",
-        friendly = true,
         max_stack = 1
-    },
-    wild_synthesis = {
-        id = 400534,
-        duration = 3600,
-        max_stack = 3
     },
 } )
 
-spec:RegisterPet( "treants",
-    54983,
-    "grove_guardians",
-    15,
-    54983 )
-
-spec:RegisterTotem( "treants", 54983 )
 
 spec:RegisterStateFunction( "break_stealth", function ()
     removeBuff( "shadowmeld" )
@@ -451,7 +379,6 @@ end )
 spec:RegisterStateFunction( "unshift", function()
     if conduit.tireless_pursuit.enabled and ( buff.cat_form.up or buff.travel_form.up ) then applyBuff( "tireless_pursuit" ) end
 
-    removeBuff( "tree_of_life_form" )
     removeBuff( "cat_form" )
     removeBuff( "bear_form" )
     removeBuff( "travel_form" )
@@ -465,7 +392,6 @@ end )
 spec:RegisterStateFunction( "shift", function( form )
     if conduit.tireless_pursuit.enabled and ( buff.cat_form.up or buff.travel_form.up ) then applyBuff( "tireless_pursuit" ) end
 
-    removeBuff( "tree_of_life_form" )
     removeBuff( "cat_form" )
     removeBuff( "bear_form" )
     removeBuff( "travel_form" )
@@ -479,7 +405,7 @@ spec:RegisterStateFunction( "shift", function( form )
         applyBuff( "celestial_guardian" )
     end
 
-    if form == "bear_form" or form == "cat_form" and talent.call_of_the_elder_druid.enabled and debuff.oath_of_the_elder_druid.down then
+    if talent.call_of_the_elder_druid.enabled and debuff.oath_of_the_elder_druid.down then
         applyBuff( "heart_of_the_wild", 15 )
         applyDebuff( "player", "oath_of_the_elder_druid" )
     end
@@ -498,6 +424,14 @@ spec:RegisterHook( "runHandler", function( ability )
     end
 end )
 
+spec:RegisterStateExpr( "lunar_eclipse", function ()
+    return eclipse.wrath_counter
+end )
+
+spec:RegisterStateExpr( "solar_eclipse", function ()
+    return eclipse.starfire_counter
+end )
+
 
 -- Tier 30
 spec:RegisterGear( "tier30", 202518, 202516, 202515, 202514, 202513 )
@@ -508,67 +442,6 @@ spec:RegisterGear( "tier31", 207252, 207253, 207254, 207255, 207257, 217193, 217
 -- (2) You and your Grove Guardian's Nourishes now heal $s1 additional allies within $423618r yds at $s2% effectiveness.
 -- (4) Consuming Clearcasting now causes your Regrowth to also cast Nourish onto a nearby injured ally at $s1% effectiveness, preferring those with your heal over time effects.
 
-local TranquilityTickHandler = setfenv( function()
-
-    addStack( "tranquility_hot" )
-    if talent.dreamstate.enabled then
-        for ability, _ in pairs( class.abilities ) do
-            reduceCooldown( ability, 4 )
-        end
-    end
-
-end, state )
-
-local ComboPointPeriodic = setfenv( function()
-    gain( 1, "combo_points" )
-end, state )
-
-local TreantSpawnPeriodic = setfenv( function()
-    summonPet( "treants", 15 )
-    addStack( "grove_guardians" ) -- Just for tracking.
-    if talent.harmony_of_the_grove.enabled then addStack( "harmony_of_the_grove" ) end
-end, state )
-
-
-spec:RegisterHook( "reset_precast", function ()
-
-    if buff.casting.up and buff.casting.v1 == 740 then
-
-        local tickInterval = spec.auras.tranquility.tick_time
-        local tick, expires = buff.casting.applied, buff.casting.expires
-
-        for i = 1, 4 do
-            tick = tick + tickInterval
-            if tick > query_time and tick < expires then
-                state:QueueAuraEvent( "tranquility_tick", TranquilityTickHandler, tick, "AURA_TICK" )
-            end
-        end
-
-    end
-
-    if buff.heart_of_the_wild.up then
-        local tick, expires = buff.heart_of_the_wild.applied, buff.heart_of_the_wild.expires
-        for i = 2, expires - query_time, 2 do
-            tick = query_time + i
-            if tick < expires then
-                state:QueueAuraEvent( "incarnation_combo_point_perodic", ComboPointPeriodic, tick, "AURA_TICK" )
-            end
-        end
-    end
-
-    if buff.incarnation.up then
-        local tick, expires = buff.incarnation.applied, buff.incarnation.expires
-        for i = 10, expires - query_time, 10 do
-            tick = query_time + i
-            if tick < expires then
-                state:QueueAuraEvent( "tree_of_life_treant_spawn", TreantSpawnPeriodic, tick, "AURA_TICK" )
-            end
-        end
-    end
-
-
-
-end )
 
 -- Abilities
 spec:RegisterAbilities( {
@@ -587,7 +460,7 @@ spec:RegisterAbilities( {
         texture = 132137,
 
         handler = function ()
-            active_dot.cenarion_ward = active_dot.cenarion_ward + 1
+            applyBuff( "cenarion_ward" )
         end,
     },
 
@@ -606,7 +479,6 @@ spec:RegisterAbilities( {
         texture = 134222,
 
         handler = function ()
-            applyBuff( "efflorescence" )
         end,
     },
 
@@ -624,7 +496,6 @@ spec:RegisterAbilities( {
         toggle = "cooldowns",
 
         handler = function ()
-            applyBuff( "flourish" )
             if buff.cenarion_ward.up then buff.cenarion_ward.expires = buff.cenarion_ward.expires + 8 end
             if buff.grove_tending.up then buff.grove_tending.expires = buff.grove_tending.expires + 8 end
             if buff.lifebloom_2.up then buff.lifebloom_2.expires = buff.lifebloom_2.expires + 8 end
@@ -642,7 +513,7 @@ spec:RegisterAbilities( {
     grove_guardians = {
         id = 102693,
         cast = 0.0,
-        cooldown = function () return 20 - 3 * talent.early_spring.rank end,
+        cooldown = 20,
         recharge = 20,
         charges = 3,
         icd = 0.5,
@@ -654,10 +525,15 @@ spec:RegisterAbilities( {
         talent = "grove_guardians",
         startsCombat = false,
 
+        -- Effects:
+        -- #0: { 'type': DUMMY, 'subtype': NONE, 'target': TARGET_UNIT_TARGET_ALLY, }
+        -- #1: { 'type': SUMMON, 'subtype': NONE, 'points': 1.0, 'value': 54983, 'schools': ['physical', 'holy', 'fire', 'arcane'], 'value1': 5734, 'target': TARGET_DEST_CASTER, }
+
         handler = function()
-            summonPet( "treants", 15 )
-            addStack( "grove_guardians" ) -- Just for tracking.
-            if talent.harmony_of_the_grove.enabled then addStack( "harmony_of_the_grove" ) end
+            class.abilities.swiftmend.handler()
+            if talent.wild_synthesis.enabled then class.abilities.wild_growth.handler() end
+            applyBuff( "grove_guardians" ) -- Just for tracking.
+            if talent.harmony_of_the_grove.enabled then applyBuff( "harmony_of_the_grove" ) end
         end,
     },
 
@@ -665,7 +541,7 @@ spec:RegisterAbilities( {
     incarnation = {
         id = 33891,
         cast = 0,
-        cooldown = function() return buff.tree_of_life_form.up and 0 or 180 end,
+        cooldown = 180,
         gcd = "spell",
 
         talent = "incarnation",
@@ -675,14 +551,7 @@ spec:RegisterAbilities( {
         toggle = "cooldowns",
 
         handler = function ()
-            if buff.incarnation.down then
-                applyBuff( "incarnation" )
-                if talent.cenarius_guidance.enabled then for i = 10, 30, 10 do
-                        state:QueueAuraEvent( "tree_of_life_treant_spawn", TreantSpawnPeriodic, queryTime + i , "AURA_TICK" )
-                    end
-                end
-            end
-            shift( "incarnation_tree_of_life" )
+            applyBuff( "incarnation_tree_of_life" )
         end,
 
         copy = "incarnation_tree_of_life"
@@ -732,7 +601,7 @@ spec:RegisterAbilities( {
     ironbark = {
         id = 102342,
         cast = 0,
-        cooldown = function() return 90 - ( talent.improved_ironbark.enabled and 20 or 0 ) end,
+        cooldown = 90,
         gcd = "off",
 
         talent = "ironbark",
@@ -748,7 +617,7 @@ spec:RegisterAbilities( {
 
     -- Heals the target for 7,866 over 15 sec. When Lifebloom expires or is dispelled, the target is instantly healed for 4,004. May be active on one target at a time. Lifebloom counts for 2 stacks of Mastery: Harmony.
     lifebloom = {
-        id = function() return talent.undergrowth.enabled and 188550 or 33763 end,
+        id = 188550,
         cast = 0,
         cooldown = 0,
         gcd = "spell",
@@ -761,10 +630,9 @@ spec:RegisterAbilities( {
         texture = 134206,
 
         handler = function ()
-            active_dot.lifebloom = min( active_dot.lifebloom + 1, 1 + ( 1 * talent.undergrowth.rank ) )
+            if active_dot.lifebloom_2 > 0 then applyBuff( "lifebloom" )
+            elseif active_dot.lifebloom > 0 then applyBuff( "lifebloom_2" ) end
         end,
-
-        copy = { 188550, 33763 }
     },
 
     -- Cures harmful effects on the friendly target, removing all Magic, Curse, and Poison effects.
@@ -800,7 +668,7 @@ spec:RegisterAbilities( {
         id = 132158,
         cast = 0,
         charges = function() if talent.twinleaf.enabled then return 2 end end,
-        cooldown = function() return 60 - 12 * talent.passing_seasons.rank end,
+        cooldown = 60,
         recharge = function() if talent.twinleaf.enabled then return 60 end end,
         gcd = "off",
 
@@ -818,7 +686,7 @@ spec:RegisterAbilities( {
     -- Heals a friendly target for 6,471. Receives triple bonus from Mastery: Harmony.
     nourish = {
         id = 50464,
-        cast = function() return 2 * haste * ( talent.wild_synthesis.enabled and ( 1 - 0.34 * buff.wild_synthesis.stack ) or 1 ) end,
+        cast = 2,
         cooldown = 0,
         gcd = "spell",
 
@@ -830,7 +698,6 @@ spec:RegisterAbilities( {
         texture = 236162,
 
         handler = function ()
-            removeBuff( "wild_synthesis" )
         end,
     },
 
@@ -861,24 +728,20 @@ spec:RegisterAbilities( {
     -- Heals a friendly target for 4,267 and another 1,284 over 12 sec. Tree of Life: Instant cast.
     regrowth = {
         id = 8936,
-        cast = function() return ( buff.tree_of_life_form or buff.blooming_infusion_regrowth.up ) and 0 or 1.5 * ( talent.wildwood_roots.enabled and ( 1 - 0.05 * buff.abundance.stack ) or 1 ) end,
+        cast = function() return ( buff.incarnation.up or buff.clearcasting.up ) and 0 or 1.5 * ( talent.wildwood_roots.enabled and ( 1 - 0.05 * buff.abundance.stack ) or 0 ) end,
         cooldown = 0,
         gcd = "spell",
 
-        spend = function() return buff.clearcasting.up and 0 or 0.10 * ( talent.abundance.enabled and ( 1 - 0.08 * buff.abundance.stack ) or 1 ) end,
+        spend = 0.10,
         spendType = "mana",
 
         startsCombat = false,
         texture = 136085,
 
         handler = function ()
-            removeBuff( "natures_swiftness" )
+            removeBuff( "abundance" )
             removeBuff( "clearcasting" )
-            active_dot.regrowth = active_dot.regrowth + 1 + ( talent.power_of_the_archdruid.enabled and buff.power_of_the_archdruid.up and 2 or 0 )
-            if talent.soul_of_the_forest.enabled then removeBuff( "soul_of_the_forest" ) end
-            if talent.forestwalk.enabled then applyBuff( "forestwalk" ) end
-            if talent.wild_synthesis.enabled then addStack( "wild_synthesis" ) end
-            if talent.blooming_infusion.enabled then removeBuff( "blooming_infusion_regrowth" ) end
+            applyBuff( "regrowth" )
         end,
     },
 
@@ -889,7 +752,7 @@ spec:RegisterAbilities( {
         cooldown = 0,
         gcd = "spell",
 
-        spend = function() return ( buff.tree_of_life_form.up and 0.7 or 1 ) * 0.021 end,
+        spend = function() return ( buff.incarnation.up and 0.7 or 1 ) * 0.021 end,
         spendType = "mana",
 
         talent = "rejuvenation",
@@ -897,18 +760,7 @@ spec:RegisterAbilities( {
         texture = 136081,
 
         handler = function ()
-            -- Main Rejuv buff
-            if talent.germination.enabled then
-                if buff.rejuvenation.down or buff.rejuvenation.remains < buff.rejuvenation_germination.remains then 
-                    applyBuff( "rejuvenation" )
-
-                elseif buff.germination.remains < buff.rejuvenation.remains then applyBuff( "rejuvenation_germination" )
-                end
-            else applyBuff( "rejuvenation" )
-            end
-
-            if talent.soul_of_the_forest.enabled then removeBuff( "soul_of_the_forest" ) end
-            active_dot.rejuvenation = active_dot.rejuvenation + 1 + ( talent.power_of_the_archdruid.enabled and buff.power_of_the_archdruid.up and 2 or 0 )
+            applyBuff( "rejuvenation" )
         end,
     },
 
@@ -927,61 +779,6 @@ spec:RegisterAbilities( {
 
         handler = function ()
             gain( 0.3 * health.max, "health" )
-        end,
-    },
-
-    starfire = {
-        id = 197628,
-        cast = function ()
-            if buff.blooming_infusion.up then return 0 end
-            return haste * 2.25
-        end,
-        cooldown = 0,
-        gcd = "spell",
-
-        spend = 0.06,
-        spendType = "mana",
-
-        startsCombat = true,
-        texture = 135753,
-        talent = "starfire",
-
-
-        handler = function ()
-            if buff.moonkin_form.down and buff.treant_form.down and buff.tree_of_life_form.down then
-                if talent.fluid_form.enabled then
-                    shift( "moonkin_form" )
-                else unshift()
-                end
-            end
-
-            if talent.blooming_infusion.enabled then removeBuff( "blooming_infusion" ) end
-
-            if talent.master_shapeshifter.enabled then gain( 43750, "mana" ) end
-        end,
-
-    },
-
-    starsurge = {
-        id = 197626,
-        cast = 0,
-        cooldown = function() return 10 - ( 4 * talent.starlight_conduit.rank ) end,
-        gcd = "spell",
-
-        spend = function () return ( talent.starlight_conduit.enabled and 0.003 or 0.006 ) end,
-        spendType = "mana",
-
-        startsCombat = true,
-        texture = 135730,
-        talent = "starsurge",
-
-        handler = function ()
-            gain( 0.3 * health.max, "health" )
-            if talent.master_shapeshifter.enabled then gain( 43750, "mana" ) end
-            if talent.call_of_the_elder_druid.enabled and debuff.oath_of_the_elder_druid.down then
-                applyBuff( "heart_of_the_wild", 15 )
-                applyDebuff( "player", "oath_of_the_elder_druid" )
-            end
         end,
     },
 
@@ -1020,17 +817,6 @@ spec:RegisterAbilities( {
                 elseif buff.renewing_bloom.up then removeBuff( "renewing_bloom" )
                 else removeBuff( "rejuvenation" ) end
             end
-
-            if talent.reforestation.enabled then
-                if buff.reforestation.stack == 3 then
-                    removeBuff( "reforestation" )
-                    applyBuff( "incarnation", ( 10 + 3 * talent.potent_enchantments.rank ) )
-                    shift( "tree_of_life_form" )
-                else addStack( "reforestation" )
-                end
-            end
-
-            if talent.soul_of_the_forest.enabled then applyBuff( "soul_of_the_forest" ) end
         end,
     },
 
@@ -1072,16 +858,7 @@ spec:RegisterAbilities( {
         toggle = "defensives",
 
         start = function()
-            TranquilityTickHandler()
-
-            local tickTime = query_time
-            -- Schedule the next 4 ticks of Tranquility.
-            for i = 1, 4 do
-                tickTime = tickTime + spec.auras.tranquility.tick_time
-                if tickTime <= query_time + spec.auras.tranquility.duration then
-                    state:QueueAuraEvent( "tranquility_tick", TranquilityTickHandler, tickTime, "AURA_TICK" )
-                end
-            end
+            applyBuff( "tranquility" )
         end,
     },
 
@@ -1100,48 +877,8 @@ spec:RegisterAbilities( {
         texture = 236153,
 
         handler = function ()
-            if talent.soul_of_the_forest.enabled then removeBuff( "soul_of_the_forest" ) end
-            active_dot.wild_growth = active_dot.wild_growth + 5 + ( talent.improved_wild_growth.enabled and 1 or 0 ) + ( buff.tree_of_life_form.up and 2 or 0 )
-
+            applyBuff( "wild_growth" )
         end,
-    },
-
-    wrath = {
-        id = 5176,
-        cast = function ()
-            if buff.blooming_infusion.up or buff.tree_of_life_form.up then return 0 end
-            return haste * 1.5
-        end,
-        cooldown = 0,
-        gcd = "spell",
-
-        spend = 0.002,
-        spendType = "mana",
-
-        startsCombat = true,
-        texture = 535045,
-
-        velocity = 20,
-
-        energize_amount = function() return action.wrath.spend * -1 end,
-
-        handler = function ()
-
-            if buff.moonkin_form.down and buff.treant_form.down and buff.tree_of_life_form.down then
-                if talent.fluid_form.enabled then
-                    shift( "moonkin_form" )
-                else unshift()
-                end
-            end
-
-            if talent.blooming_infusion.enabled then removeBuff( "blooming_infusion" ) end
-            removeBuff( "gathering_starstuff" )
-
-            removeBuff( "dawning_sun" )
-            if talent.master_shapeshifter.enabled then gain( 43750, "mana" ) end
-        end,
-
-        copy = { "solar_wrath", 5176 }
     },
 } )
 
@@ -1155,10 +892,10 @@ spec:RegisterOptions( {
     aoe = 3,
     cycle = false,
 
-    nameplates = false,
-
+    nameplates = true,
+    nameplateRange = 10,
     rangeFilter = false,
-    healing_mode = false,
+
     damage = true,
     damageDots = true,
     damageExpiration = 6,
@@ -1166,26 +903,12 @@ spec:RegisterOptions( {
     package = "Restoration Druid",
 } )
 
+
 spec:RegisterSetting( "experimental_msg", nil, {
     type = "description",
-    name = strformat( "Restoration Druid supports healing maintenance by recommending key abilities. It will suggest maintaining %s, keeping at least one %s active, maintaining %s, using %s after a %s, and alerting you when %s can activate %s.",
-        Hekili:GetSpellLinkWithTexture( spec.abilities.lifebloom.id ),
-        Hekili:GetSpellLinkWithTexture( spec.abilities.rejuvenation.id ),
-        Hekili:GetSpellLinkWithTexture( spec.abilities.efflorescence.id ),
-        Hekili:GetSpellLinkWithTexture( spec.abilities.wild_growth.id ),
-        Hekili:GetSpellLinkWithTexture( spec.abilities.swiftmend.id ),
-        Hekili:GetSpellLinkWithTexture( spec.abilities.swiftmend.id ),
-        Hekili:GetSpellLinkWithTexture( spec.abilities.incarnation.id ) ),
-    width = "full",
-    fontSize = "medium"
-} )
-
-spec:RegisterSetting( "healing_mode", false, {
-    name = "Healing Helper Mode",
-    desc = "If checked, healing abilities may be recommended using the default priority package.",
-    type = "toggle",
+    name = "|cFFFF0000WARNING|r:  Healer support in this addon is focused on DPS output only.  This is more useful for solo content or downtime when your healing output is less critical in a group/encounter.  Use at your own risk.",
     width = "full",
 } )
 
 
-spec:RegisterPack( "Restoration Druid", 20241110, [[Hekili:1MvFVTnVr8plbdqZoV4j53sYGTb626aEkW6aECbE(pjlBrhZzzjd9sYcGH(SV7ifLiPiTDs7aABAepE8UF3R8OVN)p8xgfwq8)(q3HJ988ChmC0WrJ9xw8(rI)YJHB2h(c8Fscpa)7VtYlsZclOPjvR(hzL0iKK3JtdJqoLNwMTbiZF56sACXVL4V2e7hozeq7rYg)V75oXF5oAueHtljFJ)sK2h88EWZ9VwTA57z0T)58Qv7iHX0KxQwDinIuTkV84X0SIQVv9ng9Up)GR39vRWF(eSV)yhbKrk83)Eyr1Q)zA2by1O0QvBWFVyhWR82D)4dJWt7h7aw)hHzW)qrs8xgtZlYrLd2g8JVZGmss46ysK)Fd(CgTGKrdrDE72b57cJsF7ajoAq5XQvNovTI99JzPVfR(P8suTdcpSUmFhSK)YWniY6VmlCpXVaanRNvpqnstJHJkzWM0Kxt3tck2rcYpsbAYhKroestauBw1QXU8d9gqRdJjjfg3r9XuTQpN6T0x2veOWNPTsiymYkcs3YyXB04iuChPjUnQd9OMSd)jJSnJaOfqm)ajjKSxEVA1IQvpdsSdsI4WNxTYZLjAoSnVj9W60GJP0Kcyzy1jSvkOhaLkniIsy8PHb3vTA4y(X0t9ZQC6wqlz6QcNCu3YyRBCH2g73GMi2t3SN5)6OVzyBdz8eIjIJdkcZEHawK83OhjbmV1Bzu0hqX33eteuGoJaSpwd23MMfKq(Vf4Yn2GJG3cynRJqH1MyXyvSllmFhESY2mfRfI0mjyGoG)iBrv1OLHCn1Ssm1I4KxMSLMr08FUsXzIWLbG)JzKxdEzt0aVbGOeaG0bH3eEwVscahWduc3FYJB2QJxOhGW3xjrb1sJuWIzT5rBrcyG95GvnfWZ1aGk5xmdjXSi8K1Ch3uN)radSSsokbGtCfytuAXauQhOlQN1ip6cKmt4QudW81uGvbKjKsuNE2cSEin9Q8s0r3HcNJMyZ6mesol1MCTesaWukQdcbNUdEYKHsSvUdv)RWB8Cw6PMn0GdGnlT0PiGOlQhDd9WZWEvp7bpgISGZ7jbe01huYQNd6yEjOMSt3EDWRYx2SZKNE5QRlVPNE6wbLBjzPBOPL5bRbPtwi7KTFK1KwZylIONLsCnk2CUMz0J4)l52NksjC2iF1eNXG1hAAJKNFXuME6vaS7I1GGQy0SM2a0ZAJHrcbqYhteDXoEBPSnua6kbmUWyie4XM0oNV8IfGspZ(v63QN8SvFKcwM6AbyLaKDzeSDVcwxGyl5MAlUPIh5)u(k8Dr83r()5hHj7nyIzvBK2bVch)EbqxK89(VtW23ji8bmXqBYIZoMULSoon9G0b)L4431ktiD2n7GFWnTVDoQ4fryzHAwqKgQ2axMebimCdGc1ACDuRq8VOeEMUPnPvljXBVwTYO8IxK4tjXVdoy54PBOruHet2Unof8f3qsWBhQWJ)fuiQieVM2xrQ81VpLYEzI55AEfcP3wCGKej7Q97F9R2XMmcxlz9Fl9D8onbMxs1bTViTxl4b5hqrUGrrl8jqD1LHFUzplb)inOPilmjN3zaGrWfxlYiKZ1RSKmRXQVe)w47qKmsr1kHAfUfGeiFUeOP06a29tZASa(iY2WY427b3G77lHscRHcbYcMi0uq1Ac4QKHnAPrLURE367TxFwQ5bL7A3EmGLPeW3GxPVqJn5x2Y(CsrbohGb1zYcWzli3UaOv8FjaNdaFAab8zHis(zWD8Nt(nE3A7vh)mhrzoja2)HCtxw5NJ1htz)8S3areNG3ROj8OzUis9YHncMr3OwAlRmXQrPUAU9ADgoAlThAVT6E1cAhdvZ8DAMntxsA69UUA7dqGVlR5BXWzGZmJcTr(sjnkeZ6ParTTn0L3YzQB0PUZ6Xyh9)Q635Z1tJTs4MUz3LVwNLdXEAgdnP9KTlJyRk3Nh4E0AJIwue75B0U)i8F4x6RTZCREUQ6BZn)MkNb)n4UIAP4ly1kWggnpFuL6qqU5J57sHRkKfsJ4cd6VIfdbvEnRYiV9t8(eRjVWcvctIyxz(bi5sb7E60CC0ejKbsUkHz71ZAQu(PBE1RTk0vN0WELMZYcw(vgwcO5Rqvs8RSrM7(Sl4i(wywcwMYF5VDah6nczJ5EmyliSrupO6BmgTLgd(G)PQv)6X6QVXpX8bnw87M)x0XDZu1b8ntMamVNUDUPQeg3ed(SUJM9au22NI8xB7lr(RkTrGC)gLAHo3yyE)sBxV3H7XcuZRBAazNXEpK5qhi7Jlen15)4BLxh)JVpTQZC1gmR3ZRKp3ZIH60PodYrbnVo)cK0Uf8WD1ZAIVtNUC56ftDFyK7TxQe9Pt3CPIZ9v8h51mUxjlphIKQD40TUXIjoxA20shJOk6fphPdWBOIGkkbIBrTs1SN(1Orp6OX3h1fagJXihJf5w4v7czSTmjwXkIjLxa95qhxWFc5Ex37A(kIaQ)v9NVtNFgdF7DnVA3SXUTosN5T66F6KYR0nB80okf9OjtrVEsgJtN4daAXZUocon3ZTVtp5XanFII7rnH3nC8Pt9e)Im93oEMe9cgF3ynIwiru)(OAZhfVJmzlgENLbJF7W(6QSYKVUxmCS5E601o4YpLZQTPGUyO(bDMqIExkkVVZngEQaNEQHkZbx)lKoOdmXC3VKIlNpW1XInyMNRoZLtxFJEEDNA3TjUo9m98s2H2rwxA2JogFkPoQ95sf2ZEUqhHFj4T39XHAcBepMYTUdEshU4Ko3RVfBQn0TtmTWFcKydpWJrzPdlSNoh9L6PNH3PJrSdWELM8pB0Q6RRyY6PKWyKHOPzJWk9kz0QfR5DLRFQSdtD6z1hUnuT7JJ0buB8c6ANavuwzMzOHa5N94dKu6s5K6uN25MRTxKpOrN9udOivBNM6QPZyvC4QokViqltQBSgt2jnYwjOuFAUZ8AyNys8M4wZyZzjnK4vZcZ863gfPUYqhwWH8tf4yFO79BeiXG2)KcuNJfBc5IhS205nD2kdOVP)PUJTNXpJJ02exBM7SUgjMx)DsFtAU33zXY2FHNZ5MophDmmz(5Jyc(1naDtAIKWjYyRmx9LHLf7sZWxczF4o6EkBka()V]] )
+spec:RegisterPack( "Restoration Druid", 20240908, [[Hekili:1IvAVnUnt4FlglGGDoCLptsHT)q7lkAdqx8I6fy)MoSeTfHLLuPKsAam0V9oK6IIhwoztbA3KypCoFMhoCSMy9nRT(UziRVo1C6CZNmFCm8llNn3AB2BjiRTjUEhDpa)sK7j4F)luAwmXndhhv48)i5yFQiVfg76tvvACoXdeZA7UCCy2FezTtL(NT4rq2eKN1xNyUWABa23hvklk1ZA7VJCdrKcNecoMGZWO0chxccS4)F797J9Ytr(foXrHVnU45INPQ(EZNU3CYDfo0F(4px489ae4Iy4))v3ScNFlMCc(w)4chp6FNfGJoK2E6hUFMjCQVfaw57UGT)oMkI12qCAwklnH27MhMb)6xzPnxpAwaIJJ5HH27CtdS2IIC3fI8T(fRmiI5LAhIKIihbJki1mQuTFYwpiGreSR12bfo7Y3VFCcj(1WX5jfogfo1FyAGRF8RNqH(W30AMi3SCck1(f8bCiv9Z)uvFaYLKzhV3olaz)ko0NAIfFQMaQT2W5pLsv9YpvvNeZ(jO3h0Q3ma5fLnM4EenUsGcNZNRumaDS3dijMAtZiyVmkAOXcK8i7YF3MIBkrp2LToWzPM(X3JPB1CTLPQ4jTQyyLFkvNyziAy4fhhc5MifIqqNCXrqR2McNLMfo3x4md(XnqZsPN5b2KGZtTpa99UrEczObnckR7gbhXfsXrVeFeXeknbdbbRMpXui8AA0YJ2Jji(4LG2dO9aQOmaqMl5akBCg(eO2yBFmIfnlQ(sMZHpbyMxq(2v6Rnx79MxiCoMosP1vQ3mrJ3CkoUF3rWpMmvJrMQTIsn3liBue6eJgCvHZJCPeqpP5GQyArKk5hpX9a7lv4dpOjq0t3a09anzL4JPoo1NktlCDyQqUDJxwOqT1cE(1xHlLeiGZk75Q5Rv6vY0fC(sl3sZhLMtVPY290U80GoUgTTTH1xxZzt3NcSFB)hKFNBk2tP6eTDvLsVhFiiZUJEw2d5TomdbNi47W)1b1qniajihEJveFYKHvAn(AOWAYCnd2H9IpTl2ojghLbF96MUsbixJcUTWz68sZmS7h3vta)0CwS2rtgDpYCThCJWbh1KnP5ESh9kBM66Ey4ytz6uax)kobzZMW4gMeJu3Oi2Nau72rO)P7TjjaAbQMvdvP4M2AbZciW4huZ(H7X7ggTkSmsvheI3oFb(grWZf5QhvFzEcb9I9bp)XtAU5TgnjYjTUHgPhAETLeXzc60y)Ei5nvKq5WfROIO2f0pBWa5bqywHRbCHzDUXpUAkcrx9If5z9iYQAOsvcU87uFZ(fgw5s3FQcLiDfAn4OP3SIHGdSuvYfiKGetE9txGMtZXpQQqvF0sa1ORanEPk9sn3tkoJtBoGZk1POEJd5wpvtUOFOI2MhfDw0jo6mDDhm4iDdJO)EWRclRgmjnIZ1XBknwsTK7rKypCmms7oW74Dsj2(zAjTwX(YYHRvEfxtGTUmYuIi(pHBFznLWf787sCgcv)qCeknTxkZj6FFMikQjd2nhTs7W502i5Nb10DXmVok7p(aVLoJQbEBOD(qVIqKz)kXT6FPhxZYstnjwUesab5xosmWVqLu9GX01Vat(vEOTrUjPbXagH4I9lBAPGbOpNAHDiiiqL2LcK2HoW4NCJ8zCL3dp3oJrqJtP3jfHgZX(7sokokAN9LipSANz7VWAtU6NrR)TkxufSxfWYLq28fejL(P1R3cQMV6sIO7wYA7FCkjMKrtzZkXuugB2(Kgx8mtr7XHak9lfoF(56INlTy64Mk(TR)jX8UAPKs(QfRozEhE)Av7nr5HyPpTNO5mGKTlwJ)tBxKg)N2zVxuTpOZl4mgO4HEp)LVuxwOQqy3n3r3AZAitaCHhUonA4txiAjNcq4g5BxFCkFQTN)6PM8oTuA(6mdVkA2w27)OLBd79FoL5jakCx5(WwprtX98zPB95061ILOIk)sy6PgQD)bNp3)wV2S08(zM303MUoFEqF74AuhmC5Td315sHYue3nsgY3gTzHrFpKHZm1tk2RD4mamjnVJwp8g9iDV)B1JFor0dgc69brhGPyqrQ3v0MjvqiLB3KtvSDbXXLqXCuGlGNOAxgExP36oGQ)uCxpI6tz77WRzfpRMB2cKUWIDgD(CNv6SA(sPGcNOQumCixX485YPf28KPrTMwpXCKXq(zgwVOd8OsWBNo)85H1)bV83mFfN81k(25ccTHtOrJOHD572m4fBZ0B18kQBMosmK7mM0D1tsTEIOCTt5(HaR6gzEZurdDHwIH91LpYyGI3vAmSBRYAa63dDGuAIb37lW55dmn0udwnXuu5801de51nQGBlmngQAxe6tTZ0(vREWq5EhKc7lrfoupxOrnUeq7YBsOPTP(L33aV6wmDvk66jJ0ut1LDL6PRXtGhRyBak9fjvONoNILgkYWBiveLsSxzj)J2T29P4QQEDimMPOBA1m6n9Dy0QCR1Y(1pe7WsJHAXWTTQYVKwkP2GcKRtqiYhmRumqa)BKFhKs9XjjDpTXGRDwK3zrN9UuQlvvNwAkeZ0BX5gtFC1a1meoDAt7u0FNJGb0AhxNGoa3Jdfen)eEjxEwqmXA7F6E0naFeZEkN1)(d]] )

--- a/TheWarWithin/DruidRestoration.lua
+++ b/TheWarWithin/DruidRestoration.lua
@@ -210,12 +210,16 @@ spec:RegisterAuras( {
     cenarion_ward = {
         id = 102351,
         duration = 30,
-        max_stack = 1
+        max_stack = 1,
+        dot = "buff",
+        friendly = true
     },
     cenarion_ward_hot = {
         id = 102352,
         duration = 8,
         tick_time = function() return mod_liveliness_hot( 2 ) end,
+        dot = "buff",
+        friendly = true,
         max_stack = 1
     },
     -- [393381] During Incarnation: Tree of Life, you summon a Grove Guardian every $393418t sec. The cooldown of Incarnation: Tree of Life is reduced by ${$s1/-1000}.1 sec when Grove Guardians fade.
@@ -230,15 +234,18 @@ spec:RegisterAuras( {
         duration = 15,
         max_stack = 1
     },
+    cultivation = {
+        id = 200389,
+        duration = 6,
+        dot = "buff",
+        friendly = true,
+        max_stack = 1
+    },
     efflorescence = {
-        id = 81262,
+        id = 145205,
         duration = 30,
         tick_time = function() return mod_liveliness_hot( 2 ) end,
-        pandemic = true,
         max_stack = 1,
-
-        -- Affected by:
-        -- disentanglement[233673] #1: { 'type': APPLY_AURA, 'subtype': ADD_PCT_MODIFIER, 'points': -40.0, 'target': TARGET_UNIT_CASTER, 'modifies': POWER_COST, }
     },
     flourish = {
         id = 197721,
@@ -276,33 +283,43 @@ spec:RegisterAuras( {
     harmony_of_the_grove = {
         id = 428737,
         duration = 15,
+        max_stack = 3
+    },
+    -- The actual incarn buff
+    incarnation = {
+        id = 117679,
+        duration = 3600,
         max_stack = 1
     },
+    -- This is the form
     incarnation_tree_of_life = {
         id = 33891,
         duration = 30,
         max_stack = 1,
-        copy = "incarnation"
+        copy = "tree_of_life_form"
     },
     ironbark = {
         id = 102342,
         duration = function() return talent.regenerative_heartwood.enabled and 16 or 12 end,
         max_stack = 1
     },
+    -- talent = double lifebloom. Both spellID and actual buff spellID change.
     lifebloom = {
         id = 33763,
         duration = 15,
-        tick_time = function() return mod_liveliness_hot( 1 ) end,
+        tick_time = function() return haste * mod_liveliness_hot( 1 ) end,
         max_stack = 1,
         dot = "buff",
-        copy = 290754
+        friendly = true,
     },
     lifebloom_2 = {
         id = 188550,
         duration = 15,
-        tick_time = function() return mod_liveliness_hot( 1 ) end,
+        tick_time = function() return haste * mod_liveliness_hot( 1 ) end,
         max_stack = 1,
-        dot = "buff"
+        dot = "buff",
+        friendly = true,
+        copy = "lifebloom"
     },
     natures_swiftness = {
         id = 132158,
@@ -323,22 +340,33 @@ spec:RegisterAuras( {
         duration = 60,
         max_stack = 1,
     },
+    reforestation = {
+        id = 392360,
+        duration = 3600,
+        max_stack = 3,
+    },
     regrowth = {
         id = 8936,
         duration = function() return 12 + 3 * talent.thriving_vegetation.rank end,
-        tick_time = function() return mod_liveliness_hot( 2 ) end,
+        tick_time = function() return haste * mod_liveliness_hot( 2 ) end,
+        dot = "buff",
+        friendly = true,
         max_stack = 1
     },
     rejuvenation = {
         id = 774,
-        duration = 12,
-        tick_time = function() return mod_liveliness_hot( 3 ) end,
+        duration = function() return 12 + 3 * talent.improved_rejuvenation.rank end,
+        tick_time = function() return haste * mod_liveliness_hot( 3 ) end,
+        dot = "buff",
+        friendly = true,
         max_stack = 1
     },
     rejuvenation_germination = {
         id = 155777,
-        duration = 12,
-        tick_time = function() return mod_liveliness_hot( 3 ) end,
+        duration = function () return spec.auras.rejuvenation.duration end,
+        tick_time = function() return haste * mod_liveliness_hot( 3 ) end,
+        dot = "buff",
+        friendly = true,
         max_stack = 1
     },
     renewing_bloom = {
@@ -347,25 +375,60 @@ spec:RegisterAuras( {
         tick_time = function() return mod_liveliness_hot( 1 ) end,
         max_stack = 1
     },
+    soul_of_the_forest = {
+        id = 114108,
+        duration = 15,
+        max_stack = 1,
+    },
+    spring_blossoms = {
+        id = 207386,
+        duration = 6,
+        dot = "buff",
+        friendly = true,
+        max_stack = 1,
+    },
     tranquility = {
         id = 740,
         duration = function() return 8 * haste end,
-        max_stack = 1,
+        generate = function( t )
+            if buff.casting.up and buff.casting.v1 == 740 then
+                t.applied  = buff.casting.applied
+                t.duration = buff.casting.duration
+                t.expires  = buff.casting.expires
+                t.stack    = 1
+                t.caster   = "player"    
+                return
+            end
+
+            t.applied  = 0
+            t.duration = class.auras.tranquility.duration()
+            t.expires  = 0
+            t.stack    = 0
+            t.caster   = "nobody"
+        end,
+        tick_time = function() return ( 8 * haste ) / 5 end,  -- Interval between each tick based on haste
+        max_stack = 1
     },
     tranquility_hot = {
         id = 157982,
         duration = 8,
         tick_time = function() return mod_liveliness_hot( 2 ) end,
-        max_stack = 1
+        max_stack = 5
     },
     wild_growth = {
         id = 48438,
         duration = 7,
         tick_time = function() return mod_liveliness_hot( 1 ) end,
+        dot = "buff",
+        friendly = true,
         max_stack = 1
     },
+    wild_synthesis = {
+        id = 400534,
+        duration = 3600,
+        max_stack = 3
+    },
 } )
-
 
 spec:RegisterStateFunction( "break_stealth", function ()
     removeBuff( "shadowmeld" )
@@ -379,6 +442,7 @@ end )
 spec:RegisterStateFunction( "unshift", function()
     if conduit.tireless_pursuit.enabled and ( buff.cat_form.up or buff.travel_form.up ) then applyBuff( "tireless_pursuit" ) end
 
+    removeBuff( "tree_of_life_form" )
     removeBuff( "cat_form" )
     removeBuff( "bear_form" )
     removeBuff( "travel_form" )
@@ -392,6 +456,7 @@ end )
 spec:RegisterStateFunction( "shift", function( form )
     if conduit.tireless_pursuit.enabled and ( buff.cat_form.up or buff.travel_form.up ) then applyBuff( "tireless_pursuit" ) end
 
+    removeBuff( "tree_of_life_form" )
     removeBuff( "cat_form" )
     removeBuff( "bear_form" )
     removeBuff( "travel_form" )
@@ -424,14 +489,6 @@ spec:RegisterHook( "runHandler", function( ability )
     end
 end )
 
-spec:RegisterStateExpr( "lunar_eclipse", function ()
-    return eclipse.wrath_counter
-end )
-
-spec:RegisterStateExpr( "solar_eclipse", function ()
-    return eclipse.starfire_counter
-end )
-
 
 -- Tier 30
 spec:RegisterGear( "tier30", 202518, 202516, 202515, 202514, 202513 )
@@ -442,6 +499,35 @@ spec:RegisterGear( "tier31", 207252, 207253, 207254, 207255, 207257, 217193, 217
 -- (2) You and your Grove Guardian's Nourishes now heal $s1 additional allies within $423618r yds at $s2% effectiveness.
 -- (4) Consuming Clearcasting now causes your Regrowth to also cast Nourish onto a nearby injured ally at $s1% effectiveness, preferring those with your heal over time effects.
 
+local TranquilityTickHandler = setfenv( function()
+
+    addStack( "tranquility_hot" )
+    if talent.dreamstate.enabled then
+        for ability, _ in pairs( spec.abilities ) do
+            reduceCooldown( ability, 4)
+        end
+    end
+
+end, state )
+
+
+spec:RegisterHook( "reset_precast", function ()
+
+    if buff.casting.up and buff.casting.v1 == 740 then
+
+        local tickInterval = spec.auras.tranquility.tick_time
+        local tick, expires = buff.casting.applied, buff.casting.expires
+
+        for i = 1, 4 do
+            tick = tick + tickInterval
+            if tick > query_time and tick < expires then
+                state:QueueAuraEvent( "tranquility_tick", TranquilityTickHandler, tick, "AURA_TICK" )
+            end
+        end
+
+    end
+
+end )
 
 -- Abilities
 spec:RegisterAbilities( {
@@ -460,7 +546,7 @@ spec:RegisterAbilities( {
         texture = 132137,
 
         handler = function ()
-            applyBuff( "cenarion_ward" )
+            active_dot.cenarion_ward = active_dot.cenarion_ward + 1
         end,
     },
 
@@ -479,6 +565,7 @@ spec:RegisterAbilities( {
         texture = 134222,
 
         handler = function ()
+            applyBuff( "efflorescence" )
         end,
     },
 
@@ -496,6 +583,7 @@ spec:RegisterAbilities( {
         toggle = "cooldowns",
 
         handler = function ()
+            applyBuff( "flourish" )
             if buff.cenarion_ward.up then buff.cenarion_ward.expires = buff.cenarion_ward.expires + 8 end
             if buff.grove_tending.up then buff.grove_tending.expires = buff.grove_tending.expires + 8 end
             if buff.lifebloom_2.up then buff.lifebloom_2.expires = buff.lifebloom_2.expires + 8 end
@@ -525,15 +613,9 @@ spec:RegisterAbilities( {
         talent = "grove_guardians",
         startsCombat = false,
 
-        -- Effects:
-        -- #0: { 'type': DUMMY, 'subtype': NONE, 'target': TARGET_UNIT_TARGET_ALLY, }
-        -- #1: { 'type': SUMMON, 'subtype': NONE, 'points': 1.0, 'value': 54983, 'schools': ['physical', 'holy', 'fire', 'arcane'], 'value1': 5734, 'target': TARGET_DEST_CASTER, }
-
         handler = function()
-            class.abilities.swiftmend.handler()
-            if talent.wild_synthesis.enabled then class.abilities.wild_growth.handler() end
             applyBuff( "grove_guardians" ) -- Just for tracking.
-            if talent.harmony_of_the_grove.enabled then applyBuff( "harmony_of_the_grove" ) end
+            if talent.harmony_of_the_grove.enabled then addStack( "harmony_of_the_grove" ) end
         end,
     },
 
@@ -541,7 +623,7 @@ spec:RegisterAbilities( {
     incarnation = {
         id = 33891,
         cast = 0,
-        cooldown = 180,
+        cooldown = function() return buff.tree_of_life_form.up and 0 or 180 end,
         gcd = "spell",
 
         talent = "incarnation",
@@ -551,7 +633,8 @@ spec:RegisterAbilities( {
         toggle = "cooldowns",
 
         handler = function ()
-            applyBuff( "incarnation_tree_of_life" )
+            if buff.incarnation.down then applyBuff( "incarnation" ) end
+            shift( "incarnation_tree_of_life" )
         end,
 
         copy = "incarnation_tree_of_life"
@@ -601,7 +684,7 @@ spec:RegisterAbilities( {
     ironbark = {
         id = 102342,
         cast = 0,
-        cooldown = 90,
+        cooldown = function() return 90 - ( talent.improved_ironbark.enabled and 20 or 0 ) end,
         gcd = "off",
 
         talent = "ironbark",
@@ -617,7 +700,7 @@ spec:RegisterAbilities( {
 
     -- Heals the target for 7,866 over 15 sec. When Lifebloom expires or is dispelled, the target is instantly healed for 4,004. May be active on one target at a time. Lifebloom counts for 2 stacks of Mastery: Harmony.
     lifebloom = {
-        id = 188550,
+        id = function() return talent.undergrowth.enabled and 188550 or 33763 end,
         cast = 0,
         cooldown = 0,
         gcd = "spell",
@@ -630,9 +713,10 @@ spec:RegisterAbilities( {
         texture = 134206,
 
         handler = function ()
-            if active_dot.lifebloom_2 > 0 then applyBuff( "lifebloom" )
-            elseif active_dot.lifebloom > 0 then applyBuff( "lifebloom_2" ) end
+
         end,
+
+        copy = { 188550, 33763 }
     },
 
     -- Cures harmful effects on the friendly target, removing all Magic, Curse, and Poison effects.
@@ -686,7 +770,7 @@ spec:RegisterAbilities( {
     -- Heals a friendly target for 6,471. Receives triple bonus from Mastery: Harmony.
     nourish = {
         id = 50464,
-        cast = 2,
+        cast = function() return 2 * haste * ( talent.wild_synthesis.enabled and ( 1 - 0.34 * buff.wild_synthesis.stack ) or 1) end,
         cooldown = 0,
         gcd = "spell",
 
@@ -698,6 +782,7 @@ spec:RegisterAbilities( {
         texture = 236162,
 
         handler = function ()
+            removeBuff( "wild_synthesis" )
         end,
     },
 
@@ -728,20 +813,23 @@ spec:RegisterAbilities( {
     -- Heals a friendly target for 4,267 and another 1,284 over 12 sec. Tree of Life: Instant cast.
     regrowth = {
         id = 8936,
-        cast = function() return ( buff.incarnation.up or buff.clearcasting.up ) and 0 or 1.5 * ( talent.wildwood_roots.enabled and ( 1 - 0.05 * buff.abundance.stack ) or 0 ) end,
+        cast = function() return ( buff.tree_of_life_form or buff.blooming_infusion_regrowth.up ) and 0 or 1.5 * ( talent.wildwood_roots.enabled and ( 1 - 0.05 * buff.abundance.stack ) or 1 ) end,
         cooldown = 0,
         gcd = "spell",
 
-        spend = 0.10,
+        spend = function() return buff.clearcasting.up and 0 or 0.10 * ( talent.abundance.enabled and ( 1 - 0.08 * buff.abundance.stack ) or 1 ) end,
         spendType = "mana",
 
         startsCombat = false,
         texture = 136085,
 
         handler = function ()
-            removeBuff( "abundance" )
             removeBuff( "clearcasting" )
-            applyBuff( "regrowth" )
+            if talent.soul_of_the_forest.enabled then removeBuff( "soul_of_the_forest" ) end
+            if talent.forestwalk.enabled then applyBuff( "forestwalk" ) end
+            if talent.wild_synthesis.enabled then addStack( "wild_synthesis" ) end
+            if talent.power_of_the_archdruid.enabled and buff.power_of_the_archdruid.up then active_dot.regrowth = active_dot.regrowth + 2 end
+            if talent.blooming_infusion.enabled then removeBuff( "blooming_infusion_regrowth" ) end
         end,
     },
 
@@ -752,7 +840,7 @@ spec:RegisterAbilities( {
         cooldown = 0,
         gcd = "spell",
 
-        spend = function() return ( buff.incarnation.up and 0.7 or 1 ) * 0.021 end,
+        spend = function() return ( buff.tree_of_life_form.up and 0.7 or 1 ) * 0.021 end,
         spendType = "mana",
 
         talent = "rejuvenation",
@@ -760,7 +848,18 @@ spec:RegisterAbilities( {
         texture = 136081,
 
         handler = function ()
-            applyBuff( "rejuvenation" )
+            -- Main Rejuv buff
+            if talent.germination.enabled then
+                if buff.rejuvenation.down or buff.rejuvenation.remains < buff.rejuvenation_germination.remains then 
+                    applyBuff( "rejuvenation" )
+
+                elseif buff.germination.remains < buff.rejuvenation.remains then applyBuff( "rejuvenation_germination" )
+                end
+            else applyBuff( "Rejuvenation" )
+            end
+
+            if talent.soul_of_the_forest.enabled then removeBuff( "soul_of_the_forest" ) end
+            if talent.power_of_the_archdruid.enabled and buff.power_of_the_archdruid.up then active_dot.rejuvenation = active_dot.rejuvenation + 2 end
         end,
     },
 
@@ -782,13 +881,62 @@ spec:RegisterAbilities( {
         end,
     },
 
+    starfire = {
+        id = 197628,
+        cast = function ()
+            if buff.blooming_infusion.up then return 0 end
+            return haste * 2.25
+        end,
+        cooldown = 0,
+        gcd = "spell",
+
+        spend = 0.06,
+        spendType = "mana",
+
+        startsCombat = true,
+        texture = 135753,
+        talent = "starfire",
+
+
+        handler = function ()
+            if buff.moonkin_form.down and buff.treant_form.down and buff.tree_of_life_form.down then
+                if talent.fluid_form.enabled then
+                    shift( "moonkin_form" )
+                else unshift()
+                end
+            end
+
+            if talent.blooming_infusion.enabled then removeBuff( "blooming_infusion" ) end
+
+        end,
+
+    },
+
+    starsurge = {
+        id = 197626,
+        cast = 0,
+        cooldown = function() return 10 - ( 4 * talent.starlight_conduit.rank ) end,
+        gcd = "spell",
+
+        spend = function () return ( talent.starlight_conduit.enabled and 0.003 or 0.006 ) end,
+        spendType = "mana",
+
+        startsCombat = true,
+        texture = 135730,
+        talent = "starsurge",
+
+        handler = function ()
+            gain( 0.3 * health.max, "health" )
+        end,
+    },
+
     -- Consumes a Regrowth, Wild Growth, or Rejuvenation effect to instantly heal an ally for 10,011. Swiftmend heals the target for 3,672 over 9 sec.
     swiftmend = {
         id = 18562,
         cast = 0,
-        charges = function() return talent.prosperity.enabled and 2 or nil end,
+        charges = function() if talent.prosperity.enabled then return 2 end end,
         cooldown = 15,
-        recharge = function() return talent.prosperity.enabled and 15 or nil end,
+        recharge = function() if talent.prosperity.enabled then return 15 end end,
         gcd = "spell",
 
         spend = 0.10,
@@ -817,6 +965,17 @@ spec:RegisterAbilities( {
                 elseif buff.renewing_bloom.up then removeBuff( "renewing_bloom" )
                 else removeBuff( "rejuvenation" ) end
             end
+
+            if talent.reforestation.enabled then
+                if buff.reforestation.stack == 3 then
+                    removeBuff( "reforestation" )
+                    applyBuff( "incarnation", ( 10 + 3 * talent.potent_enchantments.rank ) )
+                    shift( "tree_of_life_form" )
+                else addStack( "reforestation" )
+                end
+            end
+
+            if talent.soul_of_the_forest.enabled then applyBuff( "soul_of_the_forest" ) end
         end,
     },
 
@@ -858,7 +1017,16 @@ spec:RegisterAbilities( {
         toggle = "defensives",
 
         start = function()
-            applyBuff( "tranquility" )
+            TranquilityTickHandler()
+
+            local tickTime = query_time
+            -- Schedule the next 4 ticks of Tranquility.
+            for i = 1, 4 do
+                tickTime = tickTime + spec.auras.tranquility.tick_time
+                if tickTime <= query_time + spec.auras.tranquility.duration then
+                    state:QueueAuraEvent( "tranquility_tick", TranquilityTickHandler, tickTime, "AURA_TICK" )
+                end
+            end
         end,
     },
 
@@ -878,7 +1046,47 @@ spec:RegisterAbilities( {
 
         handler = function ()
             applyBuff( "wild_growth" )
+            if talent.soul_of_the_forest.enabled then removeBuff( "soul_of_the_forest" ) end
+
+            -- active dot + 5, or 7 during tree
         end,
+    },
+
+    wrath = {
+        id = 5176,
+        cast = function ()
+            if buff.blooming_infusion.up or buff.tree_of_life_form.up then return 0 end
+            return haste * 1.5
+        end,
+        cooldown = 0,
+        gcd = "spell",
+
+        spend = 0.002,
+        spendType = "mana",
+
+        startsCombat = true,
+        texture = 535045,
+
+        velocity = 20,
+
+        energize_amount = function() return action.wrath.spend * -1 end,
+
+        handler = function ()
+
+            if buff.moonkin_form.down and buff.treant_form.down and buff.tree_of_life_form.down then
+                if talent.fluid_form.enabled then
+                    shift( "moonkin_form" )
+                else unshift()
+                end
+            end
+
+            if talent.blooming_infusion.enabled then removeBuff( "blooming_infusion" ) end
+            removeBuff( "gathering_starstuff" )
+
+            removeBuff( "dawning_sun" )
+        end,
+
+        copy = { "solar_wrath", 5176 }
     },
 } )
 

--- a/TheWarWithin/DruidRestoration.lua
+++ b/TheWarWithin/DruidRestoration.lua
@@ -203,7 +203,7 @@ spec:RegisterAuras( {
         max_stack = 12
     },
     call_of_the_elder_druid = {
-        id = 3426790,
+        id = 426790,
         duration = 60,
         max_stack = 1,
         copy = "oath_of_the_elder_druid"
@@ -280,7 +280,7 @@ spec:RegisterAuras( {
         duration = 9,
         max_stack = 1,
         copy = 279793 -- Azerite.
-    },
+    },4
     harmony_of_the_grove = {
         id = 428737,
         duration = 15,
@@ -289,13 +289,13 @@ spec:RegisterAuras( {
     -- The actual incarn buff
     incarnation = {
         id = 117679,
-        duration = 3600,
+        duration = 30,
         max_stack = 1
     },
     -- This is the form
     incarnation_tree_of_life = {
         id = 33891,
-        duration = 30,
+        duration = 3600,
         max_stack = 1,
         copy = "tree_of_life_form"
     },

--- a/TheWarWithin/DruidRestoration.lua
+++ b/TheWarWithin/DruidRestoration.lua
@@ -327,7 +327,7 @@ spec:RegisterAuras( {
         duration = 3600,
         max_stack = 1,
         onRemove = function()
-            setCooldown( "natures_swiftness", spec.abilities.natures_Swiftness.cooldown )
+            setCooldown( "natures_swiftness", spec.abilities.natures_swiftness.cooldown )
         end,
     },
     natures_vigil = {
@@ -513,7 +513,7 @@ local TranquilityTickHandler = setfenv( function()
     addStack( "tranquility_hot" )
     if talent.dreamstate.enabled then
         for ability, _ in pairs( class.abilities ) do
-            reduceCooldown( ability, 4)
+            reduceCooldown( ability, 4 )
         end
     end
 
@@ -761,7 +761,7 @@ spec:RegisterAbilities( {
         texture = 134206,
 
         handler = function ()
-            active_dot.lifebloom = min( active_dot.lifebloom + 1, 1 + (1 * talent.undergrowth.rank ) )
+            active_dot.lifebloom = min( active_dot.lifebloom + 1, 1 + ( 1 * talent.undergrowth.rank ) )
         end,
 
         copy = { 188550, 33763 }
@@ -818,7 +818,7 @@ spec:RegisterAbilities( {
     -- Heals a friendly target for 6,471. Receives triple bonus from Mastery: Harmony.
     nourish = {
         id = 50464,
-        cast = function() return 2 * haste * ( talent.wild_synthesis.enabled and ( 1 - 0.34 * buff.wild_synthesis.stack ) or 1) end,
+        cast = function() return 2 * haste * ( talent.wild_synthesis.enabled and ( 1 - 0.34 * buff.wild_synthesis.stack ) or 1 ) end,
         cooldown = 0,
         gcd = "spell",
 
@@ -904,7 +904,7 @@ spec:RegisterAbilities( {
 
                 elseif buff.germination.remains < buff.rejuvenation.remains then applyBuff( "rejuvenation_germination" )
                 end
-            else applyBuff( "Rejuvenation" )
+            else applyBuff( "rejuvenation" )
             end
 
             if talent.soul_of_the_forest.enabled then removeBuff( "soul_of_the_forest" ) end
@@ -957,7 +957,7 @@ spec:RegisterAbilities( {
 
             if talent.blooming_infusion.enabled then removeBuff( "blooming_infusion" ) end
 
-            if talent.master_shapeshifter.enabled then gain( 43750, "mana") end
+            if talent.master_shapeshifter.enabled then gain( 43750, "mana" ) end
         end,
 
     },
@@ -977,7 +977,7 @@ spec:RegisterAbilities( {
 
         handler = function ()
             gain( 0.3 * health.max, "health" )
-            if talent.master_shapeshifter.enabled then gain( 43750, "mana") end
+            if talent.master_shapeshifter.enabled then gain( 43750, "mana" ) end
             if talent.call_of_the_elder_druid.enabled and debuff.oath_of_the_elder_druid.down then
                 applyBuff( "heart_of_the_wild", 15 )
                 applyDebuff( "player", "oath_of_the_elder_druid" )
@@ -1138,7 +1138,7 @@ spec:RegisterAbilities( {
             removeBuff( "gathering_starstuff" )
 
             removeBuff( "dawning_sun" )
-            if talent.master_shapeshifter.enabled then gain( 43750, "mana") end
+            if talent.master_shapeshifter.enabled then gain( 43750, "mana" ) end
         end,
 
         copy = { "solar_wrath", 5176 }

--- a/TheWarWithin/DruidRestoration.lua
+++ b/TheWarWithin/DruidRestoration.lua
@@ -8,6 +8,7 @@ local Hekili = _G[ addon ]
 local class, state = Hekili.Class, Hekili.State
 
 local spec = Hekili:NewSpecialization( 105 )
+local strformat = string.format
 
 spec:RegisterResource( Enum.PowerType.Mana )
 spec:RegisterResource( Enum.PowerType.Energy )
@@ -1154,10 +1155,10 @@ spec:RegisterOptions( {
     aoe = 3,
     cycle = false,
 
-    nameplates = true,
-    nameplateRange = 10,
-    rangeFilter = false,
+    nameplates = false,
 
+    rangeFilter = false,
+    healing_mode = false,
     damage = true,
     damageDots = true,
     damageExpiration = 6,
@@ -1165,14 +1166,18 @@ spec:RegisterOptions( {
     package = "Restoration Druid",
 } )
 
-
 spec:RegisterSetting( "experimental_msg", nil, {
     type = "description",
-    name = strformat( "%s %s supports a healing maintenance with the Totemic %s build.  It will recommend using %s and %s, keep %s / %s recharging, and use %s with to enhance particular spells.  Your %s will also be maintained.",
-        select( 7, GetSpecializationInfoByID( spec.id ) ), ( UnitClass( "player" ) ), Hekili:GetSpellLinkWithTexture( spec.abilities.chain_heal.id ), Hekili:GetSpellLinkWithTexture( spec.abilities.healing_rain.id ),
-        Hekili:GetSpellLinkWithTexture( spec.abilities.surging_totem.id ), Hekili:GetSpellLinkWithTexture( spec.abilities.riptide.id ), Hekili:GetSpellLinkWithTexture( spec.abilities.healing_stream_totem.id ),
-        Hekili:GetSpellLinkWithTexture( spec.abilities.unleash_life.id ), Hekili:GetSpellLinkWithTexture( spec.talents.earth_shield[2] ) ),
+    name = strformat( "Restoration Druid supports healing maintenance by recommending key abilities. It will suggest maintaining %s, keeping at least one %s active, maintaining %s, using %s after a %s, and alerting you when %s can activate %s.",
+        Hekili:GetSpellLinkWithTexture( spec.abilities.lifebloom.id ),
+        Hekili:GetSpellLinkWithTexture( spec.abilities.rejuvenation.id ),
+        Hekili:GetSpellLinkWithTexture( spec.abilities.efflorescence.id ),
+        Hekili:GetSpellLinkWithTexture( spec.abilities.wild_growth.id ),
+        Hekili:GetSpellLinkWithTexture( spec.abilities.swiftmend.id ),
+        Hekili:GetSpellLinkWithTexture( spec.abilities.swiftmend.id ),
+        Hekili:GetSpellLinkWithTexture( spec.abilities.incarnation.id ) ),
     width = "full",
+    fontSize = "medium"
 } )
 
 spec:RegisterSetting( "healing_mode", false, {
@@ -1183,4 +1188,4 @@ spec:RegisterSetting( "healing_mode", false, {
 } )
 
 
-spec:RegisterPack( "Restoration Druid", 20240908, [[Hekili:1IvAVnUnt4FlglGGDoCLptsHT)q7lkAdqx8I6fy)MoSeTfHLLuPKsAam0V9oK6IIhwoztbA3KypCoFMhoCSMy9nRT(UziRVo1C6CZNmFCm8llNn3AB2BjiRTjUEhDpa)sK7j4F)luAwmXndhhv48)i5yFQiVfg76tvvACoXdeZA7UCCy2FezTtL(NT4rq2eKN1xNyUWABa23hvklk1ZA7VJCdrKcNecoMGZWO0chxccS4)F797J9Ytr(foXrHVnU45INPQ(EZNU3CYDfo0F(4px489ae4Iy4))v3ScNFlMCc(w)4chp6FNfGJoK2E6hUFMjCQVfaw57UGT)oMkI12qCAwklnH27MhMb)6xzPnxpAwaIJJ5HH27CtdS2IIC3fI8T(fRmiI5LAhIKIihbJki1mQuTFYwpiGreSR12bfo7Y3VFCcj(1WX5jfogfo1FyAGRF8RNqH(W30AMi3SCck1(f8bCiv9Z)uvFaYLKzhV3olaz)ko0NAIfFQMaQT2W5pLsv9YpvvNeZ(jO3h0Q3ma5fLnM4EenUsGcNZNRumaDS3dijMAtZiyVmkAOXcK8i7YF3MIBkrp2LToWzPM(X3JPB1CTLPQ4jTQyyLFkvNyziAy4fhhc5MifIqqNCXrqR2McNLMfo3x4md(XnqZsPN5b2KGZtTpa99UrEczObnckR7gbhXfsXrVeFeXeknbdbbRMpXui8AA0YJ2Jji(4LG2dO9aQOmaqMl5akBCg(eO2yBFmIfnlQ(sMZHpbyMxq(2v6Rnx79MxiCoMosP1vQ3mrJ3CkoUF3rWpMmvJrMQTIsn3liBue6eJgCvHZJCPeqpP5GQyArKk5hpX9a7lv4dpOjq0t3a09anzL4JPoo1NktlCDyQqUDJxwOqT1cE(1xHlLeiGZk75Q5Rv6vY0fC(sl3sZhLMtVPY290U80GoUgTTTH1xxZzt3NcSFB)hKFNBk2tP6eTDvLsVhFiiZUJEw2d5TomdbNi47W)1b1qniajihEJveFYKHvAn(AOWAYCnd2H9IpTl2ojghLbF96MUsbixJcUTWz68sZmS7h3vta)0CwS2rtgDpYCThCJWbh1KnP5ESh9kBM66Ey4ytz6uax)kobzZMW4gMeJu3Oi2Nau72rO)P7TjjaAbQMvdvP4M2AbZciW4huZ(H7X7ggTkSmsvheI3oFb(grWZf5QhvFzEcb9I9bp)XtAU5TgnjYjTUHgPhAETLeXzc60y)Ei5nvKq5WfROIO2f0pBWa5bqywHRbCHzDUXpUAkcrx9If5z9iYQAOsvcU87uFZ(fgw5s3FQcLiDfAn4OP3SIHGdSuvYfiKGetE9txGMtZXpQQqvF0sa1ORanEPk9sn3tkoJtBoGZk1POEJd5wpvtUOFOI2MhfDw0jo6mDDhm4iDdJO)EWRclRgmjnIZ1XBknwsTK7rKypCmms7oW74Dsj2(zAjTwX(YYHRvEfxtGTUmYuIi(pHBFznLWf787sCgcv)qCeknTxkZj6FFMikQjd2nhTs7W502i5Nb10DXmVok7p(aVLoJQbEBOD(qVIqKz)kXT6FPhxZYstnjwUesab5xosmWVqLu9GX01Vat(vEOTrUjPbXagH4I9lBAPGbOpNAHDiiiqL2LcK2HoW4NCJ8zCL3dp3oJrqJtP3jfHgZX(7sokokAN9LipSANz7VWAtU6NrR)TkxufSxfWYLq28fejL(P1R3cQMV6sIO7wYA7FCkjMKrtzZkXuugB2(Kgx8mtr7XHak9lfoF(56INlTy64Mk(TR)jX8UAPKs(QfRozEhE)Av7nr5HyPpTNO5mGKTlwJ)tBxKg)N2zVxuTpOZl4mgO4HEp)LVuxwOQqy3n3r3AZAitaCHhUonA4txiAjNcq4g5BxFCkFQTN)6PM8oTuA(6mdVkA2w27)OLBd79FoL5jakCx5(WwprtX98zPB95061ILOIk)sy6PgQD)bNp3)wV2S08(zM303MUoFEqF74AuhmC5Td315sHYue3nsgY3gTzHrFpKHZm1tk2RD4mamjnVJwp8g9iDV)B1JFor0dgc69brhGPyqrQ3v0MjvqiLB3KtvSDbXXLqXCuGlGNOAxgExP36oGQ)uCxpI6tz77WRzfpRMB2cKUWIDgD(CNv6SA(sPGcNOQumCixX485YPf28KPrTMwpXCKXq(zgwVOd8OsWBNo)85H1)bV83mFfN81k(25ccTHtOrJOHD572m4fBZ0B18kQBMosmK7mM0D1tsTEIOCTt5(HaR6gzEZurdDHwIH91LpYyGI3vAmSBRYAa63dDGuAIb37lW55dmn0udwnXuu5801de51nQGBlmngQAxe6tTZ0(vREWq5EhKc7lrfoupxOrnUeq7YBsOPTP(L33aV6wmDvk66jJ0ut1LDL6PRXtGhRyBak9fjvONoNILgkYWBiveLsSxzj)J2T29P4QQEDimMPOBA1m6n9Dy0QCR1Y(1pe7WsJHAXWTTQYVKwkP2GcKRtqiYhmRumqa)BKFhKs9XjjDpTXGRDwK3zrN9UuQlvvNwAkeZ0BX5gtFC1a1meoDAt7u0FNJGb0AhxNGoa3Jdfen)eEjxEwqmXA7F6E0naFeZEkN1)(d]] )
+spec:RegisterPack( "Restoration Druid", 20241110, [[Hekili:1MvFVTnVr8plbdqZoV4j53sYGTb626aEkW6aECbE(pjlBrhZzzjd9sYcGH(SV7ifLiPiTDs7aABAepE8UF3R8OVN)p8xgfwq8)(q3HJ988ChmC0WrJ9xw8(rI)YJHB2h(c8Fscpa)7VtYlsZclOPjvR(hzL0iKK3JtdJqoLNwMTbiZF56sACXVL4V2e7hozeq7rYg)V75oXF5oAueHtljFJ)sK2h88EWZ9VwTA57z0T)58Qv7iHX0KxQwDinIuTkV84X0SIQVv9ng9Up)GR39vRWF(eSV)yhbKrk83)Eyr1Q)zA2by1O0QvBWFVyhWR82D)4dJWt7h7aw)hHzW)qrs8xgtZlYrLd2g8JVZGmss46ysK)Fd(CgTGKrdrDE72b57cJsF7ajoAq5XQvNovTI99JzPVfR(P8suTdcpSUmFhSK)YWniY6VmlCpXVaanRNvpqnstJHJkzWM0Kxt3tck2rcYpsbAYhKroestauBw1QXU8d9gqRdJjjfg3r9XuTQpN6T0x2veOWNPTsiymYkcs3YyXB04iuChPjUnQd9OMSd)jJSnJaOfqm)ajjKSxEVA1IQvpdsSdsI4WNxTYZLjAoSnVj9W60GJP0Kcyzy1jSvkOhaLkniIsy8PHb3vTA4y(X0t9ZQC6wqlz6QcNCu3YyRBCH2g73GMi2t3SN5)6OVzyBdz8eIjIJdkcZEHawK83OhjbmV1Bzu0hqX33eteuGoJaSpwd23MMfKq(Vf4Yn2GJG3cynRJqH1MyXyvSllmFhESY2mfRfI0mjyGoG)iBrv1OLHCn1Ssm1I4KxMSLMr08FUsXzIWLbG)JzKxdEzt0aVbGOeaG0bH3eEwVscahWduc3FYJB2QJxOhGW3xjrb1sJuWIzT5rBrcyG95GvnfWZ1aGk5xmdjXSi8K1Ch3uN)radSSsokbGtCfytuAXauQhOlQN1ip6cKmt4QudW81uGvbKjKsuNE2cSEin9Q8s0r3HcNJMyZ6mesol1MCTesaWukQdcbNUdEYKHsSvUdv)RWB8Cw6PMn0GdGnlT0PiGOlQhDd9WZWEvp7bpgISGZ7jbe01huYQNd6yEjOMSt3EDWRYx2SZKNE5QRlVPNE6wbLBjzPBOPL5bRbPtwi7KTFK1KwZylIONLsCnk2CUMz0J4)l52NksjC2iF1eNXG1hAAJKNFXuME6vaS7I1GGQy0SM2a0ZAJHrcbqYhteDXoEBPSnua6kbmUWyie4XM0oNV8IfGspZ(v63QN8SvFKcwM6AbyLaKDzeSDVcwxGyl5MAlUPIh5)u(k8Dr83r()5hHj7nyIzvBK2bVch)EbqxK89(VtW23ji8bmXqBYIZoMULSoon9G0b)L4431ktiD2n7GFWnTVDoQ4fryzHAwqKgQ2axMebimCdGc1ACDuRq8VOeEMUPnPvljXBVwTYO8IxK4tjXVdoy54PBOruHet2Unof8f3qsWBhQWJ)fuiQieVM2xrQ81VpLYEzI55AEfcP3wCGKej7Q97F9R2XMmcxlz9Fl9D8onbMxs1bTViTxl4b5hqrUGrrl8jqD1LHFUzplb)inOPilmjN3zaGrWfxlYiKZ1RSKmRXQVe)w47qKmsr1kHAfUfGeiFUeOP06a29tZASa(iY2WY427b3G77lHscRHcbYcMi0uq1Ac4QKHnAPrLURE367TxFwQ5bL7A3EmGLPeW3GxPVqJn5x2Y(CsrbohGb1zYcWzli3UaOv8FjaNdaFAab8zHis(zWD8Nt(nE3A7vh)mhrzoja2)HCtxw5NJ1htz)8S3areNG3ROj8OzUis9YHncMr3OwAlRmXQrPUAU9ADgoAlThAVT6E1cAhdvZ8DAMntxsA69UUA7dqGVlR5BXWzGZmJcTr(sjnkeZ6ParTTn0L3YzQB0PUZ6Xyh9)Q635Z1tJTs4MUz3LVwNLdXEAgdnP9KTlJyRk3Nh4E0AJIwue75B0U)i8F4x6RTZCREUQ6BZn)MkNb)n4UIAP4ly1kWggnpFuL6qqU5J57sHRkKfsJ4cd6VIfdbvEnRYiV9t8(eRjVWcvctIyxz(bi5sb7E60CC0ejKbsUkHz71ZAQu(PBE1RTk0vN0WELMZYcw(vgwcO5Rqvs8RSrM7(Sl4i(wywcwMYF5VDah6nczJ5EmyliSrupO6BmgTLgd(G)PQv)6X6QVXpX8bnw87M)x0XDZu1b8ntMamVNUDUPQeg3ed(SUJM9au22NI8xB7lr(RkTrGC)gLAHo3yyE)sBxV3H7XcuZRBAazNXEpK5qhi7Jlen15)4BLxh)JVpTQZC1gmR3ZRKp3ZIH60PodYrbnVo)cK0Uf8WD1ZAIVtNUC56ftDFyK7TxQe9Pt3CPIZ9v8h51mUxjlphIKQD40TUXIjoxA20shJOk6fphPdWBOIGkkbIBrTs1SN(1Orp6OX3h1fagJXihJf5w4v7czSTmjwXkIjLxa95qhxWFc5Ex37A(kIaQ)v9NVtNFgdF7DnVA3SXUTosN5T66F6KYR0nB80okf9OjtrVEsgJtN4daAXZUocon3ZTVtp5XanFII7rnH3nC8Pt9e)Im93oEMe9cgF3ynIwiru)(OAZhfVJmzlgENLbJF7W(6QSYKVUxmCS5E601o4YpLZQTPGUyO(bDMqIExkkVVZngEQaNEQHkZbx)lKoOdmXC3VKIlNpW1XInyMNRoZLtxFJEEDNA3TjUo9m98s2H2rwxA2JogFkPoQ95sf2ZEUqhHFj4T39XHAcBepMYTUdEshU4Ko3RVfBQn0TtmTWFcKydpWJrzPdlSNoh9L6PNH3PJrSdWELM8pB0Q6RRyY6PKWyKHOPzJWk9kz0QfR5DLRFQSdtD6z1hUnuT7JJ0buB8c6ANavuwzMzOHa5N94dKu6s5K6uN25MRTxKpOrN9udOivBNM6QPZyvC4QokViqltQBSgt2jnYwjOuFAUZ8AyNys8M4wZyZzjnK4vZcZ863gfPUYqhwWH8tf4yFO79BeiXG2)KcuNJfBc5IhS205nD2kdOVP)PUJTNXpJJ02exBM7SUgjMx)DsFtAU33zXY2FHNZ5MophDmmz(5Jyc(1naDtAIKWjYyRmx9LHLf7sZWxczF4o6EkBka()V]] )

--- a/TheWarWithin/Priorities/DruidRestoration.simc
+++ b/TheWarWithin/Priorities/DruidRestoration.simc
@@ -7,7 +7,7 @@ actions.precombat+=/prowl,if=talent.rake.enabled
 actions+=/skull_bash
 actions+=/berserking
 actions+=/natures_vigil,if=!buff.prowl.up&!buff.shadowmeld.up
-## actions+=/run_action_list,name=healing,if=!buff.prowl.up&!buff.shadowmeld.up&druid.time_spend_healing,line_cd=20
+actions+=/call_action_list,name=healing,if=settings.healing_mode
 actions+=/heart_of_the_wild,if=!buff.prowl.up&!buff.shadowmeld.up
 actions+=/use_items,if=!buff.prowl.up&!buff.shadowmeld.up
 actions+=/potion,if=!buff.prowl.up&!buff.shadowmeld.up
@@ -41,4 +41,15 @@ actions.cat+=/sunfire,cycle_targets=1,if=refreshable&target.time_to_die>5&active
 actions.cat+=/pool_resource,for_next=1
 actions.cat+=/shred,if=energy>60&combo_points<5
 
-## actions.healing+=/strict_sequence,name=healregrowthregrowthregrowthregrowth
+# On the tank
+actions.healing+=/rejuvenation,if=active_dot.rejuvenation<1
+# On an ally
+actions.healing+=/lifebloom,if=(active_dot.lifebloom<1)|(active_dot.lifebloom<2&buff.lifebloom.up&talent.undergrowth.enabled)
+# On yourself
+actions.healing+=/lifebloom,if=(active_dot.lifebloom<2&buff.lifebloom.down&talent.undergrowth.enabled)
+# Maintain Efflo
+actions.healing+=/efflorescence,if=buff.efflorescence.down
+# transform into tree
+actions.healing+=/swiftmend,if=(active_dot.regrowth+active_dot.wild_growth+active_dot.rejuvenation)>1&talent.reforestation.enabled&buff.reforestation.stack=3
+# Always wild growth after swiftmend
+actions.healing+=/wild_growth,if=prev.1.swiftmend


### PR DESCRIPTION
# Restoration Druid TWW Modelling Cleanup

## Guardian Cleanup
- Account for `Master Shapeshifter` talent mana refund for Resto Druids when casting `Ironfur`

## Feral Cleanup
- Account for `Master Shapeshifter` talent mana refund for Resto Druids when casting `Rip`, `Ferocious Bite` or `Maim` with 5 combo points

## Balance Cleanup
- `Nature's Swiftness` stuff
- `Rebirth` to account for buff consumptions
- Separate `Starsurge` into a specific Balance and Resto version

## Restoration Cleanup

### Basics
- `strformat`
- Remove `Eclipse` stuff
- More `Grove Guardians` NPC support
- Default settings
- Pack string
- Shapeshift form logic tested and corrected

### Spell, Buff, Talent Remodelling
- `Tranquility`
  - Proper support for HoT stack application and CDR emulation with `Dreamstate` talent 
- `Incarnation` / `Tree of Life`
  - All SpellIDs corrected, behaviour modelled correctly, `Grove Guardians` summon emulation
- `Cenarion Ward`
  - Shield and HoT tracking implemented via `active_dot.cenarion_ward`
- `Efflorescence`
  - Updated buff tracking for use with APL via `buff.efflorescence`
  - Spring Blossoms HoT tracking implemented via `active_dot.spring_blossoms`
- `Flourish`
  - Active state tracking for use with APL via `buff.flourish`
- `Grove Guardians`
  - Correct Cooldown, tracking buff and `summonPet`
- `Incarnation`
  - Spell and buffs remodelled to reflect correct SpellIDs, form shifting, and buffs to the empowered spells during shapeshift form
  - Support for `Grove Guardian` summon emulation with the `Cenarius' Guidance` talent
- `Ironbark`
  - Cooldown now accounts for `Improved Ironbark` talent
- `Lifebloom`
  - HoT Application tracking implemented via `active_dot.lifebloom`
  - SpellID corrected (it changes with `Undergrowth` talent
- `Nature's Swiftness`
  - Cooldown accounts for `Passing Seasons` talent
- `Nourish`
  - Cast speed modelling, including `Wild Synthesis` talent / buff
- Regrowth
  - Cast speed model updated to reflect current iteration of `Clearcasting` and `Incarnation`
  - Cost model updated to reflect `Clearcasting` and `Abundance`
  - Buff consumption
  - HoT application tracking implemented via `active_dot.regrowth`
- `Rejuvenation`
  - Cost model updated to reflect only being **_in tree form_** during incarnation
  - HoT application tracking implemented via `active_dot.rejuvenation`
  - `Germination` HoT application tracking implemented via `active_dot.germination`
  - `Cultivation` modelling added, /w HoT application tracking implemented via `active_dot.cultivation`
- `Soul of the Forest` talent
  - Support added in all relevant spells + aura
- `Swiftmend`
  - Charge/Recharge converted to `if then return end end` format
  - `Reforestation` modelling /w aura and `Tree of Life` shifting
- Wild Growth
  - HoT application tracking implemented via `active_dot.wild_growth`, and incorporates talents
- `Heart of the Wild`
  - Support for `Call of the Archdruid `talent
  - Emulation of periodic combo point gains
- `Starsurge`, `Starfire` and `Wrath`
  - Remodelled as their own unique versions compared to Balance, support for any and all shapeshifting, buffs, mana returns, costs, cast times
### Spec Options
Healing mode, similar to Restoration Shaman. Opt-In.
- Maintain Efflorescence
- Maintain atleast 1 rejuvenation (for the tank)
- Maintain Lifebloom (1 or 2 depending on your talents)
- Always wild growth after a swiftmend
- Tree-proc swiftmends