### PR TITLE
Helper Function: spreadActiveDots( aura, count, limit, target )

### DIFF
--- a/State.lua
+++ b/State.lua
@@ -1189,9 +1189,36 @@ local function removeDebuffStack( unit, aura, stacks )
 
     return removed
 end
-
 state.removeDebuffStack = removeDebuffStack
 
+local function spreadActiveDots( aura, count, limit, target )
+    if not aura or not count or count < 1 then
+        Error( "Invalid arguments passed to spreadActiveDots: aura='%s', count='%s'.\n\n%s", tostring( aura ), tostring( count ), debugstack() )
+        return 0
+    end
+
+    limit = limit or state.true_active_enemies
+    target = target or false
+
+    state.active_dot[ aura ] = state.active_dot[ aura ] or 0
+
+    local auraInfo = class.auras[ aura ]
+    local isFriendly = auraInfo and auraInfo.friendly
+
+    if not isFriendly then
+        limit = min( limit, state.true_active_enemies )
+    end
+
+    if target then
+        state.applyDebuff( "target", aura )
+    end
+
+    state.active_dot[ aura ] = min( state.active_dot[ aura ] + count, limit )
+
+    -- Return the new number of active dots for the aura.
+    return state.active_dot[ aura ]
+end
+state.spreadActiveDots = spreadActiveDots
 
 local function setStance( stance )
     for k in pairs( state.stance ) do


### PR DESCRIPTION
Another helper function to reduce repeated code. This function allows you to spread dots. :)

Resubmitting on a dedicated branch because my branches are a mess right now and trying to clean them up.

## Features
- Apply multiple counts of the same dot (technically, any debuff I think) with cleaner code, built in checks
- Parameters
  - aura: `"flame_shock"`, `"shadow_word_pain"` .. same syntax as used in other related functions like `applyBuff()`
  - count: The amount of dots you want to spread
    - I could also make this optional and default it to 1?
  - limit: The maximum number of dots. 
    - If not supplied or nil, this will default to true_active_enemies. 
    - Friendly dots can override this since they are not capped by enemies. 
    - However, for actual debuffs a limit smaller than true_active_enemies can be supplied and will be respected
  - target: Boolean
    - whether or not this should apply the debuff to your target. 
    - Sometimes this is true, sometimes it isn't. 
    - Parameter is optional, defaults to false if unsupplied or nil.
- Works with friendly HoTs (given that they are defined properly in their specs aura registration)
- Returns the new number of active_dots in case you want to use it
- No need to sit and try to remember setting the limits using `min()` every time you add active_dots

### Possible gaps?
- Do we need to account for providing the # of stacks if we choose to supply target=true? Or in that case would we just allow target=false and do the `applyDebuff()` separately (hence my comment sometimes its true, sometimes it isnt)?
## Commented Code
```LUA
local function spreadActiveDots( aura, count, limit, target )
    if not aura or not count or count < 1 then
        Error( "Invalid arguments passed to spreadActiveDots: aura='%s', count='%s'.\n\n%s", tostring( aura ), tostring( count ), debugstack() )
        return 0
    end

    -- Default limit to true_active_enemies if not provided.
    limit = limit or state.true_active_enemies
    target = target or false

    -- Ensure the active_dot table exists for the aura.
    state.active_dot[ aura ] = state.active_dot[ aura ] or 0

    -- Check if the aura is friendly (this is how HoTs are represented)
    local auraInfo = class.auras[ aura ]
    local isFriendly = auraInfo and auraInfo.friendly

    -- Apply the hard cap by true_active_enemies if the aura is not friendly.
    if not isFriendly then
        limit = min( limit, state.true_active_enemies )
    end

    -- If the target parameter is true, apply or refresh the debuff on the target.
    if target then
        state.applyDebuff( "target", aura )
    end

    -- Spread the remaining count across additional targets, respecting the limit.
    state.active_dot[ aura ] = min( state.active_dot[ aura ] + count, limit )

    -- Return the new number of active dots for the aura.
    return state.active_dot[ aura ]
end
state.spreadActiveDots = spreadActiveDots
```

## Real Examples

### Shadow Priest Shadowcrash
```LUA
        impact = function ()
            removeBuff( "deaths_torment" )
            if talent.whispering_shadows.enabled then
                applyDebuff( "target", "vampiric_touch" )
                active_dot.vampiric_touch = min( active_enemies, active_dot.vampiric_touch + 7 )
                if talent.misery.enabled then
                    applyDebuff( "target", "shadow_word_pain" )
                    active_dot.shadow_word_pain = min( active_enemies, active_dot.shadow_word_pain + 7 )
                end
            end
        end,
```
```LUA
        impact = function ()
            removeBuff( "deaths_torment" )
            if talent.whispering_shadows.enabled then
                spreadActiveDots( "vampiric_touch", 7, nil, true )
                if talent.misery.enabled then
                     spreadActiveDots( "shadow_word_pain", 7, nil, true )
                end
            end
        end,
```

### Unholy DK Clawing Shadows, Vile Contagion
#### Clawing Shadows
```LUA
            if debuff.undeath.up then
                applyDebuff( "target", "undeath", debuff.undeath.stack + 1 )
                active_dot.undeath = min( active_enemies, active_dot.undeath + 1 )
            end
```

```LUA
            if debuff.undeath.up then
                applyDebuff( "target", "undeath", debuff.undeath.stack + 1 )
                spreadActiveDots( "undeath", 1 )
            end
```
#### Vile Contagion
```LUA
        handler = function ()
            if debuff.festering_wound.up then
                active_dot.festering_wound = min( active_enemies, active_dot.festering_wound + 7 )
            end
        end,
```
```LUA
        handler = function ()
            if debuff.festering_wound.up then
                spreadActiveDots( "festering_wound", 7 )
            end
        end,
```

### Fire Mage Fire Blast
```LUA
            if buff.lit_fuse.up then
                removeBuff( "lit_fuse" )
                active_dot.living_bomb = min( active_dot.living_bomb + ( talent.blast_zone.enabled and 3 or 1 ), true_active_enemies )
            end
```
```LUA
            if buff.lit_fuse.up then
                removeBuff( "lit_fuse" )
                spreadActiveDots( "living_bomb", talent.blast_zone.enabled and 3 or 1 )
            end
```
### Disc Priest Atonements
```LUA
            if buff.atonement.down then
                applyBuff( "atonement", ( ( talent.enduring_luminescence.enabled and 0.7 or 0.6 ) * class.auras.atonement.duration ) + ( buff.radiant_providence.up and 3 or 0 ) )
                active_dot.atonement = min( active_dot.atonement + 3, group_members )
            else
                active_dot.atonement = min( active_dot.atonement + 4, group_members )
            end
```
```LUA
            if buff.atonement.down then
                applyBuff( "atonement", ( ( talent.enduring_luminescence.enabled and 0.7 or 0.6 ) * class.auras.atonement.duration ) + ( buff.radiant_providence.up and 3 or 0 ) )
                spreadActiveDots( "atonement", 3, group_members )
            else
                spreadActiveDots( "atonement", 4, group_members )
            end
```