### PR TITLE
Small fixes: Scalecommander, Paladin, Monk, Spriest

### DIFF
--- a/TheWarWithin/EvokerAugmentation.lua
+++ b/TheWarWithin/EvokerAugmentation.lua
@@ -199,6 +199,13 @@ spec:RegisterAuras( {
         friendly = true,
         no_ticks = true
     },
+    -- Damage taken has a chance to summon air support from the Dracthyr.
+    bombardments = {
+        id = 434473,
+        duration = 6.0,
+        pandemic = true,
+        max_stack = 1,
+    },
     -- Exposing Temporal Wounds on enemies in your path. Immune to crowd control.
     breath_of_eons = {
         id = 403631,
@@ -879,6 +886,7 @@ spec:RegisterAbilities( {
             return 3 - ( talent.volcanism.enabled and 1 or 0 )
         end,
         spendType = "essence",
+        cycle = function() if talent.bombardments.enabled and buff.mass_eruption_stacks.up then return "bombardments" end end,
 
         talent = "eruption",
         startsCombat = true,

--- a/TheWarWithin/EvokerDevastation.lua
+++ b/TheWarWithin/EvokerDevastation.lua
@@ -213,7 +213,7 @@ spec:RegisterAuras( {
     -- Damage taken has a chance to summon air support from the Dracthyr.
     bombardments = {
         id = 434473,
-        duration = 10.0,
+        duration = 6.0,
         pandemic = true,
         max_stack = 1,
     },
@@ -979,6 +979,8 @@ spec:RegisterAbilities( {
 
         spend = function () return buff.essence_burst.up and 0 or ( buff.imminent_destruction.up and 2 or 3 ) end,
         spendType = "essence",
+
+        cycle = function() if talent.bombardments.enabled and buff.mass_disintegrate_stacks.up then return "bombardments" end end,
 
         startsCombat = true,
 

--- a/TheWarWithin/MonkBrewmaster.lua
+++ b/TheWarWithin/MonkBrewmaster.lua
@@ -1558,16 +1558,40 @@ spec:RegisterAbilities( {
 
         spend = 20,
         spendType = "energy",
+        toggle = function() if talent.pressure_points.enabled then return "interrupts" end end,
 
         talent = "paralysis",
         startsCombat = true,
-        debuff = function() return talent.pressure_points.enabled and "dispellable_enrage" or nil end,
+
+        usable = function () if talent.pressure_points.enabled then
+            return buff.dispellable_enrage.up end
+            return true
+        end,
 
         handler = function ()
             applyDebuff( "target", "paralysis" )
-            if talent.pressure_points.enabled then removeDebuff( "target", "dispellable_enrage" ) end
+            if talent.pressure_points.enabled then removeBuff( "dispellable_enrage" ) end
         end,
     },
+
+
+
+--[[
+    -- Talent: Removes $s1 Enrage and $s2 Magic effect from an enemy target.$?s343244[    Successfully dispelling an effect generates $343244s1 Focus.][]
+    tranquilizing_shot = {
+
+        usable = function () return buff.dispellable_enrage.up or buff.dispellable_magic.up, "requires enrage or magic effect" end,
+
+        handler = function ()
+            if talent.devilsaur_tranquilizer.enabled and buff.dispellable_enrage.up and buff.dispellable_magic.up then reduceCooldown( "tranquilizing_shot", 5 ) end
+            removeBuff( "dispellable_enrage" )
+            removeBuff( "dispellable_magic" )
+            if state.spec.survival or talent.improved_tranquilizing_shot.enabled then gain( 10, "focus" ) end
+        end,
+    },
+--]]
+
+
 
     -- Taunts the target to attack you and causes them to move toward you at 50% increased speed. This ability can be targeted on your Statue of the Black Ox, causing the same effect on all enemies within 10 yards of the statue.
     provoke = {

--- a/TheWarWithin/MonkWindwalker.lua
+++ b/TheWarWithin/MonkWindwalker.lua
@@ -1522,22 +1522,28 @@ spec:RegisterAbilities( {
         end,
     },
 
-    -- Talent: Incapacitates the target for $d. Limit 1. Damage will cancel the effect.
     paralysis = {
         id = 115078,
         cast = 0,
-        cooldown = function() return talent.improved_paralysis.enabled and 30 or 45 end,
+        cooldown = function() return 45 - ( 7.5 * talent.ancient_arts.rank ) end,
         gcd = "spell",
         school = "physical",
 
         spend = 20,
         spendType = "energy",
+        toggle = function() if talent.pressure_points.enabled then return "interrupts" end end,
 
         talent = "paralysis",
-        startsCombat = false,
+        startsCombat = true,
+
+        usable = function () if talent.pressure_points.enabled then
+            return buff.dispellable_enrage.up end
+            return true
+        end,
 
         handler = function ()
             applyDebuff( "target", "paralysis" )
+            if talent.pressure_points.enabled then removeBuff( "dispellable_enrage" ) end
         end,
     },
 

--- a/TheWarWithin/PaladinHoly.lua
+++ b/TheWarWithin/PaladinHoly.lua
@@ -642,9 +642,7 @@ spec:RegisterHook( "reset_precast", function()
 end )
 
 spec:RegisterHook( "spend", function( amt, resource )
-    
-    if amt == 0 or amt == nil then Hekili:Print("Free spend detected: ", state.this_action, " spending ", amt, " ", resource) end
-    
+        
     if amt > 0 and resource == "holy_power" then
         if talent.tirions_devotion.enabled then
             reduceCooldown( "lay_on_hands", amt * 1.5 )

--- a/TheWarWithin/PaladinHoly.lua
+++ b/TheWarWithin/PaladinHoly.lua
@@ -276,6 +276,11 @@ spec:RegisterAuras( {
         duration = 3600,
         max_stack = 3
     },
+    blessed_assurance = {
+        id = 433019,
+        duration = 20,
+        max_stack = 1,
+    },
     blessing_of_autumn = {
         id = 388010,
         duration = 30,
@@ -455,7 +460,10 @@ spec:RegisterAuras( {
     infusion_of_light = {
         id = 54149,
         duration = 15,
-        max_stack = 2,
+        max_stack = function() if talent.inflorescence_of_the_sunwell.enabled then
+            return 2 end
+            return 1
+        end,
         copy = 53576
     },
     liberation = {
@@ -628,12 +636,15 @@ spec:RegisterHook( "reset_precast", function()
     end
 
     if talent.holy_armaments.enabled then
-        if IsActiveSpell( 432472 ) then applyBuff( "sacred_weapon_ready" )
+        if IsSpellKnownOrOverridesKnown( 432472 ) then applyBuff( "sacred_weapon_ready" )
         else applyBuff( "holy_bulwark_ready" ) end
     end
 end )
 
 spec:RegisterHook( "spend", function( amt, resource )
+    
+    if amt == 0 or amt == nil then Hekili:Print("Free spend detected: ", state.this_action, " spending ", amt, " ", resource) end
+    
     if amt > 0 and resource == "holy_power" then
         if talent.tirions_devotion.enabled then
             reduceCooldown( "lay_on_hands", amt * 1.5 )
@@ -641,6 +652,10 @@ spec:RegisterHook( "spend", function( amt, resource )
 
         if talent.relentless_inquisition.enabled then
             addStack( "relentless_inquisitor" )
+        end
+
+        if talent.blessed_assurance.enabled then
+            applyBuff( "blessed_assurance" )
         end
     end
 end )
@@ -1288,7 +1303,11 @@ spec:RegisterAbilities( {
         texture = 135907,
 
         handler = function ()
-            removeBuff( "infusion_of_light" )
+            if buff.infusion_of_light.up then
+                removeStack( "infusion_of_light" )
+                if talent.valiance.enabled then reduceCooldown( "holy_armaments", 3 ) end
+                if talent.imbued_infusions.enabled then reduceCooldown( "holy_shock", 1) end
+            end
             removeBuff( "divine_favor" )
             if talent.boundless_salvation.enabled and buff.tyrs_deliverance.up then
                 buff.tyrs_deliverance.expires = buff.tyrs_deliverance.expires + 4
@@ -1411,7 +1430,9 @@ spec:RegisterAbilities( {
             removeBuff( "liberation" )
 
             if buff.infusion_of_light.up then
-                removeBuff( "infusion_of_light" )
+                removeStack( "infusion_of_light" )
+                if talent.valiance.enabled then reduceCooldown( "holy_armaments", 3 ) end
+                if talent.imbued_infusions.enabled then reduceCooldown( "holy_shock", 1) end
             end
             if talent.boundless_salvation.enabled and buff.tyrs_deliverance.up then
                 buff.tyrs_deliverance.expires = buff.tyrs_deliverance.expires + 8
@@ -1517,6 +1538,12 @@ spec:RegisterAbilities( {
             gain( 1, "holy_power" )
             HandleAwakening()
 
+            if buff.infusion_of_light.up then
+                removeStack( "infusion_of_light" )
+                if talent.valiance.enabled then reduceCooldown( "holy_armaments", 3 ) end
+                if talent.imbued_infusions.enabled then reduceCooldown( "holy_shock", 1) end
+            end
+
             removeBuff( "liberation" )
 
             if talent.empyrean_legacy.enabled and debuff.empyrean_legacy_icd.down then
@@ -1562,6 +1589,7 @@ spec:RegisterAbilities( {
         texture = 461859,
 
         handler = function ()
+            if talent.blessed_assurance.enabled then applyBuff( "blessed_assurance" ) end
             spend( 0.18 * mana.max, "mana" )
             if buff.divine_purpose.down and buff.shining_righteousness_ready.down then addStack( "afterimage_stacks", nil, 3 ) end
             if buff.dawnlight.up then
@@ -1662,7 +1690,10 @@ spec:RegisterAbilities( {
         texture = 236265,
         equipped = "shield",
 
+        
         handler = function ()
+            if talent.blessed_assurance.enabled then applyBuff( "blessed_assurance" ) end
+
             if buff.divine_purpose.down and buff.shining_righteousness_ready.down then addStack( "afterimage_stacks", nil, 3 ) end
             removeBuff( "divine_purpose" )
             reduceCooldown( "crusader_strike", 1.5 )
@@ -1757,6 +1788,7 @@ spec:RegisterAbilities( {
         texture = 133192,
 
         handler = function ()
+            if talent.blessed_assurance.enabled then applyBuff( "blessed_assurance" ) end
             if buff.afterimage_stacks.stack >= 20 then removeStack( "afterimage_stacks", 20 ) end
             if buff.dawnlight.up then
                 applyBuff( "dawnlight_hot" )

--- a/TheWarWithin/PaladinProtection.lua
+++ b/TheWarWithin/PaladinProtection.lua
@@ -1667,11 +1667,11 @@ spec:RegisterAbilities( {
     -- Talent: Heals a friendly target for an amount equal to 100% your maximum health. Cannot be used on a target with Forbearance. Causes Forbearance for 30 sec.
     lay_on_hands = {
         id = function() if talent.empyreal_ward.enabled then
-            return 633 end
-            return 471195
+            return 471195 end
+            return 633
         end,
         cast = 0,
-        cooldown = function () return 600 * ( talent.unbreakable_spirit.enabled and 0.7 or 1 ) * ( 1 - 0.3 * talent.uthers_counsel.rank ) end,
+        cooldown = function () return 600 * ( talent.unbreakable_spirit.enabled and 0.7 or 1 ) * ( talent.uthers_counsel.enabled and 0.7 or 1 ) end,
         gcd = "off",
         school = "holy",
 
@@ -1683,9 +1683,12 @@ spec:RegisterAbilities( {
 
         handler = function ()
             gain( health.max, "health" )
-            applyDebuff( "player", "forbearance" )
-            if azerite.empyreal_ward.enabled then applyBuff( "empyrael_ward" ) end
+            if talent.tirions_devotion.enabled then gain( 0.05 * mana.max, "mana" ) end
+            -- applyDebuff( "", "forbearance" )
+            if talent.empyreal_ward.enabled then applyBuff( "empyrael_ward" ) end
         end,
+
+        copy = { 633, 471195 }
     },
 
     -- Talent: For the next 15 sec, you generate an absorb shield for 20% of all damage you deal, and Avenger's Shield damage is increased by 20% and its cooldown is reduced by 75%.

--- a/TheWarWithin/PaladinProtection.lua
+++ b/TheWarWithin/PaladinProtection.lua
@@ -1440,7 +1440,7 @@ spec:RegisterAbilities( {
 
     -- Talent: Empowers you with the spirit of ancient kings, reducing all damage you take by 50% for 8 sec.
     guardian_of_ancient_kings = {
-        id = function () return IsSpellKnownOrOverridesKnown( 212641 ) and 212641 or 86659 end,
+        id = function () return IsSpellKnownOrOverridesKnown( 228049 ) and 228049 or 86659 end,
         cast = 0,
         cooldown = function () return 300 - ( conduit.royal_decree.mod * 0.001 ) end,
         gcd = "off",

--- a/TheWarWithin/PaladinProtection.lua
+++ b/TheWarWithin/PaladinProtection.lua
@@ -1666,7 +1666,10 @@ spec:RegisterAbilities( {
 
     -- Talent: Heals a friendly target for an amount equal to 100% your maximum health. Cannot be used on a target with Forbearance. Causes Forbearance for 30 sec.
     lay_on_hands = {
-        id = 633,
+        id = function() if talent.empyreal_ward.enabled then
+            return 633 end
+            return 471195
+        end,
         cast = 0,
         cooldown = function () return 600 * ( talent.unbreakable_spirit.enabled and 0.7 or 1 ) * ( 1 - 0.3 * talent.uthers_counsel.rank ) end,
         gcd = "off",

--- a/TheWarWithin/PaladinProtection.lua
+++ b/TheWarWithin/PaladinProtection.lua
@@ -774,8 +774,8 @@ spec:RegisterAuras( {
 
     -- Azerite Powers
     empyreal_ward = {
-        id = 287731,
-        duration = 60,
+        id = 387792,
+        duration = 8,
         max_stack = 1,
     },
 
@@ -1054,6 +1054,10 @@ spec:RegisterAbilities( {
 
         talent = "avengers_shield",
         startsCombat = true,
+        max_targets = function() if talent.soaring_shield.enabled then
+                return 5 end
+                return 3
+            end,
 
         handler = function ()
             applyDebuff( "target", "avengers_shield" )
@@ -1066,7 +1070,7 @@ spec:RegisterAbilities( {
             if talent.crusaders_resolve.enabled then applyDebuff( "target", "crusaders_resolve" ) end
             if talent.first_avenger.enabled then applyBuff( "first_avenger" ) end
             if talent.gift_of_the_golden_valkyr.enabled then
-                reduceCooldown( "guardian_of_ancient_kings", 0.5 * talent.gift_of_the_golden_valkyr.rank * min( active_enemies, 3 + ( talent.soaring_shield.enabled and 2 or 0 ) ) )
+                reduceCooldown( "guardian_of_ancient_kings", 1 * talent.gift_of_the_golden_valkyr.rank * min( active_enemies, action.avengers_shield.max_targets ))
             end
             if talent.refining_fire.enabled then applyDebuff( "target", "refining_fire" ) end
             if talent.strength_in_adversity.enabled then addStack( "strength_in_adversity", nil, min( active_enemies, 3 + ( talent.soaring_shield.enabled and 2 or 0 ) ) ) end
@@ -1440,7 +1444,7 @@ spec:RegisterAbilities( {
 
     -- Talent: Empowers you with the spirit of ancient kings, reducing all damage you take by 50% for 8 sec.
     guardian_of_ancient_kings = {
-        id = function () return IsSpellKnownOrOverridesKnown( 212641 ) and 212641 or 86659 end,
+        id = function () return IsSpellKnownOrOverridesKnown( 228049 ) and 228049 or 86659 end,
         cast = 0,
         cooldown = function () return 300 - ( conduit.royal_decree.mod * 0.001 ) end,
         gcd = "off",
@@ -1456,7 +1460,7 @@ spec:RegisterAbilities( {
             if conduit.royal_decree.enabled then applyBuff( "royal_decree" ) end
         end,
 
-        copy = { 86659, 212641 }
+        copy = { 86659, 212641, 228049 }
     },
 
     -- Empowers the friendly target with the spirit of the forgotten queen, causing the target to be immune to all damage for 10 sec.
@@ -1666,7 +1670,10 @@ spec:RegisterAbilities( {
 
     -- Talent: Heals a friendly target for an amount equal to 100% your maximum health. Cannot be used on a target with Forbearance. Causes Forbearance for 30 sec.
     lay_on_hands = {
-        id = 633,
+        id = function() if talent.empyreal_ward.enabled then
+                return 633 end
+                return 471195
+            end,
         cast = 0,
         cooldown = function () return 600 * ( talent.unbreakable_spirit.enabled and 0.7 or 1 ) * ( 1 - 0.3 * talent.uthers_counsel.rank ) end,
         gcd = "off",
@@ -1680,8 +1687,9 @@ spec:RegisterAbilities( {
 
         handler = function ()
             gain( health.max, "health" )
-            applyDebuff( "player", "forbearance" )
-            if azerite.empyreal_ward.enabled then applyBuff( "empyrael_ward" ) end
+            if talent.tirions_devotion.enabled then gain( 0.05 * mana.max, "mana" ) end
+            -- applyDebuff( "", "forbearance" )
+            if talent.empyreal_ward.enabled then applyBuff( "empyrael_ward" ) end
         end,
     },
 

--- a/TheWarWithin/PriestShadow.lua
+++ b/TheWarWithin/PriestShadow.lua
@@ -409,6 +409,10 @@ spec:RegisterHook( "reset_precast", function ()
         state:QueueAuraExpiration( "voidform", ExpireVoidform, buff.voidform.expires )
     end
 
+    if not IsSpellKnownOrOverridesKnown( 391403 ) then
+        removeBuff( "mind_flay_insanity" )
+    end
+
     if IsActiveSpell( 356532 ) then
         applyBuff( "direct_mask", class.abilities.fae_guardians.lastCast + 20 - now )
     end


### PR DESCRIPTION
### Evoker
- Implement target cycling for `bombardments`
  - Fixes https://github.com/Hekili/hekili/issues/4219

### Monk
- Change soothe behaviour of `paralysis` to mirror how other specs/classes do it
  - Fixes https://github.com/Hekili/hekili/issues/4209

### Holy Paladin
- `holy_armaments`
  - Better swapping detection between the 2
- `blessed_assurance` fully implemented
- `infusion_of_light` touchups
  - armament CDR
  - `holy_shock` CDR
  - Proper stacks and consumptions
- Addresses https://github.com/Hekili/hekili/issues/4174

### Prot Paladin
- Fix `lay_on_hands`
  - Fixes https://github.com/Hekili/hekili/issues/4222
- update `empyreal_ward`
- Fix `guardian_of_ancient_kings` spellIDs
- improve `avengers_shield` CDR for `guardian_of_the_ancient_kings`
- fix `shining_light` interactions
- `holy_armaments`
  - Better swapping detection between the 2


### Shadow Priest
- Better swapping of `mind_flay` and `mind_flay_insanity` texture
  - Fixes https://github.com/Hekili/hekili/issues/4220