### PR TITLE
Fix Fury Warrior back-to-back Whirlwind recommendations

### DIFF
--- a/TheWarWithin/WarriorFury.lua
+++ b/TheWarWithin/WarriorFury.lua
@@ -1872,12 +1872,16 @@ spec:RegisterAbilities( {
 
         usable = function ()
             if action.taunt.known and action.heroic_throw.known and settings.check_ww_range and not ( action.taunt.in_range and not action.heroic_throw.in_range ) then return false, "target is outside of whirlwind range" end
+            if active_enemies == 1 and buff.meat_cleaver.up then return false, "meat cleaver already active" end
             return true
         end,
 
         handler = function ()
-            if talent.improved_whirlwind.enabled then
-                applyBuff( "meat_cleaver", nil, talent.meat_cleaver.enabled and 4 or 2 )
+            if talent.improved_whirlwind.enabled or talent.meat_cleaver.enabled then
+                -- Only apply if buff is down or about to expire
+                if buff.meat_cleaver.down or buff.meat_cleaver.remains < gcd.max then
+                    applyBuff( "meat_cleaver", nil, talent.meat_cleaver.enabled and 4 or 2 )
+                end
             end
         end,
     },

--- a/TheWarWithin/WarriorFury.lua
+++ b/TheWarWithin/WarriorFury.lua
@@ -1870,10 +1870,10 @@ spec:RegisterAbilities( {
 
         texture = 132369,
 
-        usable = function ()
+        readyTime = function ()
             if action.taunt.known and action.heroic_throw.known and settings.check_ww_range and not ( action.taunt.in_range and not action.heroic_throw.in_range ) then return false, "target is outside of whirlwind range" end
-            if active_enemies == 1 and buff.meat_cleaver.up then return false, "meat cleaver already active" end
-            return true
+            if active_enemies == 1 and buff.meat_cleaver.up then return buff.meat_cleaver.remains end
+            return 0
         end,
 
         handler = function ()


### PR DESCRIPTION
Issue:
- Fixes issue where Whirlwind was recommended occasionally back-to-back in single target
- Adds proper buff duration check before reapplication
- Maintains correct stack count (4 with Meat Cleaver, 2 with Improved Whirlwind)
- Improves usability check to prevent unnecessary Whirlwind casts

Changes:
1. Modified handler to check buff duration before reapplication
2. Kept existing usability check for single target scenarios
3. Maintained proper stack application logic