### PR TITLE
Fix Fury Warrior Storm Bolt detection during Bladestorm

### DIFF
--- a/TheWarWithin/WarriorFury.lua
+++ b/TheWarWithin/WarriorFury.lua
@@ -1725,9 +1725,9 @@ spec:RegisterAbilities( {
 
         talent = "storm_bolt",
 
-        -- Add usable check for Unrelenting Onslaught talent
         usable = function()
-            if buff.bladestorm.up and not talent.unrelenting_onslaught.enabled then 
+            -- Check both Bladestorm IDs and talent requirement
+            if (buff.bladestorm.up or buff[446035].up or buff[227847].up) and not talent.unrelenting_onslaught.enabled then 
                 return false, "can't use during bladestorm without unrelenting onslaught" 
             end
             return true


### PR DESCRIPTION
Issue:
Storm Bolt recommendation is inconsistent during Bladestorm in scenarios when Unrelenting Onslaught is talented.

Potential Fix:
Updated Storm Bolt's usable function to properly detect Bladestorm buff by checking both spell IDs (446035 and 227847).