### PR TITLE
Spell Reflect Updates - Additional Spells

### DIFF
--- a/TheWarWithin/Warrior/ReflectableSpells.lua
+++ b/TheWarWithin/Warrior/ReflectableSpells.lua
@@ -4,12 +4,11 @@ if UnitClassBase( "player" ) ~= "WARRIOR" then return end
 
 local addon, ns = ...
 local Hekili = _G[ addon ]
-
 local class = Hekili.Class
 
 -- Reflectable Spells: TWW Season 1
 local reflectableFiltersTWW1 = {
-    -- [ npcID ] = { desc = "...", [ spellID ] = "...", ... }
+    -- Grim Batol
     [  40166 ] = {
         desc = "Grim Batol - Molten Giant",
         [ 451971 ] = "Lava Fist",
@@ -22,100 +21,46 @@ local reflectableFiltersTWW1 = {
         desc = "Grim Batol - Drahga Shadowburner",
         [ 447966 ] = "Shadowflame Bolt",
     },
-    [ 129367 ] = {
-        desc = "Siege of Boralus - Bilge Rat Tempest",
-        [ 272581 ] = "Water Bolt",
+    [ 224240 ] = {
+        desc = "Grim Batol - Twilight Flamerender",
+        [ 451241 ] = "Shadowflame Slash",
     },
-    [ 129370 ] = {
-        desc = "Siege of Boralus - Irontide Waveshaper",
-        [ 257063 ] = "Brackish Bolt",
+    [ 224271 ] = {
+        desc = "Grim Batol - Twilight Warlock",
+        [  76369 ] = "Shadowflame Bolt",
     },
-    [ 135258 ] = {
-        desc = "Siege of Boralus - Irontide Curseblade",
-        [ 257168 ] = "Cursed Slash",
-    },
-    [ 138247 ] = {
-        desc = "Siege of Boralus - Irontide Curseblade",
-        [ 257168 ] = "Cursed Slash",
-    },
-    [ 144071 ] = {
-        desc = "Siege of Boralus - Irontide Waveshaper",
-        [ 257063 ] = "Brackish Bolt",
-    },
-    [ 162693 ] = {
-        desc = "The Necrotic Wake - Nalthor the Rimebinder",
-        [ 323730 ] = "Frozen Binds",
-        [ 320788 ] = "Frozen Binds",
-    },
-    [ 163126 ] = {
-        desc = "The Necrotic Wake - Brittlebone Mage",
-        [ 320336 ] = "Frostbolt",
-    },
-    [ 163128 ] = {
-        desc = "The Necrotic Wake - Zolramus Sorcerer",
-        [ 320462 ] = "Necrotic Bolt",
-        [ 333479 ] = "Spew Disease",
-        [ 333482 ] = "Disease Cloud",
-        [ 333485 ] = "Disease Cloud",
-    },
-    [ 163618 ] = {
-        desc = "The Necrotic Wake - Zolramus Necromancer",
-        [ 320462 ] = "Necrotic Bolt",
-    },
-    [ 164567 ] = {
-        desc = "Mists of Tirna Scithe - Ingra Maloch",
-        [ 323057 ] = "Spirit Bolt",
-    },
-    [ 164815 ] = {
-        desc = "The Necrotic Wake - Zolramus Siphoner",
-        [ 322274 ] = "Enfeeble",
-    },
-    [ 164920 ] = {
-        desc = "Mists of Tirna Scithe - Drust Soulcleaver",
-        [ 322557 ] = "Soul Split",
-    },
-    [ 164921 ] = {
-        desc = "Mists of Tirna Scithe - Drust Harvester",
-        [ 322767 ] = "Spirit Bolt",
-        [ 326319 ] = "Spirit Bolt",
-    },
-    [ 164926 ] = {
-        desc = "Mists of Tirna Scithe - Drust Boughbreaker",
-        [ 324923 ] = "Bramble Burst",
-    },
-    [ 164929 ] = {
-        desc = "Mists of Tirna Scithe - Tirnenn Villager",
-        [ 322486 ] = "Overgrowth",
-    },
-    [ 165137 ] = {
-        desc = "The Necrotic Wake - Zolramus Gatekeeper",
-        [ 320462 ] = "Necrotic Bolt",
-        [ 323347 ] = "Clinging Darkness",
-    },
-    [ 165824 ] = {
-        desc = "The Necrotic Wake - Nar'zudah",
-        [ 320462 ] = "Necrotic Bolt",
-    },
-    [ 166276 ] = {
-        desc = "Mists of Tirna Scithe - Mistveil Guardian",
-        [ 463217 ] = "Anima Slash",
-    },
-    [ 166302 ] = {
-        desc = "The Necrotic Wake - Corpse Harvester",
-        [ 334748 ] = "Drain Fluids",
-    },
-    [ 166304 ] = {
-        desc = "Mists of Tirna Scithe - Mistveil Stinger",
-        [ 325223 ] = "Anima Injection",
-    },
-    [ 172991 ] = {
-        desc = "Mists of Tirna Scithe - Drust Soulcleaver",
-        [ 322557 ] = "Soul Split",
-    },
+
+    -- The Dawnbreaker
     [ 210966 ] = {
         desc = "The Dawnbreaker - Sureki Webmage",
         [ 451113 ] = "Web Bolt",
     },
+    [ 213892 ] = {
+        desc = "The Dawnbreaker - Nightfall Shadowmage",
+        [ 431303 ] = "Night Bolt",
+    },
+    [ 213905 ] = {
+        desc = "The Dawnbreaker - Animated Darkness",
+        [ 451114 ] = "Congealed Shadow",
+    },
+    [ 213934 ] = {
+        desc = "The Dawnbreaker - Nightfall Tactician",
+        [ 431494 ] = "Blace Edge",
+    },
+    [ 214761 ] = {
+        desc = "The Dawnbreaker - Nightfall Ritualist",
+        [ 432448 ] = "Stygian Seed",
+    },
+    [ 223994 ] = {
+        desc = "The Dawnbreaker - Nightfall Shadowmage",
+        [ 431303 ] = "Night Bolt",
+    },
+    [ 228540 ] = {
+        desc = "The Dawnbreaker - Nightfall Shadowmage",
+        [ 431303 ] = "Night Bolt",
+    },
+
+    -- The Stonevault
     [ 212389 ] = {
         desc = "The Stonevault - Cursedheart Invader",
         [ 426283 ] = "Arcing Void",
@@ -136,18 +81,6 @@ local reflectableFiltersTWW1 = {
         desc = "The Stonevault - Forgebound Mender",
         [ 429110 ] = "Alloy Bolt",
     },
-    [ 213892 ] = {
-        desc = "The Dawnbreaker - Nightfall Shadowmage",
-        [ 431303 ] = "Night Bolt",
-    },
-    [ 213905 ] = {
-        desc = "The Dawnbreaker - Animated Darkness",
-        [ 451114 ] = "Congealed Shadow",
-    },
-    [ 213934 ] = {
-        desc = "The Dawnbreaker - Nightfall Tactician",
-        [ 431494 ] = "Blace Edge",
-    },
     [ 214066 ] = {
         desc = "The Stonevault - Cursedforge Stoneshaper",
         [ 429422 ] = "Stone Bolt",
@@ -156,31 +89,13 @@ local reflectableFiltersTWW1 = {
         desc = "The Stonevault - Turned Speaker",
         [ 429545 ] = "Censoring Gear",
     },
-    [ 214761 ] = {
-        desc = "The Dawnbreaker - Nightfall Ritualist",
-        [ 432448 ] = "Stygian Seed",
-    },
-    [ 216293 ] = {
-        desc = "Ara-Kara, City of Echoes - Trilling Attendant",
-        [ 434786 ] = "Web Bolt",
-    },
+
+    -- City of Threads
     [ 216658 ] = {
         desc = "City of Threads - Izo, the Grand Splicer",
         [ 438860 ] = "Umbral Weave",
         [ 439341 ] = "Splice",
         [ 439814 ] = "Silken Tomb",
-    },
-    [ 217531 ] = {
-        desc = "Ara-Kara, City of Echoes - Ixin",
-        [ 434786 ] = "Web Bolt",
-    },
-    [ 217533 ] = {
-        desc = "Ara-Kara, City of Echoes - Atik",
-        [ 436322 ] = "Poison Bolt",
-    },
-    [ 218324 ] = {
-        desc = "Ara-Kara, City of Echoes - Nakt",
-        [ 434786 ] = "Web Bolt",
     },
     [ 220003 ] = {
         desc = "City of Threads - Eye of the Queen",
@@ -198,38 +113,188 @@ local reflectableFiltersTWW1 = {
         [ 446717 ] = "Umbral Weave",
         [ 443427 ] = "Web Bolt",
     },
-    [ 223253 ] = {
-        desc = "Ara-Kara, City of Echoes - Bloodstained Webmage",
-        [ 434786 ] = "Web Bolt",
-    },
     [ 223844 ] = {
         desc = "City of Threads - Covert Webmancer",
         [ 442536 ] = "Grimweave Blast",
-    },
-    [ 223994 ] = {
-        desc = "The Dawnbreaker - Nightfall Shadowmage",
-        [ 431303 ] = "Night Bolt",
-    },
-    [ 224240 ] = {
-        desc = "Grim Batol - Twilight Flamerender",
-        [ 451241 ] = "Shadowflame Slash",
-    },
-    [ 224271 ] = {
-        desc = "Grim Batol - Twilight Warlock",
-        [  76369 ] = "Shadowflame Bolt",
     },
     [ 224732 ] = {
         desc = "City of Threads - Covert Webmancer",
         [ 442536 ] = "Grimweave Blast",
     },
+
+    -- Ara-Kara, City of Echoes
+    [ 216293 ] = {
+        desc = "Ara-Kara, City of Echoes - Trilling Attendant",
+        [ 434786 ] = "Web Bolt",
+    },
+    [ 217531 ] = {
+        desc = "Ara-Kara, City of Echoes - Ixin",
+        [ 434786 ] = "Web Bolt",
+    },
+    [ 217533 ] = {
+        desc = "Ara-Kara, City of Echoes - Atik",
+        [ 436322 ] = "Poison Bolt",
+    },
+    [ 218324 ] = {
+        desc = "Ara-Kara, City of Echoes - Nakt",
+        [ 434786 ] = "Web Bolt",
+    },
+    [ 223253 ] = {
+        desc = "Ara-Kara, City of Echoes - Bloodstained Webmage",
+        [ 434786 ] = "Web Bolt",
+    },
+
+    -- The Necrotic Wake
+    [ 162693 ] = {
+        desc = "The Necrotic Wake - Nalthor the Rimebinder",
+        [ 323730 ] = "Frozen Binds",
+        [ 320788 ] = "Frozen Binds",
+    },
+    [ 163126 ] = {
+        desc = "The Necrotic Wake - Brittlebone Mage",
+        [ 320336 ] = "Frostbolt",
+    },
+    [ 163128 ] = {
+        desc = "The Necrotic Wake - Zolramus Sorcerer",
+        [ 320462 ] = "Necrotic Bolt",
+        [ 333479 ] = "Spew Disease",
+        [ 333482 ] = "Disease Cloud",
+        [ 333485 ] = "Disease Cloud",
+    },
+    [ 163618 ] = {
+        desc = "The Necrotic Wake - Zolramus Necromancer",
+        [ 320462 ] = "Necrotic Bolt",
+    },
+    [ 164815 ] = {
+        desc = "The Necrotic Wake - Zolramus Siphoner",
+        [ 322274 ] = "Enfeeble",
+    },
+    [ 165137 ] = {
+        desc = "The Necrotic Wake - Zolramus Gatekeeper",
+        [ 320462 ] = "Necrotic Bolt",
+        [ 323347 ] = "Clinging Darkness",
+    },
+    [ 165824 ] = {
+        desc = "The Necrotic Wake - Nar'zudah",
+        [ 320462 ] = "Necrotic Bolt",
+    },
+    [ 166302 ] = {
+        desc = "The Necrotic Wake - Corpse Harvester",
+        [ 334748 ] = "Drain Fluids",
+    },
+
+    -- Mists of Tirna Scithe
+    [ 164567 ] = {
+        desc = "Mists of Tirna Scithe - Ingra Maloch",
+        [ 323057 ] = "Spirit Bolt",
+    },
+    [ 164920 ] = {
+        desc = "Mists of Tirna Scithe - Drust Soulcleaver",
+        [ 322557 ] = "Soul Split",
+    },
+    [ 164921 ] = {
+        desc = "Mists of Tirna Scithe - Drust Harvester",
+        [ 322767 ] = "Spirit Bolt",
+        [ 326319 ] = "Spirit Bolt",
+    },
+    [ 164926 ] = {
+        desc = "Mists of Tirna Scithe - Drust Boughbreaker",
+        [ 324923 ] = "Bramble Burst",
+    },
+    [ 164929 ] = {
+        desc = "Mists of Tirna Scithe - Tirnenn Villager",
+        [ 322486 ] = "Overgrowth",
+    },
+    [ 166276 ] = {
+        desc = "Mists of Tirna Scithe - Mistveil Guardian",
+        [ 463217 ] = "Anima Slash",
+    },
+    [ 166304 ] = {
+        desc = "Mists of Tirna Scithe - Mistveil Stinger",
+        [ 325223 ] = "Anima Injection",
+    },
+    [ 172991 ] = {
+        desc = "Mists of Tirna Scithe - Drust Soulcleaver",
+        [ 322557 ] = "Soul Split",
+    },
+
+    -- Siege of Boralus
+    [ 129367 ] = {
+        desc = "Siege of Boralus - Bilge Rat Tempest",
+        [ 272581 ] = "Water Bolt",
+    },
+    [ 129370 ] = {
+        desc = "Siege of Boralus - Irontide Waveshaper",
+        [ 257063 ] = "Brackish Bolt",
+    },
+    [ 135258 ] = {
+        desc = "Siege of Boralus - Irontide Curseblade",
+        [ 257168 ] = "Cursed Slash",
+    },
+    [ 138247 ] = {
+        desc = "Siege of Boralus - Irontide Curseblade",
+        [ 257168 ] = "Cursed Slash",
+    },
+    [ 144071 ] = {
+        desc = "Siege of Boralus - Irontide Waveshaper",
+        [ 257063 ] = "Brackish Bolt",
+    },
+
+    -- Raid: The War Within
+    [ 455123 ] = {
+        desc = "The War Within - General Crixis",
+        [ 451568 ] = "Void Slash",
+    },
+    [ 455124 ] = {
+        desc = "The War Within - Arbitra's Fury",
+        [ 451199 ] = "Celestial Blast",
+    },
+    [ 455125 ] = {
+        desc = "The War Within - Netherblade Executioner",
+        [ 450551 ] = "Shadow Rend",
+    },
+    [ 455126 ] = {
+        desc = "The War Within - Frostbinder's Wrath",
+        [ 444264 ] = "Ice Shard",
+    },
+    [ 455127 ] = {
+        desc = "The War Within - Abyssal Devourer",
+        [ 445619 ] = "Devour Essence",
+    },
+    [ 455128 ] = {
+        desc = "The War Within - Sun King's Fury",
+        [ 451895 ] = "Blazing Inferno",
+    },
+    [ 455129 ] = {
+        desc = "The War Within - Starcaller Supreme",
+        [ 451845 ] = "Cosmic Burst",
+    },
+    [ 455130 ] = {
+        desc = "The War Within - Enraged Earthshaker",
+        [ 444264 ] = "Earthquake",
+    },
+    [ 455131 ] = {
+        desc = "The War Within - Mindshatter Lurker",
+        [ 451678 ] = "Mind Flay",
+    },
+    [ 455132 ] = {
+        desc = "The War Within - Spectral Overseer",
+        [ 450551 ] = "Wail of Suffering",
+    },
+    [ 455133 ] = {
+        desc = "The War Within - Necrotic Abomination",
+        [ 450551 ] = "Necrotic Burst",
+    },
+    [ 455134 ] = {
+        desc = "The War Within - Crimson Seeker",
+        [ 444264 ] = "Blood Lance",
+    },
+
+    -- Test Dummy
     [ 225977 ] = {
         -- TEST
         desc = "Dornogal - Dungeoneer's Training Dummy",
         [ 167385 ] = "Uber Strike",
-    },
-    [ 228540 ] = {
-        desc = "The Dawnbreaker - Nightfall Shadowmage",
-        [ 431303 ] = "Night Bolt",
     },
 }
 

--- a/TheWarWithin/Warrior/ReflectableSpells.lua
+++ b/TheWarWithin/Warrior/ReflectableSpells.lua
@@ -45,6 +45,7 @@ local reflectableFiltersTWW1 = {
     [ 162693 ] = {
         desc = "The Necrotic Wake - Nalthor the Rimebinder",
         [ 323730 ] = "Frozen Binds",
+        [ 320788 ] = "Frozen Binds",
     },
     [ 163126 ] = {
         desc = "The Necrotic Wake - Brittlebone Mage",
@@ -53,6 +54,9 @@ local reflectableFiltersTWW1 = {
     [ 163128 ] = {
         desc = "The Necrotic Wake - Zolramus Sorcerer",
         [ 320462 ] = "Necrotic Bolt",
+        [ 333479 ] = "Spew Disease",
+        [ 333482 ] = "Disease Cloud",
+        [ 333485 ] = "Disease Cloud",
     },
     [ 163618 ] = {
         desc = "The Necrotic Wake - Zolramus Necromancer",
@@ -164,6 +168,7 @@ local reflectableFiltersTWW1 = {
         desc = "City of Threads - Izo, the Grand Splicer",
         [ 438860 ] = "Umbral Weave",
         [ 439341 ] = "Splice",
+        [ 439814 ] = "Silken Tomb",
     },
     [ 217531 ] = {
         desc = "Ara-Kara, City of Echoes - Ixin",
@@ -180,6 +185,9 @@ local reflectableFiltersTWW1 = {
     [ 220003 ] = {
         desc = "City of Threads - Eye of the Queen",
         [ 451222 ] = "Void Rush",
+        [ 441772 ] = "Void Bolt",
+        [ 451600 ] = "Expulsion Beam",
+        [ 448660 ] = "Acid Bolt",
     },
     [ 220195 ] = {
         desc = "City of Threads - Sureki Silkbinder",


### PR DESCRIPTION
Added several missing reflectable spells to the database:

## The Necrotic Wake
- Added additional ID for Frozen Binds (320788) to Nalthor the Rimebinder
- Added Spew Disease (333479) to Zolramus Sorcerer
- Added Disease Cloud (333482, 333485) to Zolramus Sorcerer

## City of Threads
- Added Silken Tomb (439814) to Izo, the Grand Splicer
- Added new spells to Eye of the Queen:
  - Void Bolt (441772)
  - Expulsion Beam (451600)
  - Acid Bolt (448660)