### PR TITLE
fix: Enhancement Shaman variable and debuff reference errors

### DIFF
--- a/TheWarWithin/ShamanEnhancement.lua
+++ b/TheWarWithin/ShamanEnhancement.lua
@@ -886,7 +886,7 @@ local recall_totems = {
 
 local recallTotem1
 local recallTotem2
-local tiWindow, tiSpell, tiTarget = 0, "lightning_bolt"
+local tiWindow, tiSpell, tiTarget = 0, "lightning_bolt", nil
 local recent_spell_hits = {}
 local actual_spirits, virtual_spirits = {}, {}
 local molten_weapons, virtual_molten_weapons = {}, {}
@@ -1191,9 +1191,9 @@ spec:RegisterHook( "reset_precast", function ()
         vesper_used = 0
     end
 
-    vesper_totem_heal_charges = nil
-    vesper_totem_dmg_charges = nil
-    vesper_totem_used_charges = nil
+    vesper_totem_heal_charges = 0
+    vesper_totem_dmg_charges = 0
+    vesper_totem_used_charges = 0
 
     if totem.vesper_totem.up then
         applyBuff( "vesper_totem", totem.vesper_totem.remains )
@@ -2162,7 +2162,7 @@ spec:RegisterAbilities( {
         velocity = 30,
 
         indicator = function()
-            return active_enemies > 1 and settings.cycle and dot.flame_shock.down and active_dot.flame_shock > 0 and "cycle" or nil
+            return active_enemies > 1 and settings.cycle and debuff.flame_shock.down and active_dot.flame_shock > 0 and "cycle" or nil
         end,
 
         handler = function ()

--- a/TheWarWithin/ShamanEnhancement.lua
+++ b/TheWarWithin/ShamanEnhancement.lua
@@ -2162,7 +2162,7 @@ spec:RegisterAbilities( {
         velocity = 30,
 
         indicator = function()
-            return active_enemies > 1 and settings.cycle and debuff.flame_shock.down and active_dot.flame_shock > 0 and "cycle" or nil
+            return active_enemies > 1 and settings.cycle and dot.flame_shock.down and active_dot.flame_shock > 0 and "cycle" or nil
         end,
 
         handler = function ()


### PR DESCRIPTION
- Initialize tiTarget with nil to prevent value assignment warning
- Set vesper totem charges to 0 instead of nil for integer type compliance
- Change dot.flame_shock to debuff.flame_shock for correct debuff reference