### PR TITLE
Potential Fix operator precedence in timeToInterrupt function

### DIFF
--- a/State.lua
+++ b/State.lua
@@ -1213,7 +1213,7 @@ local function timeToInterrupt()
     local casting = state.debuff.casting
     if casting.down or casting.v2 == 1 then return 3600 end
     if casting.v3 == 1 then return 0 end
-    return max( 0, casting.remains - (Hekili.DB.profile.toggles.interrupts.castRemainingThreshold or 0.25) )
+    return max( 0, casting.remains - ( Hekili.DB.profile.toggles.interrupts.castRemainingThreshold or 0.25 ) )
 end
 state.timeToInterrupt = timeToInterrupt
 

--- a/State.lua
+++ b/State.lua
@@ -1213,7 +1213,7 @@ local function timeToInterrupt()
     local casting = state.debuff.casting
     if casting.down or casting.v2 == 1 then return 3600 end
     if casting.v3 == 1 then return 0 end
-    return max( 0, casting.remains - Hekili.DB.profile.toggles.interrupts.castRemainingThreshold or 0.25 )
+    return max( 0, casting.remains - (Hekili.DB.profile.toggles.interrupts.castRemainingThreshold or 0.25) )
 end
 state.timeToInterrupt = timeToInterrupt
 


### PR DESCRIPTION
- Added parentheses around the OR condition in timeToInterrupt function to fix operator precedence issue.