### PR TITLE
Interrupt Timing Setting

### DIFF
--- a/Options.lua
+++ b/Options.lua
@@ -739,7 +739,7 @@ do
                 },
 
                 filterCasts = true,
-                castRemainingThreshold = 0,
+                castRemainingThreshold = 0.25,
                 castFilters = {
                     [40167] = {
                     desc = "Grim Batol - Twilight Beguiler",
@@ -8719,12 +8719,12 @@ do
                         castRemainingThreshold = {
                             type = "range",
                             name = "Interrupt timing",
-                            desc = "When set to 0, uses the addon default behaviour of recommending interrupts at 0.25 seconds remaining on the cast.\n\n"
-                                    .. "If set above 0, this setting controls how far into a cast your interrupt will be recommended.\n\n"
-                                    .. "On a 5 second cast, a value of 0.50 would recommend the interrupt at 2.5 seconds remaining (50% of the cast), and a value of 0.90 would recommend it at 0.5 seconds remaining (90% of the cast finished).",
-                            min = 0,
-                            max = 0.95,
-                            step = 0.01,
+                            desc = "This setting controls the point at which your interrupt will be recommended.\n\n"
+                                    .. "If set to 2, it would recommend your interrupt it when there are 2 seconds or less remaining on the cast. A smaller value is a 'later' interrupt which is more efficient but easier to make a mistake with.\n\n"
+                                    .. "The default value is 0.25.",
+                            min = 0.25,
+                            max = 3,
+                            step = 0.25,
                             width = 2,
                             order = 4.3
                         },

--- a/Options.lua
+++ b/Options.lua
@@ -739,6 +739,7 @@ do
                 },
 
                 filterCasts = true,
+                castRemainingThreshold = 0,
                 castFilters = {
                     [40167] = {
                     desc = "Grim Batol - Twilight Beguiler",
@@ -8701,6 +8702,31 @@ do
                                 ( GetSpellInfo( 427459 ) or "Toxic Bloom" ) ),
                             width = 2,
                             order = 4
+                        },
+                        lb3 = {
+                            type = "description",
+                            name = "",
+                            width = "full",
+                            order = 4.1
+                        },
+
+                        indent3 = {
+                            type = "description",
+                            name = "",
+                            width = 1,
+                            order = 4.2,
+                        },
+                        castRemainingThreshold = {
+                            type = "range",
+                            name = "Interrupt timing",
+                            desc = "When set to 0, uses the addon default behaviour of recommending interrupts at 0.25 seconds remaining on the cast.\n\n"
+                                    .. "If set above 0, this setting controls how far into a cast your interrupt will be recommended.\n\n"
+                                    .. "On a 5 second cast, a value of 0.50 would recommend the interrupt at 2.5 seconds remaining (50% of the cast), and a value of 0.90 would recommend it at 0.5 seconds remaining (90% of the cast finished).",
+                            min = 0,
+                            max = 0.95,
+                            step = 0.01,
+                            width = 2,
+                            order = 4.3
                         },
 
                         defensives = {

--- a/Options.lua
+++ b/Options.lua
@@ -8718,10 +8718,9 @@ do
                         },
                         castRemainingThreshold = {
                             type = "range",
-                            name = "Interrupt timing",
-                            desc = "This setting controls the point at which your interrupt will be recommended.\n\n"
-                                    .. "If set to 2, it would recommend your interrupt it when there are 2 seconds or less remaining on the cast. A smaller value is a 'later' interrupt which is more efficient but easier to make a mistake with.\n\n"
-                                    .. "The default value is 0.25.",
+                            name = "Interrupt Timing",
+                            desc = "By default, interrupts are recommended when an enemy's cast has 0.25 seconds (or less) remaining.\n\n"
+                                    .. "If set to 2, an interrupt could be recommended when the cast has less than 2 seconds remaining.",
                             min = 0.25,
                             max = 3,
                             step = 0.25,

--- a/State.lua
+++ b/State.lua
@@ -1210,10 +1210,13 @@ state.interrupt = interrupt
 
 -- Use this for readyTime in an interrupt action; will interrupt casts at end of cast and channels ASAP.
 local function timeToInterrupt()
+    local castRemainingThreshold = 0
+    castRemainingThreshold = Hekili.DB.profile.toggles.interrupts.castRemainingThreshold
     local casting = state.debuff.casting
     if casting.down or casting.v2 == 1 then return 3600 end
     if casting.v3 == 1 then return 0 end
-    return max( 0, casting.remains - 0.25 )
+    if castRemainingThreshold == 0 then return max( 0, casting.remains - 0.25 )
+    else return max( 0, casting.remains - ( casting.duration * ( 1 - castRemainingThreshold ) ) ) end
 end
 state.timeToInterrupt = timeToInterrupt
 

--- a/State.lua
+++ b/State.lua
@@ -1215,8 +1215,7 @@ local function timeToInterrupt()
     local casting = state.debuff.casting
     if casting.down or casting.v2 == 1 then return 3600 end
     if casting.v3 == 1 then return 0 end
-    if castRemainingThreshold == 0 then return max( 0, casting.remains - 0.25 )
-    else return max( 0, casting.remains - ( casting.duration * ( 1 - castRemainingThreshold ) ) ) end
+    return max( 0, casting.remains - castRemainingThreshold )
 end
 state.timeToInterrupt = timeToInterrupt
 

--- a/State.lua
+++ b/State.lua
@@ -1210,12 +1210,10 @@ state.interrupt = interrupt
 
 -- Use this for readyTime in an interrupt action; will interrupt casts at end of cast and channels ASAP.
 local function timeToInterrupt()
-    local castRemainingThreshold = 0
-    castRemainingThreshold = Hekili.DB.profile.toggles.interrupts.castRemainingThreshold
     local casting = state.debuff.casting
     if casting.down or casting.v2 == 1 then return 3600 end
     if casting.v3 == 1 then return 0 end
-    return max( 0, casting.remains - castRemainingThreshold )
+    return max( 0, casting.remains - Hekili.DB.profile.toggles.interrupts.castRemainingThreshold or 0.25 )
 end
 state.timeToInterrupt = timeToInterrupt
 


### PR DESCRIPTION
Adds a configurable setting for users to specify how far into the castbar their interrupt will be recommended. Setting to 0 uses the previous addon behaviour as a default. Setting has been tested ingame.

![image](https://github.com/user-attachments/assets/963ce30c-f2af-4f9d-af8a-c9ac8a1c4fc8)
