### PR TITLE
Simplify Whirlwind range check for Fury Warrior

### DIFF
--- a/TheWarWithin/WarriorFury.lua
+++ b/TheWarWithin/WarriorFury.lua
@@ -1871,14 +1871,14 @@ spec:RegisterAbilities( {
 
         texture = 132369,
 
-        usable = function ()
+        readyTime = function ()
             if settings.check_ww_range and target.distance > 8 then return false, "target is outside of whirlwind range" end
             if active_enemies == 1 and buff.meat_cleaver.up then return false, "meat cleaver already active" end
             return true
         end,
 
         handler = function ()
-            if talent.improved_whirlwind.enabled then
+            if talent.improved_whirlwind.enabled or talent.meat_cleaver.enabled then
                 applyBuff( "meat_cleaver", nil, talent.meat_cleaver.enabled and 4 or 2 )
             end
         end,

--- a/TheWarWithin/WarriorFury.lua
+++ b/TheWarWithin/WarriorFury.lua
@@ -1862,6 +1862,7 @@ spec:RegisterAbilities( {
         cast = 0,
         cooldown = 0,
         gcd = "spell",
+        range = 8,
 
         startsCombat = true,
 
@@ -1871,7 +1872,8 @@ spec:RegisterAbilities( {
         texture = 132369,
 
         usable = function ()
-            if action.taunt.known and action.heroic_throw.known and settings.check_ww_range and not ( action.taunt.in_range and not action.heroic_throw.in_range ) then return false, "target is outside of whirlwind range" end
+            if settings.check_ww_range and target.distance > 8 then return false, "target is outside of whirlwind range" end
+            if active_enemies == 1 and buff.meat_cleaver.up then return false, "meat cleaver already active" end
             return true
         end,
 


### PR DESCRIPTION
Simplifies the Whirlwind range check to directly use the ability's 8-yard range instead of proxying through taunt and heroic throw ranges.

Changes:
- Adds explicit range = 8 property to Whirlwind ability definition
- Removes complex condition using taunt and heroic throw ranges
- Directly checks target distance against Whirlwind's 8-yard range
- Maintains existing settings.check_ww_range toggle functionality

This change makes the range check more accurate and maintainable while preserving the optional nature of the range check via settings.