### PR TITLE
(DRAFT) Attempt to improve Hot Streak projectile tracking for Fire Mage

### DIFF
--- a/TheWarWithin/MageFire.lua
+++ b/TheWarWithin/MageFire.lua
@@ -1,6 +1,4 @@
-
 -- MageFire.lua
--- October 2024
 
 if UnitClassBase( "player" ) ~= "MAGE" then return end
 
@@ -990,22 +988,65 @@ spec:RegisterStateFunction( "hot_streak", function( willCrit )
 end )
 
 
+-- Spell velocities for spells that can trigger Hot Streak
 local hot_streak_spells = {
-    -- "dragons_breath",
-    "fireball",
-    -- "fire_blast",
-    "phoenix_flames",
-    "pyroblast",
-    "scorch",
+    fireball         = { velocity = 45 },
+    frostfire_bolt   = { velocity = 40 },
+    pyroblast       = { velocity = 35 },
+    phoenix_flames  = { velocity = 50 },
+    scorch         = { velocity = 35 }
 }
+
+-- Tracks spells currently in flight that could trigger Hot Streak
 spec:RegisterStateExpr( "hot_streak_spells_in_flight", function ()
     local count = 0
-
-    for i, spell in ipairs( hot_streak_spells ) do
-        if state:IsInFlight( spell ) then count = count + 1 end
+    local currentTime = state.query_time
+    
+    -- Keep track of when our next Hot Streak might proc
+    local nextCritTime
+    local heatingUpActive = state.buff.heating_up.up
+    
+    for spell, data in pairs( hot_streak_spells ) do
+        if state:IsInFlight( spell ) then
+            local travelTime = state.action[spell].travel_time
+            
+            -- Only count spells that are actually traveling (not just queued)
+            if state.action[spell].in_flight and state.action[spell].in_flight_remains > 0 then
+                count = count + 1
+                
+                local impactTime = currentTime + state.action[spell].in_flight_remains
+                
+                -- Check if this spell will crit from Combustion or 100% crit chance
+                local willCrit = state.buff.combustion.up or state.stat.crit >= 100
+                if spell == "fireball" then
+                    -- Account for Fireball's stacking crit buff
+                    willCrit = willCrit or (state.buff.fireball.stack * 10 + state.stat.crit >= 100)
+                end
+                
+                -- Figure out if this will give us Heating Up or Hot Streak
+                if willCrit then
+                    if heatingUpActive then
+                        -- This will give us Hot Streak - track earliest possible proc
+                        if not nextCritTime or impactTime < nextCritTime then
+                            nextCritTime = impactTime
+                        end
+                    else
+                        -- First crit will give us Heating Up
+                        heatingUpActive = true
+                    end
+                end
+            end
+        end
     end
 
+    -- Store predicted Hot Streak time for other functions
+    state.predicted_hot_streak_time = nextCritTime
+    
     return count
+end )
+
+spec:RegisterStateExpr( "predicted_hot_streak_time", function()
+    return state.predicted_hot_streak_time
 end )
 
 spec:RegisterStateExpr( "expected_kindling_reduction", function ()

--- a/TheWarWithin/MageFire.lua
+++ b/TheWarWithin/MageFire.lua
@@ -994,7 +994,6 @@ local hot_streak_spells = {
     frostfire_bolt   = { velocity = 40 },
     pyroblast       = { velocity = 35 },
     phoenix_flames  = { velocity = 50 },
-    scorch         = { velocity = 35 }
 }
 
 -- Tracks spells currently in flight that could trigger Hot Streak
@@ -1006,6 +1005,24 @@ spec:RegisterStateExpr( "hot_streak_spells_in_flight", function ()
     local nextCritTime
     local heatingUpActive = state.buff.heating_up.up
     
+    -- First check Scorch cast in progress since it has no travel time
+    if state.prev.scorch and state.prev_gcd.scorch and state.casting.scorch then
+        count = count + 1
+        local impactTime = currentTime + state.action.scorch.execute_remains
+        
+        -- Check if this Scorch will crit (during Combustion or other guaranteed crit effects)
+        local willCrit = state.buff.combustion.up or state.stat.crit >= 100 or target.health.pct < 30
+        
+        if willCrit then
+            if heatingUpActive then
+                nextCritTime = impactTime
+            else
+                heatingUpActive = true
+            end
+        end
+    end
+    
+    -- Then check other spells in flight
     for spell, data in pairs( hot_streak_spells ) do
         if state:IsInFlight( spell ) then
             local travelTime = state.action[spell].travel_time


### PR DESCRIPTION
Hi Hekili,

I've put together a new draft that attempts to add more accurate spell velocity tracking for Hot Streak generation. This version tracks the projectiles for Fireball, Pyroblast, Phoenix Flames, Scorch, and Frostfire Bolt in an effort to improve Hot Streak proc predictions and Fire Blast usage. I'm not entirely sure if this is the right approach, so any feedback would be really helpful.