### PR TITLE
fix: Remove unused parameter in imps_spawned_during metamethod

### DIFF
--- a/TheWarWithin/WarlockDemonology.lua
+++ b/TheWarWithin/WarlockDemonology.lua
@@ -897,7 +897,7 @@ spec:RegisterStateTable( "time_to_imps", setmetatable( {}, {
 
 
 spec:RegisterStateTable( "imps_spawned_during", setmetatable( {}, {
-    __index = function( t, k, v )
+    __index = function( t, k )
         local cap = query_time
 
         if type(k) == "number" then cap = cap + ( k / 1000 )


### PR DESCRIPTION
Remove unused 'v' parameter from __index metamethod in imps_spawned_during table to fix Lua metamethod argument count error.