### PR TITLE
Update protection warrior abilities

### DIFF
--- a/TheWarWithin/WarriorProtection.lua
+++ b/TheWarWithin/WarriorProtection.lua
@@ -769,9 +769,6 @@ spec:RegisterAbilities( {
             if talent.immovable_object.enabled then
                 applyBuff( "shield_wall", 4 )
             end
-            if talent.violent_outburst.enabled then
-                applyBuff( "violent_outburst" )
-            end
             if talent.avatar_of_the_storm.enabled then
                 applyBuff( "thunder_blast", 15, 2 )
             end

--- a/TheWarWithin/WarriorProtection.lua
+++ b/TheWarWithin/WarriorProtection.lua
@@ -1810,7 +1810,7 @@ spec:RegisterAbilities( {
         gcd = "spell",
         hasteCD = true,
 
-        spend = function () return -15
+        spend = function () return ( ( talent.thorims_might.enabled and talent.flashing_skies.enabled ) and -11 or -8 )
             * ( buff.violent_outburst.up and 2 or 1 )
             * ( buff.unnerving_focus.up and 1.5 or 1 ) end,
         spendType = "rage",

--- a/TheWarWithin/WarriorProtection.lua
+++ b/TheWarWithin/WarriorProtection.lua
@@ -772,6 +772,9 @@ spec:RegisterAbilities( {
             if talent.violent_outburst.enabled then
                 applyBuff( "violent_outburst" )
             end
+            if talent.avatar_of_the_storm.enabled then
+                applyBuff( "thunder_blast", 15, 2 )
+            end
         end,
     },
 

--- a/TheWarWithin/WarriorProtection.lua
+++ b/TheWarWithin/WarriorProtection.lua
@@ -770,6 +770,8 @@ spec:RegisterAbilities( {
                 applyBuff( "shield_wall", 4 )
             end
             if talent.avatar_of_the_storm.enabled then
+                setCooldown( "thunder_clap", 0 )
+                setCooldown( "thunder_blast", 0 )
                 applyBuff( "thunder_blast", 15, 2 )
             end
         end,


### PR DESCRIPTION
1. Make avatar apply thunder_blast buff when avatar_of_the_storm talent is enabled
2. Remove violent_outburst buff application from avatar which does not happen in-game
3. Correct thunder blast rage generation