### PR TITLE
Replaced deprecated GetItemCooldown

### DIFF
--- a/TheWarWithin/MageArcane.lua
+++ b/TheWarWithin/MageArcane.lua
@@ -9,7 +9,6 @@ local class, state = Hekili.Class, Hekili.State
 
 local FindUnitBuffByID, FindUnitDebuffByID = ns.FindUnitBuffByID, ns.FindUnitDebuffByID
 
-local GetItemCooldown = C_Item.GetItemCooldown
 local strformat = string.format
 
 local spec = Hekili:NewSpecialization( 62 )

--- a/TheWarWithin/MageArcane.lua
+++ b/TheWarWithin/MageArcane.lua
@@ -9,7 +9,7 @@ local class, state = Hekili.Class, Hekili.State
 
 local FindUnitBuffByID, FindUnitDebuffByID = ns.FindUnitBuffByID, ns.FindUnitDebuffByID
 
-local GetItemCooldown = GetItemCooldown
+local GetItemCooldown = C_Item.GetItemCooldown
 local strformat = string.format
 
 local spec = Hekili:NewSpecialization( 62 )


### PR DESCRIPTION
GetItemCooldown was deprecated in patch 10.2.6
Replaced with C_Item.GetItemCooldown