### PR TITLE
Fix for Interrupt Timing Nil Value Error

### DIFF
--- a/State.lua
+++ b/State.lua
@@ -1213,7 +1213,8 @@ local function timeToInterrupt()
     local casting = state.debuff.casting
     if casting.down or casting.v2 == 1 then return 3600 end
     if casting.v3 == 1 then return 0 end
-    return max( 0, casting.remains - Hekili.DB.profile.toggles.interrupts.castRemainingThreshold or 0.25 )
+    local threshold = Hekili.DB.profile.toggles.interrupts.castRemainingThreshold or 0.25
+    return max( 0, casting.remains - threshold )
 end
 state.timeToInterrupt = timeToInterrupt
 


### PR DESCRIPTION
While playing, I noticed random errors occurring with interrupt calculations:

Interface/AddOns/Hekili/State.lua:1216: attempt to perform arithmetic on field 'castRemainingThreshold' (a nil value)
[string "@Interface/AddOns/Hekili/State.lua"]:1216: in function <Interface/AddOns/Hekili/State.lua:1212>

Modified the `timeToInterrupt` function in State.lua to handle nil values properly:
- Added local variable to store threshold value
- Moved nil-coalescing operation before arithmetic
- Maintains default 0.25s threshold as defined in Options.lua