### PR TITLE
feat: Add Viq'Goth (Siege of Boralus) to enemy exclusions

### DIFF
--- a/Targets.lua
+++ b/Targets.lua
@@ -204,7 +204,8 @@ local enemyExclusions = {
     [168112] = 329636,    -- Kaal (when shielded)
     [193760] = true,      -- Surging Ruiner (Raszageth) -- gives bad range information.
     [204560] = true,      -- Incorporeal Being
-    [229296] = true       -- Orb of Ascendance (TWW S1 Affix)
+    [229296] = true,      -- Orb of Ascendance (TWW S1 Affix)
+    [128652] = true,      -- Viq'Goth (Siege of Boralus - untargetable background boss)
 }
 
 local requiredForInclusion = {


### PR DESCRIPTION
Adds Viq'goth (NPC ID 128652) from Siege of Boralus dungeon to the enemy exclusions table. This boss appears in the background during the encounter but is not targetable or damageable, so it should be excluded from target counting to prevent incorrect target calculations around aoe/cleave.

Changes:
- Added Viq'goth (128652) to enemyExclusions table with value `true` to always exclude
- Fixed missing comma after previous entry