### PR TITLE
Align all 3 DK specs rune definitions

### DIFF
--- a/TheWarWithin/DeathKnightBlood.lua
+++ b/TheWarWithin/DeathKnightBlood.lua
@@ -47,51 +47,45 @@ spec:RegisterResource( Enum.PowerType.Runes, {
 
     reset = function()
         local t = state.runes
-
         for i = 1, 6 do
             local start, duration, ready = GetRuneCooldown( i )
-
             start = start or 0
             duration = duration or ( 10 * state.haste )
-
-            t.expiry[ i ] = ready and 0 or start + duration
+            t.expiry[ i ] = ready and 0 or ( start + duration )
             t.cooldown = duration
         end
-
         table.sort( t.expiry )
-
         t.actual = nil
     end,
 
     gain = function( amount )
         local t = state.runes
-
         for i = 1, amount do
-            t.expiry[ 7 - i ] = 0
+            table.insert( t.expiry, 0 )
+            t.expiry[ 7 ] = nil
         end
         table.sort( t.expiry )
-
-        t.actual = nil
+        t.actual = nil -- Reset actual to force recalculation
     end,
 
     spend = function( amount )
         local t = state.runes
-    
+
         -- Consume the specified number of runes.
         for i = 1, amount do
             t.expiry[ 1 ] = ( t.expiry[ 4 ] > 0 and t.expiry[ 4 ] or state.query_time ) + t.cooldown
             table.sort( t.expiry )
         end
-    
-        -- Handle Runic Power gain, considering Rampant Transference or Rune of Hysteria.
+
+        -- Handle Runic Power gain
         local rpGainMultiplier = state.buff.rune_of_hysteria.up and 1.2 or 1
         state.gain( amount * 10 * rpGainMultiplier, "runic_power" )
-    
-        -- Handle Rune Strike cooldown reduction if applicable.
+
+        -- Handle Rune Strike cooldown reduction
         if state.talent.rune_strike.enabled then
             state.gainChargeTime( "rune_strike", amount )
         end
-    
+
         -- Handle Eternal Rune Weapon interactions (Dancing Rune Weapon synergy).
         if state.buff.dancing_rune_weapon.up and state.azerite.eternal_rune_weapon.enabled then
             local maxExtension = state.buff.dancing_rune_weapon.duration + 5
@@ -102,7 +96,7 @@ spec:RegisterResource( Enum.PowerType.Runes, {
                 )
             end
         end
-    
+
         -- Invalidate the actual rune count to force recalculation.
         t.actual = nil
     end,

--- a/TheWarWithin/DeathKnightBlood.lua
+++ b/TheWarWithin/DeathKnightBlood.lua
@@ -55,7 +55,7 @@ spec:RegisterResource( Enum.PowerType.Runes, {
             t.cooldown = duration
         end
         table.sort( t.expiry )
-        t.actual = nil
+        t.actual = nil -- Reset actual to force recalculation
     end,
 
     gain = function( amount )
@@ -65,23 +65,20 @@ spec:RegisterResource( Enum.PowerType.Runes, {
             t.expiry[ 7 ] = nil
         end
         table.sort( t.expiry )
-        t.actual = nil -- Reset actual to force recalculation
+        t.actual = nil
     end,
 
     spend = function( amount )
         local t = state.runes
 
-        -- Consume the specified number of runes.
         for i = 1, amount do
             t.expiry[ 1 ] = ( t.expiry[ 4 ] > 0 and t.expiry[ 4 ] or state.query_time ) + t.cooldown
             table.sort( t.expiry )
         end
 
-        -- Handle Runic Power gain
         local rpGainMultiplier = state.buff.rune_of_hysteria.up and 1.2 or 1
         state.gain( amount * 10 * rpGainMultiplier, "runic_power" )
 
-        -- Handle Rune Strike cooldown reduction
         if state.talent.rune_strike.enabled then
             state.gainChargeTime( "rune_strike", amount )
         end
@@ -97,7 +94,6 @@ spec:RegisterResource( Enum.PowerType.Runes, {
             end
         end
 
-        -- Invalidate the actual rune count to force recalculation.
         t.actual = nil
     end,
 

--- a/TheWarWithin/DeathKnightFrost.lua
+++ b/TheWarWithin/DeathKnightFrost.lua
@@ -72,7 +72,7 @@ spec:RegisterResource( Enum.PowerType.Runes, {
             t.expiry[ 7 ] = nil
         end
         table.sort( t.expiry )
-        t.actual = nil -- Reset actual to force recalculation
+        t.actual = nil
     end,
 
     spend = function( amount )
@@ -93,7 +93,7 @@ spec:RegisterResource( Enum.PowerType.Runes, {
             state.buff.remorseless_winter.expires = state.buff.remorseless_winter.expires + ( 0.5 * amount )
         end
 
-        t.actual = nil -- Reset actual to force recalculation
+        t.actual = nil
     end,
 
     timeTo = function( x )

--- a/TheWarWithin/DeathKnightFrost.lua
+++ b/TheWarWithin/DeathKnightFrost.lua
@@ -46,15 +46,18 @@ spec:RegisterResource( Enum.PowerType.Runes, {
     cooldown = 10,
     regen = 0,
     max = 6,
-    resource = "runes",
+    forecast = {},
+    fcount = 0,
     times = {},
     values = {},
-    forecast = {},
+    resource = "runes",
 
     reset = function()
         local t = state.runes
         for i = 1, 6 do
             local start, duration, ready = GetRuneCooldown( i )
+            start = start or 0
+            duration = duration or ( 10 * state.haste )
             t.expiry[ i ] = ready and 0 or ( start + duration )
             t.cooldown = duration
         end

--- a/TheWarWithin/DeathKnightUnholy.lua
+++ b/TheWarWithin/DeathKnightUnholy.lua
@@ -41,11 +41,13 @@ spec:RegisterResource( Enum.PowerType.Runes, {
         local t = state.runes
         for i = 1, 6 do
             local start, duration, ready = GetRuneCooldown( i )
+            start = start or 0
+            duration = duration or ( 10 * state.haste )
             t.expiry[ i ] = ready and 0 or ( start + duration )
             t.cooldown = duration
         end
         table.sort( t.expiry )
-        t.actual = nil -- Reset actual to force recalculation
+        t.actual = nil
     end,
 
     gain = function( amount )
@@ -55,7 +57,7 @@ spec:RegisterResource( Enum.PowerType.Runes, {
             t.expiry[ 7 ] = nil
         end
         table.sort( t.expiry )
-        t.actual = nil -- Reset actual to force recalculation
+        t.actual = nil
     end,
 
     spend = function( amount )
@@ -67,7 +69,7 @@ spec:RegisterResource( Enum.PowerType.Runes, {
         end
 
         -- Handle Runic Power gain
-        state.gain( amount * 10, "runic_power" )            
+        state.gain( amount * 10, "runic_power" )
 
         -- Handle Tier 20 4-piece set bonus
         if state.set_bonus.tier20_4pc == 1 then

--- a/TheWarWithin/DeathKnightUnholy.lua
+++ b/TheWarWithin/DeathKnightUnholy.lua
@@ -47,7 +47,7 @@ spec:RegisterResource( Enum.PowerType.Runes, {
             t.cooldown = duration
         end
         table.sort( t.expiry )
-        t.actual = nil
+        t.actual = nil -- Reset actual to force recalculation
     end,
 
     gain = function( amount )
@@ -68,15 +68,12 @@ spec:RegisterResource( Enum.PowerType.Runes, {
             table.insert( t.expiry, nextReady )
         end
 
-        -- Handle Runic Power gain
         state.gain( amount * 10, "runic_power" )
-
-        -- Handle Tier 20 4-piece set bonus
         if state.set_bonus.tier20_4pc == 1 then
             state.cooldown.army_of_the_dead.expires = max( 0, state.cooldown.army_of_the_dead.expires - 1 )
-        end      
+        end
 
-        t.actual = nil -- Reset actual to force recalculation
+        t.actual = nil
     end,
 
     timeTo = function( x )


### PR DESCRIPTION
- Nil protections were missing from Frost and Unholy `reset` function
  - Fixes #4379
- Update Blood expiry table stuff to match the newer version in UH/Frost
- Changed formatting / declaration order of model to be identical between the 3, no functional change
- Simplify some wordy comments, removed duplicated ones, whitespace stuff, etc.
