### PR TITLE
Add Algari Healing Potion and Cavedweller's Delight

### DIFF
--- a/Classes.lua
+++ b/Classes.lua
@@ -2394,7 +2394,7 @@ do
             items = { 211878, 211879, 211880 }
         },
         {
-            name = "cavedweller's_delight",
+            name = "cavedwellers_delight",
             items = { 212242, 212243, 212244 }
         }
     }

--- a/Classes.lua
+++ b/Classes.lua
@@ -2388,6 +2388,14 @@ do
         {
             name = "elemental_potion_of_power",
             items = { 191907, 191906, 191905, 191389, 191388, 191387 }
+        },
+        {
+            name = "algari_healing_potion",
+            items = { 211878, 211879, 211880 }
+        },
+        {
+            name = "cavedweller's_delight",
+            items = { 212242, 212243, 212244 }
         }
     }
 


### PR DESCRIPTION
_Algari Healing Potion_ and _Cavedweller's Delight_ of the current version have been added.
These two important life-saving potions of the current version have always been unable to be selected and used in the list. Their selectability has been enabled by modifying the Classes.lua file, and they can be correctly recommended through the potion toggle during battles. 