### PR TITLE
Add Nil Checks for Pocket-Sized Computronic Device Logic

### DIFF
--- a/Events.lua
+++ b/Events.lua
@@ -940,11 +940,11 @@ do
                 local redID = tonumber( redLink:match("item:(%d+)") )
                 local action = class.itemMap[ redID ]
 
-                if action then
-                    state.set_bonus[ action ] = 1
-                    state.set_bonus[ redID ] = 1
-                    class.abilities.pocketsized_computation_device = class.abilities[ action ]
-                    class.abilities[ tName ] = class.abilities[ action ]
+                if redID and action then
+                    state.set_bonus[action] = 1
+                    state.set_bonus[redID] = 1
+                    class.abilities.pocketsized_computation_device = class.abilities[action]
+                    class.abilities[tName] = class.abilities[action]
                     insert( state.items, action )
                 end
             else


### PR DESCRIPTION
Added safety checks to prevent crashes when handling the Pocket-Sized Computronic Device. Now, the code verifies both the punchcard's item ID (redID) and its mapped action (action) exist before using them. This avoids errors when the device or its gem data is missing or invalid.