### PR TITLE
lastRoll, rtb_primary, rtb_buffs_longer, normal, shorter adjustments. Enhanced Debugging Statement

### DIFF
--- a/TheWarWithin/RogueOutlaw.lua
+++ b/TheWarWithin/RogueOutlaw.lua
@@ -574,8 +574,7 @@ spec:RegisterStateExpr( "rtb_buffs", function ()
 end )
 
 spec:RegisterStateExpr( "rtb_primary_remains", function ()
-    local baseTime = max( lastRoll or 0, action.roll_the_bones.lastCast or 0 )
-    return math.max( 0, baseTime + rollDuration - query_time )
+    return max( lastRoll, action.roll_the_bones.lastCast ) + rollDuration - query_time
 end )
 
 local abs = math.abs

--- a/TheWarWithin/RogueOutlaw.lua
+++ b/TheWarWithin/RogueOutlaw.lua
@@ -901,17 +901,17 @@ spec:RegisterHook( "reset_precast", function()
         end
     end
 
-    if Hekili.ActiveDebug and buff.roll_the_bones.up then
-        Hekili:Debug( "\nRoll the Bones Buffs (vs. %.2f):", rollDuration )
-        for i = 1, 6 do
-            local bone = rtb_buff_list[ i ]
+   -- if Hekili.ActiveDebug and buff.roll_the_bones.up then
+   --     Hekili:Debug( "\nRoll the Bones Buffs (vs. %.2f):", rollDuration )
+   --     for i = 1, 6 do
+   --         local bone = rtb_buff_list[ i ]
 
-            if buff[ bone ].up then
-                local bone_duration = buff[ bone ].duration
-                Hekili:Debug( " - %-20s %5.2f : %5.2f %s", bone, buff[ bone ].remains, bone_duration, bone_duration < rollDuration and "shorter" or bone_duration > rollDuration and "longer" or "normal" )
-            end
-        end
-    end
+   --         if buff[ bone ].up then
+   --             local bone_duration = buff[ bone ].duration
+   --             Hekili:Debug( " - %-20s %5.2f : %5.2f %s", bone, buff[ bone ].remains, bone_duration, bone_duration < rollDuration and "shorter" or bone_duration > rollDuration and "longer" or "normal" )
+   --         end
+   --     end
+   -- end
 end )
 
 

--- a/TheWarWithin/RogueOutlaw.lua
+++ b/TheWarWithin/RogueOutlaw.lua
@@ -608,11 +608,11 @@ end )
 spec:RegisterStateExpr( "rtb_buffs_normal", function ()
     local n = 0
     local primary = rtb_primary_remains
-    local tolerance = 0.1  -- Threshold for "close enough"
+    local tolerance = 0.2  -- Threshold for "close enough"
 
     for _, rtb in ipairs( rtb_buff_list ) do
         local bone = buff[ rtb ]
-        if bone.up and abs( bone.remains - primary ) < tolerance then
+        if bone.up and abs( bone.remains - primary ) <= tolerance then
             n = n + 1
         end
     end

--- a/TheWarWithin/RogueOutlaw.lua
+++ b/TheWarWithin/RogueOutlaw.lua
@@ -574,7 +574,8 @@ spec:RegisterStateExpr( "rtb_buffs", function ()
 end )
 
 spec:RegisterStateExpr( "rtb_primary_remains", function ()
-    return max( lastRoll, action.roll_the_bones.lastCast ) + rollDuration - query_time
+    local baseTime = max( lastRoll or 0, action.roll_the_bones.lastCast or 0 )
+    return max( 0, baseTime + rollDuration - query_time )
 end )
 
 local abs = math.abs
@@ -611,7 +612,7 @@ spec:RegisterStateExpr( "rtb_buffs_normal", function ()
 
     for _, rtb in ipairs( rtb_buff_list ) do
         local bone = buff[ rtb ]
-        if bone.up and math.abs( bone.remains - primary ) <= tolerance then
+        if bone.up and abs( bone.remains - primary ) <= tolerance then
             n = n + 1
         end
     end
@@ -1196,7 +1197,7 @@ spec:RegisterAbilities( {
                 if buff[ v ].up then
                 -- Add 30 seconds but cap the total duration at 60 seconds.
                 local newExpires = buff[ v ].expires + 30
-                buff[ v ].expires = math.min( newExpires, query_time + 60 )
+                buff[ v ].expires = min( newExpires, query_time + 60 )
                 
                 -- Optional Debugging
                 if Hekili.ActiveDebug then

--- a/TheWarWithin/RogueOutlaw.lua
+++ b/TheWarWithin/RogueOutlaw.lua
@@ -612,7 +612,7 @@ spec:RegisterStateExpr( "rtb_buffs_normal", function ()
 
     for _, rtb in ipairs( rtb_buff_list ) do
         local bone = buff[ rtb ]
-        if bone.up and abs( bone.remains - primary ) <= tolerance then
+        if bone.up and abs( bone.remains - primary ) < tolerance then
             n = n + 1
         end
     end


### PR DESCRIPTION
Increase readability and simplify lastRoll calculations

Increased the threshold from 0.1 to 0.2 in rtb_buffs_longer and rtb_buffs_shorter to improve separation between categories.

Ensures that the new expiration time for each RtB buff after KiR does not exceed 60 seconds from the current time (query_time + 60)

Enhanced Debugging Statements:

Added lastRoll, rollDuration, and rtb_primary_remains to the debug output. Tracks key values for understanding Roll the Bones behavior in-game. Buff Status Report:

Displays the remaining time and classification (shorter, longer, or normal) for each buff compared to rollDuration. Improved Readability:

Organized debug output for better clarity during in-game testing.