### PR TITLE
Fix undefined 'icon' field in GetSpellBookItemInfo

### DIFF
--- a/Utils.lua
+++ b/Utils.lua
@@ -18,7 +18,7 @@ local UnpackAuraData = AuraUtil.UnpackAuraData
 local GetSpellBookItemInfo = function(index, bookType)
     local spellBank = ( bookType == "spell" or bookType == Enum.SpellBookItemType.Spell ) and Enum.SpellBookSpellBank.Player or Enum.SpellBookSpellBank.Pet
     local info = C_SpellBook.GetSpellBookItemInfo(index, spellBank)
-    if info then return info.name, info.icon, info.spellID end
+    if info then return info.name, info.iconID, info.spellID end
 end
 
 ns.UnitBuff = function( unit, index, filter )


### PR DESCRIPTION
It looks like the WoW API now uses iconID instead of icon when retrieving spell book information.