### PR TITLE
Remove duplicate improved_flametongue_weapon aura

### DIFF
--- a/TheWarWithin/ShamanElemental.lua
+++ b/TheWarWithin/ShamanElemental.lua
@@ -548,17 +548,6 @@ spec:RegisterAuras( {
         type = "Magic",
         max_stack = 1
     },
-    -- Fire damage dealt increased by ${$W1}.1%.
-    improved_flametongue_weapon = {
-        id = 382028,
-        duration = 3600.0,
-        max_stack = 1,
-
-        -- Affected by:
-        -- enhanced_imbues[462796] #0: { 'type': APPLY_AURA, 'subtype': ADD_PCT_MODIFIER_BY_LABEL, 'points': 30.0, 'target': TARGET_UNIT_CASTER, 'modifies': EFFECT_1_VALUE, }
-        -- enhanced_imbues[462796] #3: { 'type': APPLY_AURA, 'subtype': ADD_PCT_MODIFIER_BY_LABEL, 'points': 30.0, 'target': TARGET_UNIT_CASTER, 'modifies': EFFECT_2_VALUE, }
-        -- enhanced_imbues[462796] #4: { 'type': APPLY_AURA, 'subtype': ADD_PCT_MODIFIER_BY_LABEL, 'points': 30.0, 'target': TARGET_UNIT_CASTER, 'modifies': EFFECT_3_VALUE, }
-    },
     -- Talent: Your next Lava Burst casts instantly.
     -- https://wowhead.com/beta/spell=77762
     lava_surge = {
@@ -1309,9 +1298,9 @@ spec:RegisterHook( "reset_precast", function ()
         vesper_used = 0
     end
 
-    vesper_totem_heal_charges = nil
-    vesper_totem_dmg_charges = nil
-    vesper_totem_used_charges = nil
+    vesper_totem_heal_charges = 0
+    vesper_totem_dmg_charges = 0
+    vesper_totem_used_charges = 0
 
     recall_totem_1 = nil
     recall_totem_2 = nil

--- a/TheWarWithin/ShamanElemental.lua
+++ b/TheWarWithin/ShamanElemental.lua
@@ -1298,9 +1298,9 @@ spec:RegisterHook( "reset_precast", function ()
         vesper_used = 0
     end
 
-    vesper_totem_heal_charges = 0
-    vesper_totem_dmg_charges = 0
-    vesper_totem_used_charges = 0
+    vesper_totem_heal_charges = nil
+    vesper_totem_dmg_charges = nil
+    vesper_totem_used_charges = nil
 
     recall_totem_1 = nil
     recall_totem_2 = nil


### PR DESCRIPTION
Initialize vesper totem charges with 0 instead of nil Removed duplicate improved_flametongue_weapon