### PR TITLE
Update Shadow Priest and Retribution Paladin for Dragon Soul Tier 13

### DIFF
--- a/Cataclysm/APLs/PriestShadow.simc
+++ b/Cataclysm/APLs/PriestShadow.simc
@@ -12,30 +12,28 @@ actions.precombat+=/mind_spike
 actions+=/shadowform,if=buff.shadowform.down
 actions+=/dispersion,if=mana.pct<5
 actions+=/run_action_list,name=aoe,if=active_enemies>=2
-actions+=/run_action_list,name=opener,if=time<45&!debuff.vampiric_touch.up&!debuff.devouring_plague.up&!set_bonus.tier13_4pc=1
-actions+=/run_action_list,name=t13,if=(cooldown.shadowfiend.remains=0|pet.alive)&set_bonus.tier13_4pc=1
+actions+=/run_action_list,name=t13,if=(cooldown.shadowfiend.remains=0|pet.alive|buff.shadowfiend.up)&set_bonus.tier13_4pc=1
 actions+=/run_action_list,name=st
 
 # Tier 13 4pc Sequence
-actions.t13+=/mind_flay,interrupt_if=buff.dark_evangelism.stack=5,if=buff.dark_evangelism.stack<5
-actions.t13+=/shadowfiend,if=(!pet.alive|!buff.shadowfiend.up)
+actions.t13+=/mind_flay,interrupt_if=buff.dark_evangelism.stack>=5,if=buff.dark_evangelism.stack<5&!pet.alive
+actions.t13+=/shadowfiend,if=!pet.alive
 actions.t13+=/archangel,if=buff.dark_evangelism.stack=5
-actions.t13+=/mind_flay,interrupt_if=ticks>=2,if=mind_spike_count=5
+actions.t13+=/mind_blast,if=prev_gcd.shadowfiend|prev_gcd.archangel
+actions.t13+=/mind_flay,interrupt_if=ticks>=2,if=mind_spike_count>=4&prev_gcd.mind_spike
 actions.t13+=/mind_blast,if=prev_gcd.mind_flay
-actions.t13+=/mind_spike,if=mind_spike_count<5
+actions.t13+=/mind_spike,if=mind_spike_count<4
 actions.t13+=/mind_blast
 
-## Opener Sequence
-actions.opener+=/mind_spike,if=!debuff.mind_spike.up&!debuff.shadow_word_pain.up&!debuff.devouring_plague.up&!debuff.vampiric_touch.up
-actions.opener+=/shadow_word_pain,if=!debuff.shadow_word_pain.up&time_to_die>10
-actions.opener+=/mind_flay,interrupt_if=buff.shadow_orb.stack>=1&buff.dark_evangelism.stack>=5,if=!(buff.shadow_orb.stack>=1&buff.dark_evangelism.stack>=5)&time<=(2*gcd+2.5*action.mind_flay.duration)
-
 ## Single Target Rotation
+actions.st+=/mind_spike,if=!debuff.mind_spike.up&!debuff.shadow_word_pain.up&!debuff.devouring_plague.up&!debuff.vampiric_touch.up
+actions.st+=/shadow_word_pain,if=!debuff.shadow_word_pain.up&time_to_die>10
+actions.st+=/mind_flay,interrupt_if=buff.shadow_orb.stack>=1&buff.dark_evangelism.stack>=5,if=!(buff.shadow_orb.stack>=1&buff.dark_evangelism.stack>=5)&time<=(2*gcd+2.5*action.mind_flay.duration)
 actions.st+=/shadowfiend,if=!pet.alive
-actions.st+=/archangel,if=buff.dark_evangelism.stack=5&(debuff.vampiric_touch.remains>5&debuff.devouring_plague.remains>5)&settings.show_archangel_cooldown&(set_bonus.tier13_4pc=1&cooldown.shadowfiend.remains>30)
+actions.st+=/archangel,if=buff.dark_evangelism.stack=5&(debuff.vampiric_touch.remains>5&debuff.devouring_plague.remains>5)&settings.show_archangel_cooldown&((set_bonus.tier13_4pc=1&cooldown.shadowfiend.remains>90)|!set_bonus.tier13_4pc=1)
 actions.st+=/mind_blast,if=buff.shadow_orb.up
-actions.st+=/vampiric_touch,if=debuff.vampiric_touch.remains<debuff.vampiric_touch.tick_time&time_to_die>10
-actions.st+=/devouring_plague,if=debuff.devouring_plague.remains<debuff.devouring_plague.tick_time&time_to_die>10
+actions.st+=/vampiric_touch,if=(debuff.vampiric_touch.remains<debuff.vampiric_touch.tick_time)&time_to_die>10
+actions.st+=/devouring_plague,if=(debuff.devouring_plague.remains<debuff.devouring_plague.tick_time)&time_to_die>10
 actions.st+=/shadow_word_death,if=target.health.pct<25
 actions.st+=/mind_blast
 actions.st+=/dispersion,if=mana.pct<10

--- a/Cataclysm/APLs/PriestShadow.simc
+++ b/Cataclysm/APLs/PriestShadow.simc
@@ -2,73 +2,52 @@
 ## Based on WoWSims & WoWHead
 
 ## PreCombat-Actions
-# Enter Shadowform if not already in it
 actions.precombat+=/shadowform,if=buff.shadowform.down
-# Cast Power Word: Fortitude if not active
 actions.precombat+=/power_word_fortitude,if=buff.power_word_fortitude.down
-# Cast Inner Fire if not active
 actions.precombat+=/inner_fire,if=!up
-# Cast Vampiric Embrace if not active
 actions.precombat+=/vampiric_embrace,if=!up
-# Start precombat with Mind Spike
 actions.precombat+=/mind_spike
-
 
 # Enter Shadowform if not already in it
 actions+=/shadowform,if=buff.shadowform.down
-# Switch to AoE rotation if 2 or more enemies are present
+actions+=/dispersion,if=mana.pct<5
 actions+=/run_action_list,name=aoe,if=active_enemies>=2
-# Default to single-target rotation
+actions+=/run_action_list,name=opener,if=time<45&!debuff.vampiric_touch.up&!debuff.devouring_plague.up&!set_bonus.tier13_4pc=1
+actions+=/run_action_list,name=t13,if=(cooldown.shadowfiend.remains=0|pet.alive)&set_bonus.tier13_4pc=1
 actions+=/run_action_list,name=st
 
+# Tier 13 4pc Sequence
+actions.t13+=/mind_flay,interrupt_if=buff.dark_evangelism.stack=5,if=buff.dark_evangelism.stack<5
+actions.t13+=/shadowfiend,if=(!pet.alive|!buff.shadowfiend.up)
+actions.t13+=/archangel,if=buff.dark_evangelism.stack=5
+actions.t13+=/mind_flay,interrupt_if=ticks>=2,if=mind_spike_count=5
+actions.t13+=/mind_blast,if=prev_gcd.mind_flay
+actions.t13+=/mind_spike,if=mind_spike_count<5
+actions.t13+=/mind_blast
+
+## Opener Sequence
+actions.opener+=/mind_spike,if=!debuff.mind_spike.up&!debuff.shadow_word_pain.up&!debuff.devouring_plague.up&!debuff.vampiric_touch.up
+actions.opener+=/shadow_word_pain,if=!debuff.shadow_word_pain.up&time_to_die>10
+actions.opener+=/mind_flay,interrupt_if=buff.shadow_orb.stack>=1&buff.dark_evangelism.stack>=5,if=!(buff.shadow_orb.stack>=1&buff.dark_evangelism.stack>=5)&time<=(2*gcd+2.5*action.mind_flay.duration)
+
 ## Single Target Rotation
-
-## Opener sequence for single target
-# Cast Mind Spike if none of the main debuffs are present
-actions.st+=/mind_spike,if=!debuff.mind_spike.up&!debuff.shadow_word_pain.up&!debuff.devouring_plague.up&!debuff.vampiric_touch.up
-# Summon Shadowfiend if it is not alive and it is early in the fight
-actions.st+=/shadowfiend,if=!pet.alive&time<5
-# Emergency Mind Flay to maintain Shadow Word: Pain
-actions.st+=/mind_flay,if=debuff.shadow_word_pain.up&debuff.shadow_word_pain.remains<gcd+latency
-# Apply Shadow Word: Pain if its not up
-actions.st+=/shadow_word_pain,if=!debuff.shadow_word_pain.up
-# Cast Mind Flay to start generating Shadow Orbs and Dark Evangelism stacks
-actions.st+=/mind_flay,interrupt_if=buff.shadow_orb.stack>=1&buff.dark_evangelism.stack>=5,if=!(buff.shadow_orb.stack>=1&buff.dark_evangelism.stack>=5)&time<=(2*gcd+2.5*action.mind_flay.duration)
-
-## Main Rotation
-# Cast Mind Blast if Shadow Orbs are available
-actions.st+=/mind_blast,if=buff.shadow_orb.up
-# Reapply Vampiric Touch if its duration is about to expire
-actions.st+=/vampiric_touch,if=debuff.vampiric_touch.remains<debuff.vampiric_touch.tick_time
-# Reapply Devouring Plague if its duration is about to expire
-actions.st+=/devouring_plague,if=debuff.devouring_plague.remains<debuff.devouring_plague.tick_time
-# Cast Mind Blast as a filler
-actions.st+=/mind_blast
-# Use Archangel when Dark Evangelism stacks are maxed and main DoTs have sufficient duration
-actions.st+=/archangel,if=buff.dark_evangelism.stack=5&(debuff.vampiric_touch.remains>5&debuff.devouring_plague.remains>5)
-# Summon Shadowfiend if it is not alive
 actions.st+=/shadowfiend,if=!pet.alive
-# Use Shadow Word: Death if the target is below 25% health or mana is low
-actions.st+=/shadow_word_death,if=target.health.pct<25|mana.pct<20
-# Use Dispersion if mana is very low
+actions.st+=/archangel,if=buff.dark_evangelism.stack=5&(debuff.vampiric_touch.remains>5&debuff.devouring_plague.remains>5)&settings.show_archangel_cooldown&(set_bonus.tier13_4pc=1&cooldown.shadowfiend.remains>30)
+actions.st+=/mind_blast,if=buff.shadow_orb.up
+actions.st+=/vampiric_touch,if=debuff.vampiric_touch.remains<debuff.vampiric_touch.tick_time&time_to_die>10
+actions.st+=/devouring_plague,if=debuff.devouring_plague.remains<debuff.devouring_plague.tick_time&time_to_die>10
+actions.st+=/shadow_word_death,if=target.health.pct<25
+actions.st+=/mind_blast
 actions.st+=/dispersion,if=mana.pct<10
-# Cast Mind Flay if none of the main debuffs are about to expire and Mind Blast is on cooldown
 actions.st+=/mind_flay,if=!(debuff.vampiric_touch.remains<gcd|debuff.devouring_plague.remains<gcd|cooldown.mind_blast.remains<gcd)
+actions.st+=/mind_spike,if=time_to_die<10
 
 ## AoE Rotation
-# Cast Mind Sear if there are more than 5 enemies
 actions.aoe+=/mind_sear,if=active_enemies>5
-# Apply Shadow Word: Pain to multiple targets if it is about to expire
 actions.aoe+=/shadow_word_pain,cycle_targets=1,max_cycle_targets=5,if=settings.dots_in_aoe&debuff.shadow_word_pain.remains<debuff.shadow_word_pain.tick_time
-# Apply Vampiric Touch to multiple targets if it is about to expire and the target will live long enough
 actions.aoe+=/vampiric_touch,cycle_targets=1,max_cycle_targets=5,if=settings.dots_in_aoe&debuff.vampiric_touch.remains<debuff.vampiric_touch.tick_time&target.time_to_die>=debuff.vampiric_touch.duration
-# Reapply Devouring Plague if its duration is about to expire
 actions.aoe+=/devouring_plague,if=settings.dots_in_aoe&debuff.devouring_plague.remains<debuff.devouring_plague.tick_time
-# Cast Mind Blast if Shadow Orbs are available
 actions.aoe+=/mind_blast,if=buff.shadow_orb.up
-# Use Mind Flay to maintain Shadow Word: Pain if it is about to expire
 actions.aoe+=/mind_flay,interrupt_if=ticks>=2,if=debuff.shadow_word_pain.up&debuff.shadow_word_pain.remains<gcd+latency
-# Use Shadow Word: Death if the target is below 25% health or mana is low and there are less than 4 enemies
 actions.aoe+=/shadow_word_death,if=target.health.pct<25&active_enemies<4|mana.pct<15
-# Cast Mind Sear as a filler
 actions.aoe+=/mind_sear

--- a/Cataclysm/Paladin.lua
+++ b/Cataclysm/Paladin.lua
@@ -21,6 +21,7 @@ paladin:RegisterGear( "libram_of_three_truths", 50455 )
 -- TODO: Update for Cataclysm
 paladin:RegisterGear( "tier7ret", 43794, 43796, 43801, 43803, 43805, 40574, 40575, 40576, 40577, 40578 )
 paladin:RegisterGear( "tier10ret", 50324, 50325, 50326, 50327, 50328, 51160, 51161, 51162, 51163, 51164, 51275, 51276, 51277, 51278, 51279 )
+paladin:RegisterGear( "tier13", 78822, 78770, 78788, 78807, 78837, 76874, 76875, 76876, 76877, 76878, 78727, 78675, 78693, 78712, 78742 )
 
 -- Hooks
 local aura_assigned
@@ -1345,6 +1346,9 @@ paladin:RegisterAbilities( {
             if talent.judgements_of_the_bold.enabled then applyBuff( "judgements_of_the_bold" ) end
             if talent.judgements_of_the_just.enabled then applyDebuff( "target", "judgements_of_the_just" ) end
             if spec.retribution and buff.guardian_of_ancient_kings.up and buff.ancient_power.stacks < 20 then addStack( "ancient_power", 1 ) end
+            if set_bonus.tier13_4pc then
+                gain( 1, "holy_power" )
+            end
         end,
     },
     -- Heals a friendly target for an amount equal to your maximum health. Cannot be used on a target with Forbearance. Causes Forbearance for 1 min.

--- a/Cataclysm/Priest.lua
+++ b/Cataclysm/Priest.lua
@@ -10,6 +10,7 @@ local spec = Hekili:NewSpecialization( 5 )
 spec:RegisterGear( "tier7", 39521, 39530, 39529, 39528, 39523, 40456, 40454, 40459, 40457, 40458 )
 spec:RegisterGear( "tier9", 48755, 48756, 48757, 48758, 48759, 48078, 48077, 48081, 48079, 48080, 48085, 48086, 48082, 48084, 48083 )
 spec:RegisterGear( "tier10", 51259, 51257, 51256, 51255, 51258, 51181, 51180, 51182, 51183, 51184, 51741, 51740, 51739, 51738, 51737 )
+spec:RegisterGear( "tier13", 787777, 78798, 78817, 78826, 78845, 76348, 76347, 76346, 76345, 76344, 78682, 78703, 78722, 78731, 78750 )
 
 -- Resources
 spec:RegisterResource( Enum.PowerType.Mana )
@@ -99,20 +100,12 @@ spec:RegisterTalents( {
 
 -- Auras
 spec:RegisterAuras( {
-    -- Attempts to dispel $10872s1 disease every $t1 seconds.
-    abolish_disease = {
-        id = 552,
-        duration = 12,
-        tick_time = 3,
-        max_stack = 1,
-    },
     absolution = {
         id = 33167,
         duration = 3600,
         max_stack = 1,
 
     },
-    --
     archangel = {
         id = 81700,
         duration = 18,
@@ -285,36 +278,11 @@ spec:RegisterAuras( {
         max_stack = 1,
         copy = { 64904, 64901 },
     },
-    improved_mana_burn = { -- TODO: Check Aura (https://wowhead.com/wotlk/spell=14772)
-        id = 14772,
-        duration = 3600,
-        max_stack = 1,
-        copy = { 14772, 14750 },
-    },
-    improved_power_word_shield = { -- TODO: Check Aura (https://wowhead.com/wotlk/spell=14769)
-        id = 14769,
-        duration = 3600,
-        max_stack = 1,
-        copy = { 14769, 14768, 14748 },
-    },
-    improved_psychic_scream = { -- TODO: Check Aura (https://wowhead.com/wotlk/spell=15448)
-        id = 15448,
-        duration = 3600,
-        max_stack = 1,
-        copy = { 15448, 15392 },
-    },
     improved_renew = { -- TODO: Check Aura (https://wowhead.com/wotlk/spell=17191)
         id = 17191,
         duration = 3600,
         max_stack = 1,
         copy = { 17191, 15020, 14908 },
-    },
-    -- Spirit increased by $s1% and allows $s2% mana regeneration while casting.
-    improved_spirit_tap = {
-        id = 59000,
-        duration = 8,
-        max_stack = 1,
-        copy = { 49694, 59000 },
     },
     -- Increases armor by $s1.
     inner_fire = {
@@ -395,13 +363,6 @@ spec:RegisterAuras( {
         max_stack = 1,
         copy = { 2096, 10909 },
     },
-
-    mind_spike = { 
-        id = 73510,
-        duration = 3600,
-        max_stack = 3,
-        copy = { 87178, 87179 },
-    },
     -- Chance to hit with spells on the target increased by $s1%.
     misery = {
         id = 33198,
@@ -434,13 +395,6 @@ spec:RegisterAuras( {
         duration = 60,
         max_stack = 1,
         copy = { 1244, 1245, 2791, 10937, 10938, 21562, 25389, 48161, 79014, 79105 },
-    },
-    -- Increases Shadow Resistance by $s1.
-    prayer_of_shadow_protection = {
-        id = 27683,
-        duration = function() return glyph.shadow_protection.enabled and 1800 or 1200 end,
-        max_stack = 1,
-        copy = { 27683, 39236, 39374, 48170 },
     },
     -- Disarmed.
     psychic_horror = {
@@ -497,13 +451,6 @@ spec:RegisterAuras( {
         max_stack = 1,
         copy = { 976, 7235, 7241, 7242, 7243, 7244, 10957, 10958, 16874, 25433, 48169 },
     },
-    -- Increases Shadow damage done by $s1%.
-    shadow_weaving = {
-        id = 15258,
-        duration = 15,
-        max_stack = 5,
-        copy = { 15258 },
-    },
     -- $s1 Shadow damage every $t1 seconds.
     shadow_word_pain = {
         id = 589,
@@ -515,6 +462,27 @@ spec:RegisterAuras( {
     shadowfiend = {
         duration = 15,
         max_stack = 1,
+    },
+    active_shadow_fiend = {
+        duration = 15,
+        max_stack = 1,
+
+        generate = function( ah )
+            ah.duration = 15
+
+            if active_dot.shadowfiend > 0 then
+                ah.count = 1
+                ah.applied = action.shadowfiend.lastCast
+                ah.expires = ah.applied + ah.duration
+                ah.caster = "player"
+                return
+            end
+
+            ah.count = 0
+            ah.applied = 0
+            ah.expires = 0
+            ah.caster = "nobody"
+        end
     },
     -- Shadow damage you deal increased by $s2%.  All damage you take reduced by $s3% and threat generated is reduced by $49868s1%. You may not cast Holy spells except Cure Disease and Abolish Disease.  Grants the periodic damage from your Shadow Word: Pain, Devouring Plague, and Vampiric Touch spells the ability to critically hit for $49868s2% increased damage and grants Devouring Plague and Vampiric Touch the ability to benefit from haste.
     shadowform = {
@@ -534,11 +502,11 @@ spec:RegisterAuras( {
         duration = 5,
         max_stack = 1,
     },
-    spell_warding = { -- TODO: Check Aura (https://wowhead.com/wotlk/spell=27904)
-        id = 27904,
+    spell_warding = {
+        id = 91724,
         duration = 3600,
         max_stack = 1,
-        copy = { 27904, 27903, 27902, 27901, 27900 },
+        copy = { 27904, 27903, 27902, 27901, 27900, 91724 },
     },
     -- Spirit increased by $s1% and allows $s2% of mana regeneration while casting.
     spirit_tap = {
@@ -659,7 +627,6 @@ spec:RegisterAbilities( {
         copy = { 48119, 48120 },
     },
 
-
     -- Heals up to 5 friendly party or raid members within 15 yards of the target for 347 to 383.
     circle_of_healing = {
         id = 34861,
@@ -678,7 +645,6 @@ spec:RegisterAbilities( {
         end,
     },
 
-
     -- Removes 1 disease from the friendly target.
     cure_disease = {
         id = 528,
@@ -695,7 +661,6 @@ spec:RegisterAbilities( {
         handler = function ()
         end,
     },
-
 
     -- Instantly heals the caster for 263 to 325.
     desperate_prayer = {
@@ -717,7 +682,6 @@ spec:RegisterAbilities( {
         end,
     },
 
-
     -- Afflicts the target with a disease that causes 152 Shadow damage over 24 sec. 15% of damage caused by the Devouring Plague heals the caster. This spell can only affect one target at a time.
     devouring_plague = {
         id = 2944,
@@ -732,15 +696,11 @@ spec:RegisterAbilities( {
         texture = 252997,
 
         handler = function ()
-            if talent.shadow_weaving.rank == 3 then
-                addStack( "shadow_weaving" )
-            end
             applyDebuff( "target", "devouring_plague" )
         end,
 
         copy = { 19276, 19277, 19278, 19279, 19280, 25467, 48299, 48300 },
     },
-
 
     -- Dispels magic on the target, removing 1 harmful spell from a friend or 1 beneficial spell from an enemy.
     dispel_magic = {
@@ -764,7 +724,6 @@ spec:RegisterAbilities( {
         copy = { 988 },
     },
 
-
     -- You disperse into pure Shadow energy, reducing all damage taken by 90%.  You are unable to attack or cast spells, but you regenerate 6% mana every 1 sec for 6 sec. Dispersion can be cast while stunned, feared or silenced and clears all snare and movement impairing effects when cast, and makes you immune to them while dispersed.
     dispersion = {
         id = 47585,
@@ -781,7 +740,6 @@ spec:RegisterAbilities( {
         handler = function ()
         end,
     },
-
 
     -- Heals 3 nearby lowest health friendly party or raid targets within 40 yards for 3024 to 3342 every 2 sec for 8 sec, and increases healing done to them by 10% for 8 sec. Maximum of 12 heals. The Priest must channel to maintain the spell.
     divine_hymn = {
@@ -802,7 +760,6 @@ spec:RegisterAbilities( {
         end,
     },
 
-
     -- Fade out, temporarily reducing all your threat for 10 sec.
     fade = {
         id = 586,
@@ -819,7 +776,6 @@ spec:RegisterAbilities( {
         handler = function ()
         end,
     },
-
 
     -- Wards the friendly target against Fear.  The next Fear effect used against the target will fail, using up the ward.  Lasts 3 min.
     fear_ward = {
@@ -840,7 +796,6 @@ spec:RegisterAbilities( {
         end,
     },
 
-
     -- Heals a friendly target for 202 to 247.
     flash_heal = {
         id = 2061,
@@ -860,7 +815,6 @@ spec:RegisterAbilities( {
         copy = { 9472, 9473, 9474, 10915, 10916, 10917, 25233, 25235, 48070, 48071 },
     },
 
-
     -- A slow casting spell that heals a single target for 924 to 1039.
     greater_heal = {
         id = 2060,
@@ -879,7 +833,6 @@ spec:RegisterAbilities( {
 
         copy = { 10963, 10964, 10965, 25314, 25210, 25213, 48062, 48063 },
     },
-
 
     -- Calls upon a guardian spirit to watch over the friendly target. The spirit increases the healing received by the target by 40%, and also prevents the target from dying by sacrificing itself.  This sacrifice terminates the effect but heals the target of 50% of their maximum health. Lasts 10 sec.
     guardian_spirit = {
@@ -901,7 +854,6 @@ spec:RegisterAbilities( {
         end,
     },
 
-
     -- Heal your target for 307 to 353.
     heal = {
         id = 2050,
@@ -920,7 +872,6 @@ spec:RegisterAbilities( {
 
         copy = { 2055, 6063, 6064 },
     },
-
 
     -- Consumes the enemy in Holy flames that cause 108 to 134 Holy damage and an additional 21 Holy damage over 7 sec.
     holy_fire = {
@@ -941,7 +892,6 @@ spec:RegisterAbilities( {
         copy = { 15262, 15263, 15264, 15265, 15266, 15267, 15261, 25384, 48134, 48135 },
     },
 
-
     -- Causes an explosion of holy light around the caster, causing 29 to 34 Holy damage to all enemy targets within 10 yards and healing all party members within 10 yards for 54 to 63.  These effects cause no threat.
     holy_nova = {
         id = 15237,
@@ -961,7 +911,6 @@ spec:RegisterAbilities( {
         copy = { 15430, 15431, 27799, 27800, 27801, 25331, 48077, 48078 },
     },
 
-
     -- Restores 3% mana to 3 nearby low mana friendly party or raid targets every 2 sec for 8 sec, and increases their total maximum mana by 20% for 8 sec. Maximum of 12 mana restores. The Priest must channel to maintain the spell.
     hymn_of_hope = {
         id = 64901,
@@ -978,7 +927,6 @@ spec:RegisterAbilities( {
         handler = function ()
         end,
     },
-
 
     -- A burst of Holy energy fills the caster, increasing armor by 315.  Each melee or ranged damage hit against the priest will remove one charge.  Lasts 30 min or until 20 charges are used.
     inner_fire = {
@@ -1000,7 +948,6 @@ spec:RegisterAbilities( {
         copy = { 7128, 602, 1006, 10951, 10952, 25431, 48040, 48168 },
     },
 
-
     -- When activated, reduces the mana cost of your next spell by 100% and increases its critical effect chance by 25% if it is capable of a critical effect.
     inner_focus = {
         id = 14751,
@@ -1019,27 +966,6 @@ spec:RegisterAbilities( {
         end,
     },
 
-
-    -- Heal your target for 47 to 58.
-    lesser_heal = {
-        id = 2050,
-        cast = 1.5,
-        cooldown = 0,
-        gcd = "spell",
-
-        spend = 0.16,
-        spendType = "mana",
-
-        startsCombat = false,
-        texture = 135929,
-
-        handler = function ()
-        end,
-
-        copy = { 2052, 2053 },
-    },
-
-
     -- Allows the friendly party or raid target to levitate, floating a few feet above the ground.  While levitating, the target will fall at a reduced speed and travel over water.  Any damage will cancel the effect.  Lasts 2 min.
     levitate = {
         id = 1706,
@@ -1057,7 +983,6 @@ spec:RegisterAbilities( {
             -- TODO: glyph.levitate.enabled removes reagent requirement.
         end,
     },
-
 
     -- Creates a Holy Lightwell.  Friendly players can click the Lightwell to restore 801 health over 6 sec.  Attacks done to you equal to 30% of your total health will cancel the effect. Lightwell lasts for 3 min or 10 charges.
     lightwell = {
@@ -1079,7 +1004,6 @@ spec:RegisterAbilities( {
         end,
     },
 
-
     -- Destroy 10% of the target's mana (up to a maximum of 20% of your own maximum mana). For each mana destroyed in this way, the target takes 0.5 Shadow damage.
     mana_burn = {
         id = 8129,
@@ -1097,7 +1021,6 @@ spec:RegisterAbilities( {
         end,
     },
 
-
     -- Dispels magic in a 15 yard radius, removing 1 harmful spell from each friendly target and 1 beneficial spell from each enemy target.  Affects a maximum of 10 friendly targets and 10 enemy targets.  This dispel is potent enough to remove Magic effects that are normally undispellable.
     mass_dispel = {
         id = 32375,
@@ -1114,7 +1037,6 @@ spec:RegisterAbilities( {
         handler = function ()
         end,
     },
-
 
     -- Blasts the target for 42 to 46 Shadow damage.
     mind_blast = {
@@ -1135,7 +1057,6 @@ spec:RegisterAbilities( {
         copy = { 8102, 8103, 8104, 8105, 8106, 10945, 10946, 10947, 25372, 25375, 48126, 48127 },
     },
 
-
     -- Controls a humanoid mind up to level 82, but increases the time between its attacks by 25%.  Lasts up to 1 min.
     mind_control = {
         id = 605,
@@ -1152,7 +1073,6 @@ spec:RegisterAbilities( {
         handler = function ()
         end,
     },
-
 
     -- Assault the target's mind with Shadow energy, causing 45 Shadow damage over 3 sec and slowing their movement speed by 50%.
     mind_flay = {
@@ -1181,8 +1101,8 @@ spec:RegisterAbilities( {
         end,
 
         tick = function ()
-            if talent.shadow_weaving.rank == 3 then
-                addStack( "shadow_weaving" )
+            if talent.evangelism.enabled then
+                addStack( "dark_evangelism" )
             end
         end,
 
@@ -1195,7 +1115,6 @@ spec:RegisterAbilities( {
 
         copy = { 17311, 17312, 17313, 17314, 18807, 25387, 48155, 48156 }
     },
-
 
     -- Causes an explosion of shadow magic around the enemy target, causing 183 to 197 Shadow damage every 1 sec for 5 sec to all enemies within 10 yards around the target.
     mind_sear = {
@@ -1219,12 +1138,6 @@ spec:RegisterAbilities( {
             applyDebuff( "target", "mind_sear" )
         end,
 
-        tick = function ()
-            if talent.shadow_weaving.rank == 3 then
-                addStack( "shadow_weaving" )
-            end
-        end,
-
         breakchannel = function ()
             removeDebuff( "target", "mind_sear" )
         end,
@@ -1234,7 +1147,6 @@ spec:RegisterAbilities( {
 
         copy = { 53023 },
     },
-
 
     -- Soothes the target, reducing the range at which it will attack you by 10 yards.  Only affects Humanoid targets.  Lasts 15 sec.
     mind_soothe = {
@@ -1252,7 +1164,6 @@ spec:RegisterAbilities( {
         handler = function ()
         end,
     },
-
 
     -- Allows the caster to see through the target's eyes for 1 min.
     mind_vision = {
@@ -1272,7 +1183,6 @@ spec:RegisterAbilities( {
 
         copy = { 10909 },
     },
-
 
     -- Instantly reduces a friendly target's threat by 5%, reduces all damage taken by 40% and increases resistance to Dispel mechanics by 65% for 8 sec.
     pain_suppression = {
@@ -1294,6 +1204,7 @@ spec:RegisterAbilities( {
             applyBuff( "pain_suppression" )
         end,
     },
+
     -- Blasts the target for 1213 Shadowfrost damage, but extinguishes your shadow damage-over-time effects from the target in the process. Mind Spike also increases the critical strike chance of your next Mind Blast on the target by 30%. Stacks up to 3 times.
     mind_spike = {
         id = 73510,
@@ -1309,8 +1220,10 @@ spec:RegisterAbilities( {
 
         handler = function ()
             applyDebuff("target", "mind_spike")
+            variable.mind_spike_count = (variable.mind_spike_count or 0) + 1
         end,
     },
+
     -- Launches a volley of holy light at the target, causing 240 Holy damage to an enemy, or 670 to 756 healing to an ally instantly and every 1 sec for 2 sec.
     penance = {
         id = 47540,
@@ -1330,7 +1243,6 @@ spec:RegisterAbilities( {
             applyDebuff( "target", "penance" )
         end,
     },
-
 
     -- Infuses the target with power, increasing spell casting speed by 20% and reducing the mana cost of all spells by 20%.  Lasts 15 sec.
     power_infusion = {
@@ -1353,7 +1265,6 @@ spec:RegisterAbilities( {
         end,
     },
 
-
     -- Power infuses the target, increasing their Stamina by 3 for 30 min.
     power_word_fortitude = {
         id = 79105,
@@ -1373,7 +1284,6 @@ spec:RegisterAbilities( {
 
         copy = { 1244, 1245, 2791, 10937, 10938, 21562, 25389, 48161, 79014, 79105 },
     },
-
 
     -- Draws on the soul of the friendly target to shield them, absorbing 48 damage.  Lasts 30 sec.  While the shield holds, spellcasting will not be interrupted by damage.  Once shielded, the target cannot be shielded again for 15 sec.
     power_word_shield = {
@@ -1416,7 +1326,6 @@ spec:RegisterAbilities( {
         copy = { 996, 10960, 10961, 25316, 25308, 48072 },
     },
 
-
     -- Places a spell on the target that heals them for 800 the next time they take damage.  When the heal occurs, Prayer of Mending jumps to a party or raid member within 20 yards.  Jumps up to 5 times and lasts 30 sec after each jump.  This spell can only be placed on one target at a time.
     prayer_of_mending = {
         id = 33076,
@@ -1435,28 +1344,6 @@ spec:RegisterAbilities( {
 
         copy = { 48112, 48113 },
     },
-
-
-    -- Power infuses the target's party and raid members, increasing their Shadow resistance by 60 for 20 min.
-    prayer_of_shadow_protection = {
-        id = 27683,
-        cast = 0,
-        cooldown = 0,
-        gcd = "spell",
-
-        spend = 0.62,
-        spendType = "mana",
-
-        startsCombat = false,
-        texture = 135945,
-
-        handler = function ()
-            applyBuff( "prayer_of_shadow_protection" )
-        end,
-
-        copy = { 39374, 48170 },
-    },
-
 
     -- You terrify the target, causing them to tremble in horror for 3 sec and drop their main hand and ranged weapons for 10 sec.
     psychic_horror = {
@@ -1478,7 +1365,6 @@ spec:RegisterAbilities( {
         end,
     },
 
-
     -- The caster lets out a psychic scream, causing 2 enemies within 8 yards to flee for 8 sec.  Damage caused may interrupt the effect.
     psychic_scream = {
         id = 8122,
@@ -1499,7 +1385,6 @@ spec:RegisterAbilities( {
         copy = { 8124, 10888, 10890 },
     },
 
-
     -- Heals the target for 45 over 15 sec.
     renew = {
         id = 139,
@@ -1519,7 +1404,6 @@ spec:RegisterAbilities( {
         copy = { 6074, 6075, 6076, 6077, 6078, 10927, 10928, 10929, 25315, 25221, 25222, 48067, 48068 },
     },
 
-
     -- Brings a dead player back to life with 70 health and 135 mana.  Cannot be cast when in combat.
     resurrection = {
         id = 2006,
@@ -1538,7 +1422,6 @@ spec:RegisterAbilities( {
 
         copy = { 2010, 10880, 10881, 20770, 25435, 48171 },
     },
-
 
     -- Shackles the target undead enemy for up to 30 sec.  The shackled unit is unable to move, attack or cast spells.  Any damage caused will release the target.  Only one target can be shackled at a time.
     shackle_undead = {
@@ -1560,7 +1443,6 @@ spec:RegisterAbilities( {
         copy = { 9485, 10955 },
     },
 
-
     -- Increases the target's resistance to Shadow spells by 30 for 10 min.
     shadowfiend = {
         id = 34433,
@@ -1576,12 +1458,11 @@ spec:RegisterAbilities( {
         toggle = "cooldowns",
 
         handler = function ()
-            applyBuff( "shadowfiend" )
+            applyBuff( "active_shadow_fiend" )
         end,
 
         copy = {},
     },
-
 
     -- Increases the target's resistance to Shadow spells by 30 for 10 min.
     shadow_protection = {
@@ -1603,7 +1484,6 @@ spec:RegisterAbilities( {
         copy = { 10957, 10958, 25433, 48169 },
     },
 
-
     -- A word of dark binding that inflicts 450 to 522 Shadow damage to the target.  If the target is not killed by Shadow Word: Death, the caster takes damage equal to the damage inflicted upon the target.
     shadow_word_death = {
         id = 32379,
@@ -1623,7 +1503,6 @@ spec:RegisterAbilities( {
 
         copy = { 32996, 48157, 48158 },
     },
-
 
     -- A word of darkness that causes 30 Shadow damage over 18 sec.
     shadow_word_pain = {
@@ -1645,7 +1524,6 @@ spec:RegisterAbilities( {
         copy = { 594, 970, 992, 2767, 10892, 10893, 10894, 25367, 25368, 48124, 48125 },
     },
 
-
     -- Assume a Shadowform, increasing your Shadow damage by 15%, reducing all damage done to you by 15% and threat generated by 30%.  However, you may not cast Holy spells while in this form except Cure Disease and Abolish Disease.  Grants the periodic damage from your Shadow Word: Pain, Devouring Plague, and Vampiric Touch spells the ability to critically hit for 100% increased damage and grants Devouring Plague and Vampiric Touch the ability to benefit from haste.
     shadowform = {
         id = 15473,
@@ -1664,7 +1542,6 @@ spec:RegisterAbilities( {
             applyBuff( "shadowform" )
         end,
     },
-
 
     -- Silences the target, preventing them from casting spells for 5 sec.  Non-player victim spellcasting is also interrupted for 3 sec.
     silence = {
@@ -1689,7 +1566,6 @@ spec:RegisterAbilities( {
         end,
     },
 
-
     -- Smite an enemy for 15 to 20 Holy damage.
     smite = {
         id = 585,
@@ -1709,7 +1585,6 @@ spec:RegisterAbilities( {
         copy = { 591, 598, 984, 1004, 6060, 10933, 10934, 25363, 25364, 48122, 48123 },
     },
 
-
     -- Fills you with the embrace of Shadow energy, causing you to be healed for 15% and other party members to be healed for 3% of any single-target Shadow spell damage you deal for 30 min.
     vampiric_embrace = {
         id = 15286,
@@ -1727,7 +1602,6 @@ spec:RegisterAbilities( {
         end,
     },
 
-
     -- Causes 450 Shadow damage over 15 sec to your target and causes up to 10 party or raid members to gain 1% of their maximum mana per 5 sec when you deal damage from Mind Blast. In addition, if the Vampiric Touch is dispelled it will cause 720 damage to the afflicted target.
     vampiric_touch = {
         id = 34914,
@@ -1743,47 +1617,71 @@ spec:RegisterAbilities( {
         texture = 135978,
 
         handler = function ()
-            if talent.shadow_weaving.rank == 3 then
-                addStack( "shadow_weaving" )
-            end
             applyDebuff( "target", "vampiric_touch" )
         end,
     },
 } )
 
+-- Track the last time the Shadowfiend was cast
+spec:RegisterStateExpr( "last_shadowfiend", function ()
+    return action.shadowfiend.lastCast
+end )
+spec:RegisterStateExpr( "shadowfiend_remains", function()
+    local lastCast = action.shadowfiend.lastCast
+    if lastCast and lastCast > 0 then
+        return max( 0, lastCast + 15 - query_time )
+    end
+    return 0
+end )
+spec:RegisterStateExpr( "shadowfiend_active", function ()
+    return active_dot.shadowfiend > 0
+end )
+
+--Track how many times Mind Spike has been cast in a row
+spec:RegisterStateExpr( "mind_spike_count", function()
+    if prev_gcd.mind_spike then
+        return variable.mind_spike_count or 0
+    end
+    return 0
+end )
+
 -- Hooks
 spec:RegisterHook( "reset_precast", function ()
 end )
 
--- Expressions
-spec:RegisterStateExpr( "flay_over_blast", function()
-    local currentSP = GetSpellBonusDamage( 6 ) or 0
-    local vttimer = select( 4, GetSpellInfo( 34914 ) ) / 1000
-    local currHaste = ( ( 1.5 / vttimer ) - 1 ) * 100
-    
-    -- Hekili:Debug( "flay_over_blast()["..tostring( rtn ).."]: currentSP["..tostring( currentSP ).."], currHaste["..tostring( currHaste ).."], latency["..tostring( latency ).."] )" )
+-- Settings
+spec:RegisterSetting( "priest_description", nil, {
+    type = "description",
+    name = "Adjust the settings below according to your playstyle preference. It is always recommended that you use a simulator "..
+        "to determine the optimal values for these settings for your character."
+})
 
-    if set_bonus.tier10_4pc then
-        -- Linelo maffs for 4pc T10 with 10ms MF clip delays
-        if (currHaste > 102.68 and currentSP > 1500) or (currentSP > 5493.3 and currHaste < 50) or
-        (currentSP > 5.0219e-04*currHaste^4 - 1.7950e-01*currHaste^3 + 2.4578e+01*currHaste^2 - 1.5651e+03*currHaste^1 + 4.1580e+04) then
-            return false
-        end
-    else
-        --Linelo maffs w/o 4pc T10
-        local latency = select(4, GetNetStats()) / 1000
-        if currentSP >= (-1.0038e-02*latency^2 + 1.7241e-03*latency + 1.1564e-04)*currHaste^4 
-        +  (4.928100*latency^2 - 0.908961*latency - 0.063893)*currHaste^3
-        +  (-878.800*latency^2 + 177.068*latency + 13.641)*currHaste^2
-        +  (6.6990e+04*latency^2 - 1.5253e+04*latency - 1.3489e+03)*currHaste^1
-        +  (-1.8099e+06*latency^2 + 5.0044e+05*latency + 5.3978e+04) then
-            return false
-        end
-    end
-    
-    return true
-end )
+spec:RegisterSetting( "priest_description_footer", nil, {
+    type = "description",
+    name = "\n\n"
+})
 
+spec:RegisterSetting( "general_header", nil, {
+    type = "header",
+    name = "General"
+})
+spec:RegisterSetting( "show_archangel_cooldown", true, {
+    type = "toggle",
+    name = "Show Archangel Cooldown",
+    desc = "When enabled, the cooldown for Archangel will be recommended at 5 stacks of evangelism.",
+    width = "full",
+})
+spec:RegisterSetting( "dots_in_aoe", true, {
+    type = "toggle",
+    name = "|T252997:0|t|T136207:0|t|T135978:0|t Apply DoTs in AOE",
+    desc = "When enabled, the Shadow priority will recommend applying DoTs to your current target in multi-target scenarios before channeling |T237565:0|t Mind Sear.",
+    width = "full",
+} )
+
+spec:RegisterSetting( "general_footer", nil, {
+    type = "description",
+    name = "\n\n"
+})
 
 -- Options
 spec:RegisterOptions( {
@@ -1809,7 +1707,7 @@ spec:RegisterOptions( {
 
 
 -- Packs
-spec:RegisterPack( "Shadow", 20240719, [[Hekili:nRvBVXTns4FlbfNrCIJoVBZ2EPNxd4u3G6a00GkFx(qrLexjU7sy92jrzxdyOF73md17l5k59SBoyKyVIKZmCE75rCPZmNRDSdysUZNMF683E63p7DwZ)2fZp9Do2Y7t5o2Pm)ByBG)iMfb)V9wwqYD4JVpmHfGlppPiZhg6ljFXweLx6DuPh83)mhg2EvHiuEvSZk9QzoS8uUVZNw4yVveeWvZKN77yF9wbim8FSsVkZO0lzn8zFPijU0luKlHHxNKv69Z8BeHclWYYswlcb75B(MspL5w695mbpxw(r8zVNLZdabftM5qtU8JQz95m(pMeTIjFZfK2YHhx69tXsEwTyb9gbgiyqXjsWQcZG1Fp8eqYcqzkZm3knJ7tI61l)75nR8eX6LRkwV2Q9rwWVJj98JmWA9(CYDO2(sswWpu69HKmPqweW7Qtqf3Y1RQuC1U3bl2DD9sBuQUbhQ(RIJr1)br2uvPaxH7AybOIErrAhP9VzrPImHp4eJwLX8NQmVTADUC1Y6kzBjldwEZ0l9Uti3w69lIyicBNkUXGqJGj4MRgNI4hwOD6buBWW8bltMu6DrYpv6LLizQSyulZH8rq5rjORMhZJG0vqT4NaZoNh3tNzfXUQp5ILaNGLMlzjKRr5kDRKX5lNtQ)s(AwrOuP)Cr8Mq(BaF3gUSJLmMgWcivXHnjHsVRReXV1ic14)AkNsDY5)NcEmgQPA08QLvP52CJUXRkVECvTUCl8hrm0XhWr3Rj)IvE)alLNOwIv7tTkspQ(PQ4KQiif0q3Xc43cT1a71nnKTPO36AYiLjf(BTQZflIIWWzvcKGJBjCVa5luxSQmjmr3JrdwnaNLfwLBr721InBhUVYBLkTXs5slswhjfr8ZwOsHJ4GJn2)(Ap6hcz3RI5OhusEX6wIvDv(m(qn(W1WsrnThFLPHY4O2YpBJFWRdHM(ObHM3fPP4(uNbu5OQ9sOlvZ2VvhDdUAmTDsTADe5QwgBWeuiNnEtRb9RzRYRcnxYYUb8N3YI3WHcGiAD(3KB2tHDpYksLU97c4MKTYIw75lNDKk1cKTlVr01JUG2tV8Ww7XQ0GLVC(RqV(CRfVszOwnMOvqrgvKECDv6VqE(2A3b(S3hsFaJmd8qy5h7wMiKTkKRZLScx6jA8evHMFJZu5cTGcxJ1sDYdQT2kgaRskQ6EX)ZueqQVw7xs2jVDqTADQP(rLc)BCrhzFJ8Y6EbqYk1m4GnZHDv6yO70WzGPUZ49nwnboMI5eqgke6fBkkrR(FLd7PlY83sjwak6wE8EkcuzarS)e5rr1lQg0xMCnm4wg2HlhmAHVa7q36K6BeSAf2KPOn9E5IJE5EJMNV4OrCINV44hDp6j2)T1)nOV2LCMSkHM6Qxd3IQzfpeN58f)nWDXzH4ej8FwmtndCCZTadqzJ2HsOwkzyL6lpB(IhEafJ6dN2AExkaM2z5nuoA11T8S71PXGMvGQQrOZo1q71jcCVBrIkhQFxNCfdD)KKqfjkZquVy)Phio0dpmwzgnPATz1wF0DcnDojgCgBCAda6nbEA7rLle3ojKXx6TOLKxZ(c4V1WFbeGgUClgffLq6bEEI0wAw59ZW3tlkLfSduR)9(HC3kHTC2jqDVB)Nrqx5CjcNMdCEL5UcG)ycFukcMgVFZTlmawCqBxvYwVsY7GwK4BtI9TctW(884KInBh6AgGY8e4yom4PJQk7X)ggZnqWp3aGxBR3NCenLprhK2(2Xp94CtNGsNsSXyOqTmFCKOFCLzgOoI7w8T2EIPE)8aq1uk10KlKNNx3K7TgBYnzOSJ63b8S32bBB2cdnEnW7zq)vh7BvyBnhj135yFhllgtCRp8PQZssTJJe55ujtErAAc(se0l1sVjb2usczT3av9wLELExv5iPZCicynWjpfEefCfEBAMijtiPx8ZpSiaFHFUaDM)aaZ49MsVFNIAxj5r5)XjiPmbXqUz2S47B1Af3fizleODjdBLlsXP(vlRv6)KcNvQ5ALik9M9hvH02hnVJMvTjB2r1Pn1tL8g0JIlIwb5eWmYdtKwLF8Qi0HHpaskubKQtVdg0XMvi3Mare7cGVrCro4)PbXtxecBWV(eDqL8ySEoW59WJjH4y3jEINAyMiv98dfp2XgKbupkykD0M8v6DomrhjKVyWwgwncYQlAaUjS3bJWXErxDQR1jD8KJuXx6DM5500cDGt6PMkb6C(wdoN(4sphUg9yPDDmgFDpuk7IPcr8LMwBnkPEp6F5mvqp)Bn45hIOoWKFkif8yctMia0nqzMeaUrxSVEbeW(EAgmrsdD3r7sraTIVBGv0o)9CUutTsgWVl9EneJvy4o2Djj4yxZsyWEhPtmyR)KZJb36F)eAas466mMVASq6gI2HSb51NVGcqd77FgjLhEqP4MzpJad(hd8fJGc1JCIoymj8JnKbpkMhEA27tDhYHP31f9IMm1ENEo5HEH5S4DMHMtsFWm2580hhKLoiMb7(hZH7mHdGFGVO9aFiWcc14SkcbMW8mvuEONt)ZCtM9GHSl1MjtKy4j7RphtZ(qxR(El9LqhIbTMPdmuHBpJ8dQuqDhROAwqf)XDJOljXoV07vT(N5wlOpRCgAorDqgd7qR1Wg9y8hp1554l1qhA2xhmvtaldjpQNaZb)LjOPU6WjtQdu4RevSNmgxVBQGC6(Qh0MmbcD2Pg8snFVa6Op88)TuStAQH2hQUhhrnmgjR586PoAernZJj)Jj8)NeiqtWBKMNYB4(xgbVPXBBh6zZpL2kMWMB)Yn0ThMWxwsxZQpVqLInbLo9o7tK72b99PSlu64n(i8q0ppAwC3jVNVtL2jESI3BG6AQSpYVvj)jzrdjvn97VJbGOMBSJo(N9RZ(F9280UFgCtB275pbDCMRoAmx1TXdpCmn8p7zRt5Q)ShZPJ2O22s8g2vDrQ()X4uT(1Db30wXn1lz3ogJXRq3(ELG2BiNwJzFx5UbLSkgtM6Ym8wZPvBJFL80QZHKY7xAm(vYt7BYkB(X5)o]] )
+spec:RegisterPack( "Shadow", 20250223, [[Hekili:1MvBVTTnq4FlgfWiPnvZ2jUDVyBG2Hc02p0vmLH(HHkjAj6yIO3MevsnGH(TVJKwsuuKuUzDFOn2KNU74Dp3dVt2BU3TEUrik27tlMTy5SflU2z28BMTCPNl9qo2ZnhfEp6o4dPOe4)D3JIYEKT8H4mue7XlZQkcHT(s2xCjjL1btRdGp)EmST72ksm9dPEB1BMBGhphh69jWE7jrryHK4Yqp3B3taLX(hQo4KBuhKTd(EiLKLwhetkPW27YkQdEp(EsmXb8SISDKyWFE2ZQdeUBDWNli4sA9hzR9wujocuuk3nvD56pkK6Zf4FplzlI(Y3WTwz9hfMT0jVahY36fR)PsUbapi5kYU1BR2TZPBjh4VP6FU8ShXf(pMve5dssj0QiCRg0TPfDrstbX3rk4AysvUEXEaLKtkiH(4KTfOq7cNqsJ8lZj3J5bK6G3LsXfnbu2HdsnqQinJc5J4ciYDawbIPeARg)(IpG0reanuucFJjDckf5KhsxTuwMIQuFX38z5)Ry4Y1Om(XHT(dyFCkobY3BwVy0hmlheUG9SuscE1nlNojcZDZ2WfnRkCVtvE7or4haipj9o)8y0Dvy(ELyQ)2S0Qshkbxm)A)BYdxpFu7tNFnZ4xeMLfZIgnrhconYPaNGiPLRND8yoM6GIHd3LtFIwIb)5zYBjSe58RRdGheYO4)PcNgI7WbGp1Ga2fJoCfHL6lQYP(nPWiuX9(4hqP3HbdK4usHYZ1lVY6(sPXtMq6SYdctApLhporgRWJgv5xQQaur4EUrSB51dSSHdhLeEpd2WrFTva(HzvPudkzBmcIWG8q1Zd(3fg50QBTYZ1Oo9pm80P)gsP)GJw1LZe44bgPbY2TQmqweDfen5asBuqUPsdn(HQUL9gD2Lv(b6ZpIG3mFMPdMb84jfMvSvKW3SE(uZWHncK6KlEAp7LCFD16lw8CiD)IfolFUWz7Y8orvfi2sx2K5CHizmC91TOI7WaL5FMr5c0DqlPdRi6kiuK7Sb(tVqFo7e1YMLtnLVBLGZ4qHDaBVhIuT22VH0A6f65KMAJvBZ1ZUu5u1VGsn7idZk7DHg)iXEeRN1v63LvZ7ZYOgHGCJPgFKmNPq3kt7FMMuUmjcJO8JiLdGC2JrX098BhxS0yyu9mO)61bgwQuJvMypQc1ahpowKGlulAOZbLfqlAOLjtksXDyrz1BYENUAjODGwfGrfAAnyPQWd4RcpegdwKhUlxp)Qe0387VgNfPT2ikJw6tGlEZWtnXZPamgSFlWq17uG6)a8TNAnIa(jJBnu11qbQEu0vizZrF6vxAXdNf9IK82BsWYfAJHby3DedJeLgEWgw0AH)0(O6v3C8yxv9aiEB9GN7dcAG2XXw45(iQiLLdAg860CuIjWsiLLWM1bLv55WijNg66o2DZeOjskKaUhWDo1b1bFGkEi(4ejaLpBCl6EeSmgm8bMUjzfekFIHWyy6gqAmHUhx8RqLDWlRd(7)QeZ0eoP8Rxvh84Es4EzPrPh6S6PXqWFlpMesOXD6nsmtcO5oJ(BWSFfnM5wHkG(H)ktPrYlTqYYpsIJLorNujTruE0GVuAvYwCbZWLXzuN6p(HewaJTWRuMCf20ZL)j2y0IgDGp9j(q54u02yCK3B9CdbVgcZip3j1b6AOJp)A3EAqJksOP5ofjg0INNRW39C7mThfaqNHZAYHKyrQd2a5GzDwr9zy26AB26I6aT9ZbAEnOAUbn3PKqQL1bx26z1bRwZv7I6GNdy9qif(c4Bol5F3ypFGoucwST9CLjryVyKNsVNquGYE)i7qvXuDyL(Hp2q2IxNsbjxSX3XC8Ybyj3TDYD7P)gIiimcb2opRRje7P0(uBI8ZIo1OmJROqYx8sQa6oMUVXOUpLEHjGxogU)8RC01dCDad7DEE9jcak7LHzYXb0OTEQ5MBwDWXJaDx7OdNW0)x9pyOuMZ9kdioBpAjvaCBFdt2P50c20bTTca5AX4RsRtF6ezu2gzcXU3)MDuNYJP((4AZ8AiALuipqYq4wdHdQE6vd21jGMiOrgy3ETyYSU7Ggp9Cxk7g6ASJdghP7iEX5ODjRllni6YlK))W313bTSNBQlAXvmd6KwWXzVBA7iSXCzt9sl70M7NwIdxrg7Kwd70wbjY7jxh3sNogPtIZbo1Cb(PMUpJ7OB60N5AV28LjQnMZT2cXnlQ1HS7Ce8Z9UFC(s91D8U)zM)NhsmWBKxHxOCeM1js3lmGrLDtYzqPAO)jr7tt5DmnsfYMgrhfwUrQNSXElung389CCjSF)jyWRN1RdUwdz)oHZhKBU89heXILUQvyfTw2oAY5C4mg1J0rLyMgWuT2ivpVEq1JiB0R8ruJnEVS98(EnZ(lJmFY45xohfJD4Cc(TcB5fR1jO2HsaNgoo2AtUnVPCY7nfiv0D44n1zG7qmHGMbKm8wT1YD3Bmhd)ix2P3UG3hVuJZSG7KEZv28tr1lEQWFocjHf(tdSoMzmu)rKuvZzD1MzkGH)MwF)3Cp0fxPPx0MxNWzvPkAbUIUpdUb89aifXxY7Fd]] )
 
 
 spec:RegisterPackSelector( "discipline", "none", "|T135987:0|t Discipline",
@@ -1843,10 +1741,3 @@ spec:RegisterPackSelector( "shadow", "Shadow", "|T136207:0|t Shadow",
         return tab3 > max( tab1, tab2 )
     end )
 
--- Settings
-spec:RegisterSetting( "dots_in_aoe", true, {
-    type = "toggle",
-    name = "|T252997:0|t|T136207:0|t|T135978:0|t Apply DoTs in AOE",
-    desc = "When enabled, the Shadow priority will recommend applying DoTs to your current target in multi-target scenarios before channeling |T237565:0|t Mind Sear.",
-    width = "full",
-} )

--- a/Cataclysm/Priest.lua
+++ b/Cataclysm/Priest.lua
@@ -6,6 +6,7 @@ local class, state = Hekili.Class, Hekili.State
 
 local spec = Hekili:NewSpecialization( 5 )
 
+
 -- Sets
 spec:RegisterGear( "tier7", 39521, 39530, 39529, 39528, 39523, 40456, 40454, 40459, 40457, 40458 )
 spec:RegisterGear( "tier9", 48755, 48756, 48757, 48758, 48759, 48078, 48077, 48081, 48079, 48080, 48085, 48086, 48082, 48084, 48083 )
@@ -352,7 +353,7 @@ spec:RegisterAuras( {
     -- Chance for the next Mind Blast from the Priest to critically hit increased by 30%.
     mind_spike = { 
         id = 73510,
-        duration = 3600,
+        duration = 12,
         max_stack = 3,
         copy = { 87178, 87179 },
     },
@@ -463,7 +464,7 @@ spec:RegisterAuras( {
         duration = 15,
         max_stack = 1,
     },
-    active_shadow_fiend = {
+    active_shadowfiend = {
         duration = 15,
         max_stack = 1,
 
@@ -1096,7 +1097,7 @@ spec:RegisterAbilities( {
         start = function ()
             applyDebuff( "target", "mind_flay" )
             if talent.pain_and_suffering.rank == 3 then
-                applyDebuff( "shadow_word_pain" )
+                applyDebuff( "target", "shadow_word_pain" )
             end
         end,
 
@@ -1216,11 +1217,10 @@ spec:RegisterAbilities( {
         spendType = "mana",
 
         startsCombat = true,
-        texture = 457655    ,
+        texture = 457655,
 
         handler = function ()
             applyDebuff("target", "mind_spike")
-            variable.mind_spike_count = (variable.mind_spike_count or 0) + 1
         end,
     },
 
@@ -1458,7 +1458,8 @@ spec:RegisterAbilities( {
         toggle = "cooldowns",
 
         handler = function ()
-            applyBuff( "active_shadow_fiend" )
+            applyBuff( "shadowfiend" )
+            applyBuff( "active_shadowfiend" )
         end,
 
         copy = {},
@@ -1637,17 +1638,33 @@ spec:RegisterStateExpr( "shadowfiend_active", function ()
     return active_dot.shadowfiend > 0
 end )
 
---Track how many times Mind Spike has been cast in a row
-spec:RegisterStateExpr( "mind_spike_count", function()
-    if prev_gcd.mind_spike then
-        return variable.mind_spike_count or 0
+-- Tracker for Mind Spike casts with Tier 13 4pc
+spec:RegisterStateTable("mind_spike", {
+    counter = 0
+})
+local cast_events = {
+    SPELL_CAST_SUCCESS = true
+}
+spec:RegisterCombatLogEvent(function(_, subtype, _, sourceGUID, sourceName, _, _, destGUID, destName, destFlags, _, spellID, spellName)
+    if sourceGUID ~= state.GUID then return end
+    if not cast_events[subtype] then return end
+
+    if spellID == 73510 then -- Mind Spike
+        state.mind_spike.counter = state.mind_spike.counter + 1
+    else
+        state.mind_spike.counter = 0
     end
-    return 0
-end )
+end, false)
+spec:RegisterStateExpr("mind_spike_count", function()
+    return state.mind_spike.counter
+end)
+spec:RegisterEvent("PLAYER_REGEN_ENABLED", function()
+    state.mind_spike.counter = 0
+end)
 
 -- Hooks
-spec:RegisterHook( "reset_precast", function ()
-end )
+spec:RegisterHook("reset_precast", function()
+end)
 
 -- Settings
 spec:RegisterSetting( "priest_description", nil, {
@@ -1707,7 +1724,7 @@ spec:RegisterOptions( {
 
 
 -- Packs
-spec:RegisterPack( "Shadow", 20250223, [[Hekili:1MvBVTTnq4FlgfWiPnvZ2jUDVyBG2Hc02p0vmLH(HHkjAj6yIO3MevsnGH(TVJKwsuuKuUzDFOn2KNU74Dp3dVt2BU3TEUrik27tlMTy5SflU2z28BMTCPNl9qo2ZnhfEp6o4dPOe4)D3JIYEKT8H4mue7XlZQkcHT(s2xCjjL1btRdGp)EmST72ksm9dPEB1BMBGhphh69jWE7jrryHK4Yqp3B3taLX(hQo4KBuhKTd(EiLKLwhetkPW27YkQdEp(EsmXb8SISDKyWFE2ZQdeUBDWNli4sA9hzR9wujocuuk3nvD56pkK6Zf4FplzlI(Y3WTwz9hfMT0jVahY36fR)PsUbapi5kYU1BR2TZPBjh4VP6FU8ShXf(pMve5dssj0QiCRg0TPfDrstbX3rk4AysvUEXEaLKtkiH(4KTfOq7cNqsJ8lZj3J5bK6G3LsXfnbu2HdsnqQinJc5J4ciYDawbIPeARg)(IpG0reanuucFJjDckf5KhsxTuwMIQuFX38z5)Ry4Y1Om(XHT(dyFCkobY3BwVy0hmlheUG9SuscE1nlNojcZDZ2WfnRkCVtvE7or4haipj9o)8y0Dvy(ELyQ)2S0Qshkbxm)A)BYdxpFu7tNFnZ4xeMLfZIgnrhconYPaNGiPLRND8yoM6GIHd3LtFIwIb)5zYBjSe58RRdGheYO4)PcNgI7WbGp1Ga2fJoCfHL6lQYP(nPWiuX9(4hqP3HbdK4usHYZ1lVY6(sPXtMq6SYdctApLhporgRWJgv5xQQaur4EUrSB51dSSHdhLeEpd2WrFTva(HzvPudkzBmcIWG8q1Zd(3fg50QBTYZ1Oo9pm80P)gsP)GJw1LZe44bgPbY2TQmqweDfen5asBuqUPsdn(HQUL9gD2Lv(b6ZpIG3mFMPdMb84jfMvSvKW3SE(uZWHncK6KlEAp7LCFD16lw8CiD)IfolFUWz7Y8orvfi2sx2K5CHizmC91TOI7WaL5FMr5c0DqlPdRi6kiuK7Sb(tVqFo7e1YMLtnLVBLGZ4qHDaBVhIuT22VH0A6f65KMAJvBZ1ZUu5u1VGsn7idZk7DHg)iXEeRN1v63LvZ7ZYOgHGCJPgFKmNPq3kt7FMMuUmjcJO8JiLdGC2JrX098BhxS0yyu9mO)61bgwQuJvMypQc1ahpowKGlulAOZbLfqlAOLjtksXDyrz1BYENUAjODGwfGrfAAnyPQWd4RcpegdwKhUlxp)Qe0387VgNfPT2ikJw6tGlEZWtnXZPamgSFlWq17uG6)a8TNAnIa(jJBnu11qbQEu0vizZrF6vxAXdNf9IK82BsWYfAJHby3DedJeLgEWgw0AH)0(O6v3C8yxv9aiEB9GN7dcAG2XXw45(iQiLLdAg860CuIjWsiLLWM1bLv55WijNg66o2DZeOjskKaUhWDo1b1bFGkEi(4ejaLpBCl6EeSmgm8bMUjzfekFIHWyy6gqAmHUhx8RqLDWlRd(7)QeZ0eoP8Rxvh84Es4EzPrPh6S6PXqWFlpMesOXD6nsmtcO5oJ(BWSFfnM5wHkG(H)ktPrYlTqYYpsIJLorNujTruE0GVuAvYwCbZWLXzuN6p(HewaJTWRuMCf20ZL)j2y0IgDGp9j(q54u02yCK3B9CdbVgcZip3j1b6AOJp)A3EAqJksOP5ofjg0INNRW39C7mThfaqNHZAYHKyrQd2a5GzDwr9zy26AB26I6aT9ZbAEnOAUbn3PKqQL1bx26z1bRwZv7I6GNdy9qif(c4Bol5F3ypFGoucwST9CLjryVyKNsVNquGYE)i7qvXuDyL(Hp2q2IxNsbjxSX3XC8Ybyj3TDYD7P)gIiimcb2opRRje7P0(uBI8ZIo1OmJROqYx8sQa6oMUVXOUpLEHjGxogU)8RC01dCDad7DEE9jcak7LHzYXb0OTEQ5MBwDWXJaDx7OdNW0)x9pyOuMZ9kdioBpAjvaCBFdt2P50c20bTTca5AX4RsRtF6ezu2gzcXU3)MDuNYJP((4AZ8AiALuipqYq4wdHdQE6vd21jGMiOrgy3ETyYSU7Ggp9Cxk7g6ASJdghP7iEX5ODjRllni6YlK))W313bTSNBQlAXvmd6KwWXzVBA7iSXCzt9sl70M7NwIdxrg7Kwd70wbjY7jxh3sNogPtIZbo1Cb(PMUpJ7OB60N5AV28LjQnMZT2cXnlQ1HS7Ce8Z9UFC(s91D8U)zM)NhsmWBKxHxOCeM1js3lmGrLDtYzqPAO)jr7tt5DmnsfYMgrhfwUrQNSXElung389CCjSF)jyWRN1RdUwdz)oHZhKBU89heXILUQvyfTw2oAY5C4mg1J0rLyMgWuT2ivpVEq1JiB0R8ruJnEVS98(EnZ(lJmFY45xohfJD4Cc(TcB5fR1jO2HsaNgoo2AtUnVPCY7nfiv0D44n1zG7qmHGMbKm8wT1YD3Bmhd)ix2P3UG3hVuJZSG7KEZv28tr1lEQWFocjHf(tdSoMzmu)rKuvZzD1MzkGH)MwF)3Cp0fxPPx0MxNWzvPkAbUIUpdUb89aifXxY7Fd]] )
+spec:RegisterPack( "Shadow", 20250224, [[Hekili:1I1BVTTnt8plgfWWPnvZw2QDDZ2aTdfOnViOykd9fdvs0s0Xer)Buuj1ag6Z(oszjrjtrPK98GH1wtD8UJ397(X7OZcN7CSdqmSZTMZnTMBAUYyXQLlnFNJn7yk2Xof5)a6E4FeJIG)0(aki5j(Yhdtqb8TNLKt9Hp99KVBtIYk8Mw4b)7VGHpBVlNeY(ASZovMX069W2tX(o3A5yFGeeGlLeN57yF3bcOm()Jk8o7gfEj7HF7ZijXfEHKmg859j0cVVGFGesmapJMSNec(ZREvHxP7w49nkbNXkUHV2Nqz4aqrXc3SRlxCtPuFJI)JKODi2B)OWAzf3uA2mJuk2x8P3S5xYega8GORj73SlF)EJMLmG)ow9(stEctDFkHg4csYiS8aCTgu9rn6IehdIVNqfAysEQAXEefLsOeFxC0okYxVWrK4a3SuYdyraPW7ZXmmTkGYpCqQbsfXjmiFesHi3ryfiMsy1A85fFaPdiaAGMb)IlDekgzK6ZwBjldnp2T8xU88)1CC5guI44Wx)rSloghb57TBmhCJSfl5BCMFssi3BQ8ocooWGIJqK4SnZpDkfZmqHGYpDs(qielp9QPzyM7UK48mdgbtxS0DvQ)MfdAEoMueEVJWJUlww4bBecZ4)jhh7JBsoGJwLw2hIoEnHNpO5Pm3Q4AaI(Gl(ru89yWargzmOMz7gRR1kWARPtQpCDnN0PuGw6vqe1)GqV6n2glLhODHiiGa7eqGp6EVFGC4fI9vRwBLrgwye)h4OabyQgq76NKhZ2Uz10AflJ2hL)vBqLYl0KkJUEv)6VI4XMeFFiq0DhIEpgkU(Zegsq3vVZm2fgAsawe1BwfqLtRwTmAwsOKciA5VfGFe4VbB6MgIUpV1(Qzmyj5(hmK5kYAi)A0RSNOYMmseg0LBabVDXCvhOEG2NvwcDxfQEX0bX8tM9Y27vc)C9MzMVgs1VX0W61LoAtw3iiNkskxPmIOTGri3ORxMotDU4m10wRP9LhRLqqoXGVa2(aejQTTBfP30zZuZFnvhT42pm)QtNMOENDdmTRJ6MyUaz1(0kyO1ghwR(RCcaxE28k9yVUbpzd2xGDDFFFSgvUcjaJyIJjtu1BCaJczhex(zA1BOS7Pq9TN6Q04vj6dSqjWPtdfkecvJvACqzbuIiQjWKIuchUKl8JjFwfbiCBFTcWiQIB(T6k8fuv(h9dblkc3zBwCDe6NUTxtqIux6eKWYCjWv4j4P9rX1bzCX3RrgD9UoW9)h4BVSYKPNHFY42nQ3tfdy3JIQsjDo6lV8sjEyuumsYRVPbn3LnegGF1rimXtS)rDyrTf(tBJQxV60PMQ6lG411do2pwsdupT1sh7Nq0yEoOAUQZJjvoGvejld(yHxwEAkmXX5zQUhmmKXl8yqc4ba3zu4v49vw5MetlebxiWNMIDablJbdFKRBscLWede4hcdVasJjSdy6Vbv2EVTW7V)Rmmxt4OSFCDH3thi(hKLgfFSXQNNYa)Z0qIpHf2O3GYroan3y0FhgTJwzM7kvb0z9p4knqEjtjl)ejmu6eDwLSkrfrdXsX5r7WuUHZctygf381iEaJVGvNbtHp6yJYzhsGmYxaalYXw8b(qZq3FWFDRy(BCmAxioW5to2(Wjac5i(GZ91uqH3AHXGzwNah7QomCSLHX6ua0Jd4ycx1XUUkOCSBkjTC9EgiXHbGQED62(tLjK6DGV9LVOZ8g4m3OY6Ey4kCvVku18efENoXrlDNPOtirqKW1UvVAVB39fEBbVCLiZOy0cLX825SkUhUDF3WNkj9O23F)ZW3bq1Qo6P0Tb98RC9OWes6MBpabThLhYuHS7agGP)7a4EgpWWfyMopPGEqAffAzDuJN10(KEuABs5YKUzJA6mNFznVB5RNbe16bSZk801YTOmy(zeC9OfIFkhho)QefExjWIQ6qxOPfJZR5CvkkegZwfWqMaYw(0sJG0RBYuf0rBcwOLEFdTg9Pse9PEGFlpTrbnp8M(SANT19H4QdUkk(6wHXrqAdHxGoBHXB6rqreSDCUPNgq9YnFYTU9fTK6yBj7gQA5taghOVjrr5G9pRklDr0v0N6)p8D19wl7591FTqlx2JDjhI((S1JWgYL7RlBzNU)oTL4i7iJ(liVSh8(UOQ)l76Vf8rdNGRkl8Ed0vwz74pZ7H7)o0lAzxynZYwZ6whUw0zaNPU19plSux3jMlq9vVLT43HxiBaM1j1HQwpryvxKdeLN0pi5cjU4rd7RPcTTroGd1U4bcJZ1qFneL(Sw3E28sHLLLleguxRPCPSQUSTSmF9gHAnl8EDd(Z0Ws87shvXRjc6yeGtL(6GVQ5G3qnCJ7duORPXDrKz2GeOBReDqwRTsr8HEDZkJptxNqcH036fyZpmxyuEv8e9Atkr2AwL(j6gpzz)msdhIhZDuxnyjwN7yROPgWN(VDj0y8lvxp9HNn)9amYGbhX0q3UOFY423amVVrqwOLHCu5Ab1dhUoMuqTWAEj3gbvsvX96(5ABL66C0BD3q1)58V]] )
 
 
 spec:RegisterPackSelector( "discipline", "none", "|T135987:0|t Discipline",

--- a/Cataclysm/Warrior.lua
+++ b/Cataclysm/Warrior.lua
@@ -30,8 +30,6 @@ local function rage_amount( isOffhand )
 end
 
 
-
-
 spec:RegisterResource( Enum.PowerType.Rage, {
     anger_management = {
         talent = "anger_management",
@@ -597,8 +595,7 @@ spec:RegisterAuras( {
         friendly = true,
         dot = "buff",
     },
-
-
+    
     -- Aliases / polybuffs.
     stance = {
         alias = { "battle_stance", "defensive_stance", "berserker_stance" },
@@ -609,7 +606,7 @@ spec:RegisterAuras( {
         alias = { "my_battle_shout", "my_commanding_shout" },
         aliasMode = "first",
         aliasType = "buff"
-    }
+    },
 } )
 
 
@@ -915,7 +912,6 @@ end)
 
 -- Abilities
 spec:RegisterAbilities( {
-    
     -- The warrior shouts, increasing attack power of all raid and party members within 30 yards by 550.  Lasts 2 min.
     battle_shout = {
         id = 6673,
@@ -948,7 +944,6 @@ spec:RegisterAbilities( {
         copy = { 6673, 2048, 25289, 11551, 11550, 11549, 6192, 5242 }
     },
 
-
     -- A balanced combat stance that increases the armor penetration of all of your attacks by 10%.
     battle_stance = {
         id = 2457,
@@ -970,7 +965,6 @@ spec:RegisterAbilities( {
         end
     },
 
-
     -- The warrior enters a berserker rage, removing and granting immunity to Fear, Sap and Incapacitate effects and generating extra rage when taking damage.  Lasts 10 sec.
     berserker_rage = {
         id = 18499,
@@ -990,7 +984,6 @@ spec:RegisterAbilities( {
             applyBuff( "berserker_rage" )
         end
     },
-
 
     -- An aggressive stance.  Critical hit chance is increased by 3% and all damage taken is increased by 5%.
     berserker_stance = {
@@ -1014,7 +1007,6 @@ spec:RegisterAbilities( {
         end
     },
 
-
     -- Instantly Whirlwind up to 4 nearby targets and for the next 6 sec you will perform a whirlwind attack every 1 sec.  While under the effects of Bladestorm, you can move but cannot perform any other abilities but you do not feel pity or remorse or fear and you cannot be stopped unless killed.
     bladestorm = {
         id = 46924,
@@ -1037,7 +1029,6 @@ spec:RegisterAbilities( {
         end,
     },
 
-
     -- Instantly attack the target causing 1092 damage.  In addition, the next 3 successful melee attacks will restore 1% of max health.  This effect lasts 8 sec.  Damage is based on your attack power.
     bloodthirst = {
         id = 23881,
@@ -1056,7 +1047,6 @@ spec:RegisterAbilities( {
             applyBuff( "bloodthirst", nil, 5 )
         end,
     },
-
 
     -- Forces all enemies within 10 yards to focus attacks on you for 6 sec.
     challenging_shout = {
@@ -1077,7 +1067,6 @@ spec:RegisterAbilities( {
             applyDebuff( "target", "challenging_shout" )
         end
     },
-
 
     -- Charge an enemy, generate 15 rage, and stun it for 1.50 sec.  Cannot be used in combat.
     charge = {
@@ -1438,7 +1427,6 @@ spec:RegisterAbilities( {
         copy = { 78, 284, 285, 1608, 11564, 11565, 11566, 11567, 25286, 29707, 30324 }
     },
 
-
     -- Throws your weapon at the enemy causing 1104 damage (based on attack power).  This ability causes high threat.
     heroic_throw = {
         id = 57755,
@@ -1504,7 +1492,6 @@ spec:RegisterAbilities( {
         end,
     },
 
-
     -- Run at high speed towards a party member, intercepting the next melee or ranged attack made against them as well as reducing their total threat by 10%.
     intervene = {
         id = 3411,
@@ -1522,12 +1509,11 @@ spec:RegisterAbilities( {
             if talent.warbringer.enabled then return end
             return "defensive_stance"
         end,
-    
+
         handler = function()
             active_dot.intervene = 1
         end
     },
-
 
     -- The warrior shouts, causing up to 5 enemies within 8 yards to cower in fear.  The targeted enemy will be unable to move while cowering.  Lasts 8 sec.
     intimidating_shout = {
@@ -1546,7 +1532,6 @@ spec:RegisterAbilities( {
             applyDebuff( "target", "intimidating_shout" )
         end
     },
-
 
     -- When activated, this ability temporarily grants you 30% of your maximum health for 20 sec.  After the effect expires, the health is lost.
     last_stand = {
@@ -1589,7 +1574,6 @@ spec:RegisterAbilities( {
         end,
     },
 
-
     -- Instantly overpower the enemy, causing weapon damage.  Only useable after the target dodges.  The Overpower cannot be blocked, dodged or parried.
     overpower = {
         id = 7384,
@@ -1615,7 +1599,6 @@ spec:RegisterAbilities( {
         end,
     },
 
-
     -- Causes all enemies within 10 yards to be Dazed, reducing movement speed by 50% for 6 sec.
     piercing_howl = {
         id = 12323,
@@ -1634,7 +1617,6 @@ spec:RegisterAbilities( {
             applyDebuff( "target", "piercing_howl" )
         end
     },
-
 
     -- Pummel the target, interrupting spellcasting and preventing any spell in that school from being cast for 4 sec.
     pummel = {
@@ -1671,10 +1653,11 @@ spec:RegisterAbilities( {
         talent = "raging_blow",
         startsCombat = true,
 
-        buff = "enrage",
+        usable = function()
+            return buff.enrage.up or buff.death_wish.up or buff.berserker_rage.up, "requires any enrage effect"
+        end,
 
         handler = function()
-            removeBuff( "enrage" )
         end,
     },
 
@@ -1721,7 +1704,6 @@ spec:RegisterAbilities( {
         end,
     },
 
-
     -- Wounds the target causing them to bleed for 380 damage plus an additional 780 (based on weapon damage) over 15 sec.  If used while your target is above 75% health, Rend does 35% more damage.
     rend = {
         id = 772,
@@ -1741,7 +1723,6 @@ spec:RegisterAbilities( {
             applyDebuff( "target", "rend" )
         end,
     },
-
 
     -- Instantly counterattack any enemy that strikes you in melee for 12 sec.  Melee attacks made from behind cannot be counterattacked.  A maximum of 20 attacks will cause retaliation.
     retaliation = {
@@ -1787,7 +1768,6 @@ spec:RegisterAbilities( {
             removeBuff( "revenge_usable" )
         end,
     },
-
 
     -- Throws your weapon at the enemy causing 1104 damage (based on attack power), reducing the armor on the target by 20% for 10 sec or removing any invulnerabilities.
     shattering_throw = {
@@ -1854,7 +1834,6 @@ spec:RegisterAbilities( {
         end,
     },
 
-
    -- Reduces all damage taken by 40% for 12 sec.
     shield_wall = {
         id = 871,
@@ -1874,7 +1853,6 @@ spec:RegisterAbilities( {
             applyBuff( "shield_wall" )
         end
     },
-
 
     -- Sends a wave of force in front of the warrior, causing 1638 damage (based on attack power) and stunning all enemy targets within 10 yards in a frontal cone for 4 sec.
     shockwave = {
@@ -1896,7 +1874,6 @@ spec:RegisterAbilities( {
             if not target.is_boss then interrupt() end
         end,
     },
-
 
     -- Slams the opponent, causing weapon damage plus 250.
     slam = {
@@ -2088,7 +2065,6 @@ spec:RegisterAbilities( {
             gain( 0.2 * health.max, "health" )
         end
     },
-
 
     vigilance = {
         id = 50720,


### PR DESCRIPTION
### Changes Made for Shadow Priest

**Lua:**
- Added support for tracking Tier 13 set bonus with `set_bonus.tier13`
- Added support for Shadowfiend duration tracking with `shadowfiend_active` and `shadowfiend_remains`
- Added tracking for counting Mind Spike multiple times in a row to support T13 rotation changes with `mind_spike_count`
- Removed several old abilities that no longer exist (appeared to be remnants from Wrath)
- Added option to hide Archangel separate from the Cooldowns toggle

**APL:**
- Added new T13 priority list
> Explenation:
The T13 set bonus modifies the optimal rotation significantly. Community suggestions expect that the priest cast a mix of Mind Blast and Mind Spike while weaving in Mind Flays to maintain Dark Evangelism stacks while Shadowfiend is active.
- Cleaned up comment styling

### Changes Made for Retribution Paladin

**Lua:**
- Added support for tracking Tier 13 set bonus with `set_bonus.tier13`
- Adjusted the Judgement spell to properly track Holy Power being added with the Tier 13 set bonus

### Changes Made for Warrior

**Lua:**
- Updated Raging Blow to track if buffs Enrage, Berserker Rage, or Death Wish are present.
