### PR TITLE
Replace table.getn() with #table for Lua 5.1 compatibility

### DIFF
--- a/Utils.lua
+++ b/Utils.lua
@@ -251,7 +251,7 @@ local function orderedNext( t, state )
         t.__orderedIndex = __genOrderedIndex( t )
         key = t.__orderedIndex[ 1 ]
     else
-        for i = 1, table.getn( t.__orderedIndex ) do
+        for i = 1, #t.__orderedIndex do
             if t.__orderedIndex[ i ] == state then
                 key = t.__orderedIndex[ i+1 ]
             end


### PR DESCRIPTION
Replaced obsolete table.getn() with #table to ensure compatibility with Lua 5.1 in WoW.