### PR TITLE
Blood Deathknight Update

### DIFF
--- a/TheWarWithin/DeathKnightBlood.lua
+++ b/TheWarWithin/DeathKnightBlood.lua
@@ -178,12 +178,22 @@ spec:RegisterResource( Enum.PowerType.RunicPower, {
 } )
 
 local spendHook = function( amt, resource )
+    -- Runic Power
     if amt > 0 and resource == "runic_power" then
-        if talent.red_thirst.enabled then cooldown.vampiric_blood.expires = max( 0, cooldown.vampiric_blood.expires - amt / 10 ) end
+        if talent.red_thirst.enabled then reduceCooldown( "vampiric_blood", floor( amt / 10 ) * 2 ) end
         if talent.icy_talons.enabled then addStack( "icy_talons", nil, 1 ) end
-    elseif resource == "rune" and amt > 0 and active_dot.shackle_the_unworthy > 0 then
-        reduceCooldown( "shackle_the_unworthy", 4 * amt )
     end
+    -- Runes
+    if resource == "rune" and amt > 0 then
+        if active_dot.shackle_the_unworthy > 0 then
+            reduceCooldown( "shackle_the_unworthy", 4 * amt )
+        end
+
+        if talent.rune_carved_plates.enabled then
+            addStack( "rune_carved_plates" )
+        end
+    end
+    
 end
 
 spec:RegisterHook( "spend", spendHook )
@@ -534,7 +544,10 @@ spec:RegisterAuras( {
         id = 81256,
         duration = function () return ( pvptalent.last_dance.enabled and 6 or 8 ) + ( talent.everlasting_bond.enabled and 6 or 0 ) end,
         type = "Magic",
-        max_stack = 1
+        max_stack = 1,
+        active_weapons = function() return 
+            buff.dancing_rune_weapon.up and 1 + talent.everlasting_bond.rank or 0
+        end
     },
     -- Taunted.
     -- https://wowhead.com/beta/spell=56222
@@ -716,7 +729,7 @@ spec:RegisterAuras( {
     incite_terror = {
         id = 458478,
         duration = 15.0,
-        max_stack = 1,
+        max_stack = 5,
     },
     infliction_of_sorrow = {
         id = 460049,
@@ -776,6 +789,11 @@ spec:RegisterAuras( {
         id = 207256,
         duration = 3600,
         max_stack = 1
+    },
+    ossified_vitriol = {
+        id = 458745,
+        duration = 8,
+        max_stack = 5
     },
     -- Grants the ability to walk across water.
     -- https://wowhead.com/beta/spell=3714
@@ -986,7 +1004,7 @@ spec:RegisterAuras( {
     -- https://wowhead.com/beta/spell=55233
     vampiric_blood = {
         id = 55233,
-        duration = function () return ( level > 55 and 12 or 10 ) + ( legendary.vampiric_aura.enabled and 3 or 0 ) + ( talent.improved_vampiric_blood.enabled and 2 or 0 ) end,
+        duration = function () return 10 + ( talent.improved_vampiric_blood.rank * 2 ) + ( legendary.vampiric_aura.enabled and 3 or 0 ) end,
         max_stack = 1
     },
     -- Movement speed increased by $w1%.
@@ -1156,6 +1174,7 @@ end, state )
 
 local BonestormShield = setfenv( function()
     addStack( "bone_shield" )
+    gain( min( 0.1, 0.02 * active_enemies ) * health.max, "health" )
 end, state )
 
 
@@ -1346,18 +1365,18 @@ spec:RegisterAbilities( {
             applyDebuff( "target", "blood_plague" )
             active_dot.blood_plague = active_enemies
 
-            if buff.vampiric_strength.up then buff.vampiric_strength.expires = buff.vampiric_strength.expires + 0.5 end
-
             if talent.bind_in_darkness.enabled and debuff.reapers_mark.up then applyDebuff( "target", "reapers_mark", nil, debuff.reapers_mark.stack + 2 ) end
 
             if talent.hemostasis.enabled then
-                applyBuff( "hemostasis", 15, min( 5, active_enemies ) )
+                addStack( "hemostasis", nil, min( 5, active_enemies ) )
             end
 
-            if debuff.ashen_decay.up and set_bonus.tier31_4pc > 0 then
+            if set_bonus.tier31_4pc > 0 and debuff.ashen_decay.up then
                 debuff.ashen_decay.expires = debuff.ashen_decay.expires + 1
             end
 
+
+            -- Legacy
             if legendary.superstrain.enabled then
                 applyDebuff( "target", "frost_fever" )
                 active_dot.frost_fever = active_enemies
@@ -1365,7 +1384,7 @@ spec:RegisterAbilities( {
                 applyDebuff( "target", "virulent_plague" )
                 active_dot.virulent_plague = active_enemies
             end
-
+            if set_bonus.tier30_4pc > 0 and buff.vampiric_strength.up then buff.vampiric_strength.expires = buff.vampiric_strength.expires + 0.5 end
             if conduit.debilitating_malady.enabled then
                 addStack( "debilitating_malady", nil, 1 )
             end
@@ -1485,6 +1504,7 @@ spec:RegisterAbilities( {
         handler = function ()
             gain( 2, "runes" )
             applyBuff( "consumption" )
+            if talent.carnage.enabled then applyBuff( "blood_shield" ) end
         end,
     },
 
@@ -1530,6 +1550,7 @@ spec:RegisterAbilities( {
                 else removeBuff( "piledriver" ) end
             end
 
+            -- legacy
             if azerite.eternal_rune_weapon.enabled then applyBuff( "dancing_rune_weapon" ) end
             if legendary.crimson_rune_weapon.enabled then addStack( "bone_shield", nil, buff.dancing_rune_weapon.up and 10 or 5 ) end
         end,
@@ -1595,7 +1616,10 @@ spec:RegisterAbilities( {
             if buff.crimson_scourge.up then
                 if talent.perseverance_of_the_ebon_blade.enabled then applyBuff( "perseverance_of_the_ebon_blade" ) end
                 removeBuff( "crimson_scourge" )
-                if talent.relish_in_blood.enabled then gain( 10, "runic_power" ) end
+                if talent.relish_in_blood.enabled then
+                    gain( 10, "runic_power" ) 
+                    gain( 0.25 * buff.bone_shield.stack, "health" )
+                end
             end
 
             if legendary.phearomones.enabled and buff.death_and_decay.down then
@@ -1720,19 +1744,15 @@ spec:RegisterAbilities( {
         startsCombat = true,
 
         handler = function ()
-            removeBuff( "blood_draw" )
-            removeBuff( "heartrend" )
-            applyBuff( "blood_shield" ) -- gain absorb shield
-            if buff.coagulating_blood.up then
-                gain( 0.01 * buff.coagulating_blood.stack * health.max * ( 1.2 * buff.haemostasis.stack ) * ( 1.08 * buff.hemostasis.stack ), "health" )
-                removeBuff( "coagulating_blood" )
-            end
-            removeBuff( "haemostasis" )
-            removeBuff( "hemostasis" )
 
-            -- TODO: Calculate real health gain from Death Strike to trigger Bryndaor's Might legendary.
-            if talent.coagulopathy.enabled then applyBuff( "coagulopathy" ) end
+            applyBuff( "blood_shield" ) -- gain absorb shield
+            gain( health.max * max( 0.074,  0.01 * buff.coagulating_blood.stack * 0.25 ) * ( talent.voracious.enabled and 1.15 or 1 ) * ( talent.improved_death_strike.enabled and 1.05 or 1 ) * ( talent.hemostasis.enabled and ( 1.08 * buff.hemostasis.stack ) or 1 ), "health" )
+            removeBuff( "coagulating_blood" )
+
+            if talent.hemostasis.enabled then removeBuff( "hemostasis" ) end
+            if talent.coagulopathy.enabled then addStack( "coagulopathy" ) end
             if talent.voracious.enabled then applyBuff( "voracious" ) end
+            if talent.heartrend.enabled then removeBuff( "heartrend" ) end
         end,
     },
 
@@ -1776,8 +1796,9 @@ spec:RegisterAbilities( {
         startsCombat = true,
 
         handler = function ()
+            local RWStrikes = 1 + buff.dancing_rune_weapon.active_weapons -- the 1 is your actual spell hit
             applyDebuff( "target", "blood_plague" )
-            addStack( "bone_shield", nil, buff.dancing_rune_weapon.up and 4 or 2 )
+            addStack( "bone_shield", nil, ( 2 * RWStrikes ) )
 
             if set_bonus.tww1_4pc > 0 then
                 if buff.bone_shield.up then applyBuff( "piledriver", nil, buff.bone_shield.stack )
@@ -1821,13 +1842,15 @@ spec:RegisterAbilities( {
         max_targets = function () return buff.death_and_decay.up and talent.cleaving_strikes.enabled and 5 or 2 end,
 
         handler = function ()
+            local strikes = 1 + buff.dancing_rune_weapon.active_weapons
             if talent.heartbreaker.enabled then
-                gain( 2 * min( action.heart_strike.max_targets, true_active_enemies - 1 ) + ( 3 * buff.dancing_rune_weapon.stack ), "runic_power" )
+                gain( 15 + ( talent.heartbreaker.enabled and ( 2 * min( action.heart_strike.max_targets, true_active_enemies ) ) or 0 ) + 3 * buff.dancing_rune_weapon.active_weapons, "runic_power" )
             end
 
+            -- San'Layn stuff
             if buff.vampiric_strike.up or buff.gift_of_the_sanlayn.up then
-                gain( 0.01 * health.max, "health" )
-                applyBuff( "essence_of_the_blood_queen" ) -- TODO: mod haste
+                gain( 0.02 * health.max, "health" )
+                addStack( "essence_of_the_blood_queen" ) -- TODO: mod haste
 
                 if talent.infliction_of_sorrow.enabled and dot.blood_plague.ticking then
                     dot.blood_plague.expires = dot.blood_plague.expires + 3
@@ -1840,32 +1863,28 @@ spec:RegisterAbilities( {
 
             end
 
-            if buff.infliction_of_sorrow.up then
+            if talent.infliction_of_sorrow.enabled and buff.infliction_of_sorrow.up then
                 removeDebuff( "target", "blood_plague" )
                 removeBuff( "infliction_of_sorrow" )
             end
+            if talent.incite_terror.enabled then applyDebuff( "target", "incite_terror", nil, min( debuff.incite_terror.stack + 1, debuff.incite_terror.max_stack ) ) end
 
+            -- PvP
             if pvptalent.blood_for_blood.enabled then
                 health.current = health.current - 0.03 * health.max
-            end
+            end 
 
-            if buff.vampiric_strength.up then buff.vampiric_strength.expires = buff.vampiric_strength.expires + 0.5 end
-
-            if buff.ashen_decay_proc.up then
+            --- Legacy
+            if set_bonus.tier31_4pc > 0 and debuff.ashen_decay.up and set_bonus.tier31_4pc > 0 then debuff.ashen_decay.expires = debuff.ashen_decay.expires + 1 end
+            if azerite.deep_cuts.enabled then applyDebuff( "target", "deep_cuts" ) end
+            if legendary.gorefiends_domination.enabled and cooldown.vampiric_blood.remains > 0 then gainChargeTime( "vampiric_blood", 2 ) end
+            if set_bonus.tier31_4pc > 0 and buff.ashen_decay_proc.up then
                 applyDebuff( "target", "ashen_decay" )
                 removeBuff( "ashen_decay_proc" )
             end
-
-            if debuff.ashen_decay.up and set_bonus.tier31_4pc > 0 then -- TODO: Check if refresh is before reapplication.
-                debuff.ashen_decay.expires = debuff.ashen_decay.expires + 1
-            end
-
-            if azerite.deep_cuts.enabled then applyDebuff( "target", "deep_cuts" ) end
-
-            if legendary.gorefiends_domination.enabled and cooldown.vampiric_blood.remains > 0 then
-                gainChargeTime( "vampiric_blood", 2 )
-            end
+            if set_bonus.tier30_4pc > 0 and  buff.vampiric_strength.up then buff.vampiric_strength.expires = buff.vampiric_strength.expires + 0.5 end
         end,
+
 
         bind = "vampiric_strike",
         copy = { 206930, "vampiric_strike", 433895 }
@@ -1938,26 +1957,29 @@ spec:RegisterAbilities( {
         cooldown = 0,
         gcd = "spell",
 
-        spend = 2,
+        spend = function() return talent.exterminate.enabled and buff.exterminate.up and 1 or 2 end,
         spendType = "runes",
 
         talent = "marrowrend",
         startsCombat = true,
 
         handler = function ()
-            if buff.killing_machine.up  then removeStack( "killing_machine" ) end
+            local RWStrikes = 1 + buff.dancing_rune_weapon.active_weapons -- the 1 is your actual spell hit
+            addStack( "bone_shield", 30, buff.bone_shield.stack + 3 * RWStrikes )
 
-            addStack( "bone_shield", 30, buff.bone_shield.stack + ( buff.dancing_rune_weapon.up and 6 or 3 ) )
-
-            if buff.exterminate.stack == 1 then
-                applyDebuff( "target", spec.blood and "blood_plague" or "frost_fever" )
+            if talent.exterminate.enabled and buff.exterminate.up then
+                removeStack( "exterminate" )
+                applyDebuff( "target", "blood_plague" )
             end
-            if buff.exterminate.up then removeStack( "exterminate" ) end
+
+            if talent.ossified_vitriol.enabled then removeBuff( "ossified_vitriol" ) end
 
             if set_bonus.tww1_4pc > 0 then
                 if buff.bone_shield.up then applyBuff( "piledriver", nil, buff.bone_shield.stack )
                 else removeBuff( "piledriver" ) end
             end
+
+            -- Legacy
 
             if azerite.bones_of_the_damned.enabled then applyBuff( "bones_of_the_damned" ) end
         end,
@@ -2112,9 +2134,9 @@ spec:RegisterAbilities( {
     rune_tap = {
         id = 194679,
         cast = 0,
-        charges = function () return level > 43 and 2 or nil end,
+        charges = function () if level > 43 then return 2 end end,
         cooldown = 25,
-        recharge = function () return level > 43 and 25 or nil end,
+        recharge = function () if level > 43 then return 25 end end,
         gcd = "off",
 
         spend = 1,
@@ -2213,22 +2235,11 @@ spec:RegisterAbilities( {
         handler = function ()
             local bs = min( 5, buff.bone_shield.stack )
 
-            removeStack( "bone_shield", bs )
+
             if talent.insatiable_blade.enabled then reduceCooldown( "dancing_rune_weapon", bs * 5 ) end
+            if talent.blood_tap.enabled then  gainChargeTime( "blood_tap", bs * 2 ) end
+            removeStack( "bone_shield", bs )
             gain( 6 * bs, "runic_power" )
-
-            -- This is the only predictable Bone Shield consumption that I have noted.
-            if cooldown.dancing_rune_weapon.remains > 0 then
-                cooldown.dancing_rune_weapon.expires = cooldown.dancing_rune_weapon.expires - ( 3 * bs )
-            end
-
-            if cooldown.blood_tap.charges_fractional < cooldown.blood_tap.max_charges then
-                gainChargeTime( "blood_tap", 2 * bs )
-            end
-
-            if set_bonus.tier21_2pc == 1 then
-                cooldown.dancing_rune_weapon.expires = max( 0, cooldown.dancing_rune_weapon.expires - ( 3 * bs ) )
-            end
 
             if set_bonus.tww1_4pc > 0 then
                 if buff.bone_shield.up then applyBuff( "piledriver", nil, buff.bone_shield.stack )
@@ -2236,6 +2247,12 @@ spec:RegisterAbilities( {
             end
 
             applyBuff( "tombstone" )
+
+            -- Legacy
+            if set_bonus.tier21_2pc == 1 then
+                cooldown.dancing_rune_weapon.expires = max( 0, cooldown.dancing_rune_weapon.expires - ( 3 * bs ) )
+            end
+
         end,
     },
 

--- a/TheWarWithin/DeathKnightBlood.lua
+++ b/TheWarWithin/DeathKnightBlood.lua
@@ -180,7 +180,7 @@ spec:RegisterResource( Enum.PowerType.RunicPower, {
 local spendHook = function( amt, resource )
     -- Runic Power
     if amt > 0 and resource == "runic_power" then
-        if talent.red_thirst.enabled then reduceCooldown( "vampiric_blood", floor( amt / 10 ) * 2 ) end
+        if talent.red_thirst.enabled then reduceCooldown( "vampiric_blood", floor( amt / 5 ) ) end -- it seems to reduce it by intervals of 5, not 10
         if talent.icy_talons.enabled then addStack( "icy_talons", nil, 1 ) end
     end
     -- Runes

--- a/TheWarWithin/DeathKnightFrost.lua
+++ b/TheWarWithin/DeathKnightFrost.lua
@@ -564,7 +564,7 @@ spec:RegisterAuras( {
     -- https://wowhead.com/beta/spell=377195
     enduring_strength_buff = {
         id = 377195,
-        duration = 6,
+        duration = function() return 6 + 2 * buff.enduring_strength.stack end,
         max_stack = 1
     },
     everfrost = {
@@ -665,8 +665,8 @@ spec:RegisterAuras( {
     },
     icy_talons = {
         id = 194879,
-        duration = 6,
-        max_stack = function() return ( talent.smothering_offense.enabled and 5 or 3 ) + ( talent.dark_talons.enabled and 2 or 0 ) end,
+        duration = 10,
+        max_stack = function() return ( talent.smothering_offense.enabled and 5 or 3 ) + ( talent.dark_talons.enabled and 3 or 0 ) end,
     },
     inexorable_assault = {
         id = 253595,
@@ -683,7 +683,7 @@ spec:RegisterAuras( {
     killing_machine = {
         id = 51124,
         duration = 10,
-        max_stack = function() return 1 + talent.fatal_fixation.rank end,
+        max_stack = 2,
     },
     -- Absorbing up to $w1 magic damage.; Duration of harmful magic effects reduced by $s2%.
     lesser_antimagic_shell = {
@@ -692,7 +692,6 @@ spec:RegisterAuras( {
         max_stack = 1,
 
         -- Affected by:
-        -- fatal_fixation[405166] #0: { 'type': APPLY_AURA, 'subtype': ADD_FLAT_MODIFIER, 'points': 1.0, 'target': TARGET_UNIT_CASTER, 'modifies': MAX_STACKS, }
         -- antimagic_barrier[205727] #0: { 'type': APPLY_AURA, 'subtype': ADD_FLAT_MODIFIER, 'points': -20000.0, 'target': TARGET_UNIT_CASTER, 'modifies': COOLDOWN, }
         -- antimagic_barrier[205727] #1: { 'type': APPLY_AURA, 'subtype': ADD_PCT_MODIFIER, 'pvp_multiplier': 0.5, 'points': 40.0, 'target': TARGET_UNIT_CASTER, 'modifies': BUFF_DURATION, }
         -- osmosis[454835] #0: { 'type': APPLY_AURA, 'subtype': ADD_FLAT_MODIFIER, 'points': 15.0, 'target': TARGET_UNIT_CASTER, 'modifies': EFFECT_4_VALUE, }
@@ -988,17 +987,44 @@ local TriggerERW = setfenv( function()
     gain( 5, "runic_power" )
 end, state )
 
+local TriggerEnduringStrengthBuff = setfenv( function()
+    applyBuff( "enduring_strength_buff" )
+end, state )
+
 local any_dnd_set = false
 
+local spendHook = function( amt, resource )
+    -- Runic Power
+    if amt > 0 and resource == "runic_power" then
+        if talent.icy_talons.enabled then addStack( "icy_talons", nil, 1 ) end
+        if talent.unleashed_frenzy.enabled then addStack( "unleashed_frenzy") end
+    end
+    -- Runes
+    if resource == "rune" and amt > 0 then
+        if active_dot.shackle_the_unworthy > 0 then
+            reduceCooldown( "shackle_the_unworthy", 4 * amt )
+        end
+
+        if talent.rune_carved_plates.enabled then
+            addStack( "rune_carved_plates" )
+        end
+    end
+end
+
+spec:RegisterHook( "spend", spendHook )
+
 spec:RegisterHook( "reset_precast", function ()
-    if state:IsKnown( "deaths_due" ) then
-        class.abilities.any_dnd = class.abilities.deaths_due
-        cooldown.any_dnd = cooldown.deaths_due
-        setCooldown( "death_and_decay", cooldown.deaths_due.remains )
-    elseif state:IsKnown( "defile" ) then
-        class.abilities.any_dnd = class.abilities.defile
-        cooldown.any_dnd = cooldown.defile
-        setCooldown( "death_and_decay", cooldown.defile.remains )
+
+    if covenant.night_fae then
+        if state:IsKnown( "deaths_due" ) then
+            class.abilities.any_dnd = class.abilities.deaths_due
+            cooldown.any_dnd = cooldown.deaths_due
+            setCooldown( "death_and_decay", cooldown.deaths_due.remains )
+        elseif state:IsKnown( "defile" ) then
+            class.abilities.any_dnd = class.abilities.defile
+            cooldown.any_dnd = cooldown.defile
+            setCooldown( "death_and_decay", cooldown.defile.remains )
+        end
     else
         class.abilities.any_dnd = class.abilities.death_and_decay
         cooldown.any_dnd = cooldown.death_and_decay
@@ -1009,8 +1035,12 @@ spec:RegisterHook( "reset_precast", function ()
         any_dnd_set = true
     end
 
+    if buff.pillar_of_frost.up and talent.enduring_strength.enabled then
+        state:QueueAuraEvent( "pillar_of_frost", TriggerEnduringStrengthBuff, buff.pillar_of_frost.expires, "AURA_EXPIRATION" )
+    end
+
     local control_expires = action.control_undead.lastCast + 300
-    if control_expires > now and pet.up then
+    if talent.control_undead.enabled and control_expires > now and pet.up then
         summonPet( "controlled_undead", control_expires - now )
     end
 
@@ -1023,13 +1053,15 @@ spec:RegisterHook( "reset_precast", function ()
     end
 
     if buff.empower_rune_weapon.up then
-        local expires = buff.empower_rune_weapon.expires
-
-        while expires >= query_time do
-            state:QueueAuraExpiration( "empower_rune_weapon", TriggerERW, expires )
-            expires = expires - 5
+        local tick, expires = buff.empower_rune_weapon.applied, buff.empower_rune_weapon.expires
+        for i = 1, 4 do
+            tick = tick + 5
+            if tick > query_time and tick < expires then
+                state:QueueAuraEvent( "empower_rune_weapon", TriggerERW, tick, "AURA_TICK" )
+            end
         end
     end
+
 end )
 
 
@@ -1382,29 +1414,20 @@ spec:RegisterAbilities( {
     empower_rune_weapon = {
         id = 47568,
         cast = 0,
-        charges = function()
-            if talent.empower_rune_weapon.rank + talent.empower_rune_weapon_2.rank > 1 then return 2 end
-        end,
         cooldown = function () return ( conduit.accelerated_cold.enabled and 0.9 or 1 ) * ( essence.vision_of_perfection.enabled and 0.87 or 1 ) * ( level > 55 and 105 or 120 ) end,
-        recharge = function ()
-            if talent.empower_rune_weapon.rank + talent.empower_rune_weapon_2.rank > 1 then return ( conduit.accelerated_cold.enabled and 0.9 or 1 ) * ( essence.vision_of_perfection.enabled and 0.87 or 1 ) * ( level > 55 and 105 or 120 ) end
-        end,
         gcd = "off",
 
         talent = "empower_rune_weapon",
         startsCombat = false,
-
-        usable = function() return talent.empower_rune_weapon.rank + talent.empower_rune_weapon_2.rank > 0, "requires an empower_rune_weapon talent" end,
 
         handler = function ()
             stat.haste = state.haste + 0.15 + ( conduit.accelerated_cold.mod * 0.01 )
             gain( 1, "runes" )
             gain( 5, "runic_power" )
             applyBuff( "empower_rune_weapon" )
-            state:QueueAuraExpiration( "empower_rune_weapon", TriggerERW, query_time + 5 )
-            state:QueueAuraExpiration( "empower_rune_weapon", TriggerERW, query_time + 10 )
-            state:QueueAuraExpiration( "empower_rune_weapon", TriggerERW, query_time + 15 )
-            state:QueueAuraExpiration( "empower_rune_weapon", TriggerERW, query_time + 20 )
+            for i = 5, 20, 5 do
+                state:QueueAuraEvent( "empower_rune_weapon", TriggerERW, query_time + i, "AURA_TICK" )
+            end
         end,
 
         copy = "empowered_rune_weapon"
@@ -1419,6 +1442,7 @@ spec:RegisterAbilities( {
 
         spend = 30,
         spendType = "runic_power",
+        school = function() if talent.dark_talons.enabled and buff.icy_talons.up then return "shadowfrost" end return "frost" end,
 
         talent = "frost_strike",
         startsCombat = true,
@@ -1429,21 +1453,21 @@ spec:RegisterAbilities( {
         end,
 
         handler = function ()
-            applyDebuff( "target", "razorice", 20, 2 )
 
             if talent.obliteration.enabled and buff.pillar_of_frost.up then addStack( "killing_machine" ) end
-            removeBuff( "eradicating_blow" )
+            if talent.shattering_blade.enabled and debuff.razorice.stack == 5 then removeDebuff( "target", "razorice" ) end
+            -- if debuff.razorice.stack > 5 then applyDebuff( "target", "razorice", nil, debuff.razorice.stack - 5 ) end 
 
-            if talent.shattering_blade.enabled then
-                if debuff.razorice.stack == 5 then removeDebuff( "target", "razorice" )
-                elseif debuff.razorice.stack > 5 then applyDebuff( "target", "razorice", nil, debuff.razorice.stack - 5 ) end
-            end
+            
+            if death_knight.runeforge.razorice then applyDebuff( "target", "razorice", nil, min( 5, buff.razorice.stack + 1 ) ) end
 
-            if talent.unleashed_frenzy.enabled then addStack( "unleashed_frenzy", nil, 3 ) end
-
+            -- Legacy / PvP
             if pvptalent.bitter_chill.enabled and debuff.chains_of_ice.up then
                 applyDebuff( "target", "chains_of_ice" )
             end
+
+            if conduit.eradicating_blow.enabled then removeBuff( "eradicating_blow" ) end
+
         end,
 
         auras = {
@@ -1498,6 +1522,7 @@ spec:RegisterAbilities( {
         toggle = "cooldowns",
 
         handler = function ()
+            -- if talent.apocalypse_now.enabled then do stuff end
             applyDebuff( "target", "frostwyrms_fury" )
             if set_bonus.tier30_4pc > 0 then applyDebuff( "target", "lingering_chill" ) end
             if legendary.absolute_zero.enabled then applyDebuff( "target", "absolute_zero" ) end
@@ -1547,7 +1572,7 @@ spec:RegisterAbilities( {
         cast = 0,
         cooldown = 0,
         gcd = "spell",
-        school = function() return talent.bind_in_darkness.enabled and "shadowfrost" or "frost" end,
+        school = function() return talent.bind_in_darkness.enabled and buff.rime.up and "shadowfrost" or "frost" end,
 
         spend = function () return buff.rime.up and 0 or 1 end,
         spendType = "runes",
@@ -1560,18 +1585,14 @@ spec:RegisterAbilities( {
             active_dot.frost_fever = max( active_dot.frost_fever, active_enemies )
 
             if talent.bind_in_darkness.enabled and debuff.reapers_mark.up then applyDebuff( "target", "reapers_mark", nil, debuff.reapers_mark.stack + 2 ) end
-
             if talent.obliteration.enabled and buff.pillar_of_frost.up then addStack( "killing_machine" ) end
 
             if buff.rime.up then
                 removeBuff( "rime" )
-
-                if legendary.rage_of_the_frozen_champion.enabled then
-                    gain( 8, "runic_power" )
-                end
-                if set_bonus.tier30_2pc > 0 then
-                    addStack( "wrath_of_the_frostwyrm" )
-                end
+                if talent.rage_of_the_frozen_champion.enabled then gain( 6, "runic_power") end
+                if talent.avalanche.enabled then applyDebuff( "target", "razorice", nil, min( 5, buff.razorice.stack + 1 ) ) end
+                if legendary.rage_of_the_frozen_champion.enabled then gain( 8, "runic_power" ) end
+                if set_bonus.tier30_2pc > 0 then addStack( "wrath_of_the_frostwyrm" ) end
             end
 
             if pvptalent.delirium.enabled then applyDebuff( "target", "delirium" ) end
@@ -1640,11 +1661,12 @@ spec:RegisterAbilities( {
         cooldown = 0,
         gcd = "spell",
 
-        spend = 2,
+        spend = function() if talent.exterminate.enabled and buff.exterminate.up then return 1 end return 2 end,
         spendType = "runes",
 
         talent = "obliterate",
         startsCombat = true,
+        school = function() if buff.killing_machine.up then return "frost" end return "physical" end,
 
         cycle = function ()
             if debuff.mark_of_fyralath.up then return "mark_of_fyralath" end
@@ -1652,21 +1674,25 @@ spec:RegisterAbilities( {
         end,
 
         handler = function ()
-            removeStack( "inexorable_assault" )
+            if talent.inexorable_assault.enabled then removeStack( "inexorable_assault" ) end
 
             if buff.exterminate.up then
                 removeStack( "exterminate" )
-                if talent.wither_away.enabled and buff.exterminate.down then applyDebuff( "target", "frost_fever" ) end
+                if talent.wither_away.enabled then
+                    applyDebuff( "target", "frost_fever" )
+                    active_dot.frost_fever = max ( active_dot.frost_fever, active_enemies ) -- it applies in AoE around your target
+                end
             end
 
-            if buff.killing_machine.up and talent.bonegrinder.enabled then
-                if buff.bonegrinder_crit.stack_pct == 100 then
+            if buff.killing_machine.up then
+                if talent.bonegrinder.enabled and buff.bonegrinder_crit.stack_pct == 100 then
                     removeBuff( "bonegrinder_crit" )
                     applyBuff( "bonegrinder_frost" )
                 else
                     addStack( "bonegrinder_crit" )
                 end
-                removeBuff( "killing_machine" )
+                removeStack( "killing_machine" )
+                if talent.arctic_assault.enabled then applyDebuff( "target", "razorice", nil, min( 5, buff.razorice.stack + 1 ) ) end
             end
 
             -- Koltira's Favor is not predictable.
@@ -1712,6 +1738,8 @@ spec:RegisterAbilities( {
 
         handler = function ()
             applyBuff( "pillar_of_frost" )
+
+            -- Legacy
             if set_bonus.tier30_2pc > 0 then
                 applyDebuff( "target", "frostwyrms_fury" )
                 applyDebuff( "target", "lingering_chill" )
@@ -1764,7 +1792,7 @@ spec:RegisterAbilities( {
         cooldown = function() return 60.0 - ( 15 * talent.reapers_onslaught.rank ) end,
         gcd = "spell",
 
-        spend = function() return 2 - ( talent.swift_end.enabled and 1 or 0 ) end,
+        spend = 2,
         spendType = 'runes',
 
         talent = "reapers_mark",
@@ -1774,7 +1802,7 @@ spec:RegisterAbilities( {
             applyDebuff( "target", "reapers_mark" )
 
             if talent.grim_reaper.enabled then
-                applyBuff( "killing_machine" )
+                addStack( "killing_machine" )
             end
 
             if talent.reaper_of_souls.enabled then
@@ -1860,7 +1888,7 @@ spec:RegisterAbilities( {
         cooldown = 6,
         gcd = "spell",
 
-        spend = 1,
+        spend = function() if talent.reaper_of_souls.enabled and buff.reaper_of_souls.up then return 0 end return 1 end,
         spendType = "runes",
 
         talent = "soul_reaper",


### PR DESCRIPTION
# Blood DK Modelling Update

## Spend Hook
- Update `Vampiric Blood` CDR
- Support `Rune Carved Plates` buff

## General Changes
- Creation of `buff.dancing_rune_weapon.active_weapons` which allows for easy coding of gains that increase based on your weapons, and also has a built-in check for the buff being up for cleaner code
- if then return X end end format for some charges
- Legacy checks
- Less hardcoded values when they aren't necessary

## Ability, Aura, Talent modelling
- `Vampiric Blood`
  - Correct CDR gains
  - Correct the buff duration
- `Bonestorm`
  - Support health gains on tick
- `Blood Boil`
  - Add stacks of `hemostasis`, don't overwrite the buff
- `Consumption`
  - add `blood_shield` buff
- `Death and Decay`
  - Health gains based on bone shield stacks
- `Death Strike`
  - Recalculate guaranteed HP gains
  - Talent checks for buff add/removes
- `Death's Caress`
  - Add modelling for Dancing Rune Weapon (bonus Bone Shield stacks)
- `Heart Strike`
  - RP Gains
    -  Add modelling for Dancing Rune Weapon (bonus RP gain)
    - Don't subtract 1 enemy for some reason from cleave RP gains
    - Add the base 15 RP gain from casting
  - HP gain from vamp strike was accidentally halved (Frost DK value)
  - Don't apply max stacks of `essence_of_the_blood_queen` on every cast
  - `Incite Terror` support
  - Legacy and Talent checks
- `Marrowrend`
  - `Exterminate`
    - Correct rune cost during exterminate
    - Correct scythe behaviour
  - Dancing Rune Weapon bone shield gains support
  - `Ossified Vitriol` support
- `Rune Tap`
  - Remove deprecated code