### PR TITLE
Improve Metamorphosis timestamp initialization

### DIFF
--- a/TheWarWithin/DemonHunterHavoc.lua
+++ b/TheWarWithin/DemonHunterHavoc.lua
@@ -1098,7 +1098,7 @@ local sigil_types = {
 }
 
 spec:RegisterHook( "reset_precast", function ()
-    last_metamorphosis = nil
+    last_metamorphosis = 0
     last_infernal_strike = nil
 
     wipe( initiative_virtual )


### PR DESCRIPTION
Initialize last_metamorphosis to 0 in reset_precast to prevent type errors when tracking ability timestamps. Ensures proper integer comparison for metamorphosis cooldown calculations.