### PR TITLE
Helper Function: auraDuration( aura, duration, unit )

### DIFF
--- a/State.lua
+++ b/State.lua
@@ -1192,6 +1192,47 @@ end
 
 state.removeDebuffStack = removeDebuffStack
 
+-- Modify aura remaining duration function. Extends or reduces the duration of an aura. 
+  local function auraDuration( aura, duration, unit )
+    if not aura then
+        Error( "Invalid arguments passed to auraDuration: '%s'.\n\n%s", tostring( aura ), debugstack() )
+        return 0
+    end
+
+    duration = duration or 1
+    if duration == 0 then return 0 end
+    unit = unit or "target"
+
+    -- Buff handling.
+    local b = state.buff[ aura ]
+    if b and b.remains > 0 then
+        b.expires = b.expires + duration
+
+        if b.remains <= 0 then
+            state.removeBuff( aura )
+            return -1
+        end
+
+        return 1
+    end
+
+    -- Debuff handling.
+    local d = state.debuff[ aura ]
+    if d and d.remains > 0 then
+        d.expires = d.expires + duration
+
+        if d.remains <= 0 then
+            state.removeDebuff( unit, aura )
+            return -1
+        end
+
+        return 1
+    end
+
+    return 0
+end
+
+state.auraDuration = auraDuration
 
 local function setStance( stance )
     for k in pairs( state.stance ) do


### PR DESCRIPTION
Another helper function for changing duration of buffs/debuffs, whether extended (very common) or reduced (like warlock arts or devastation evoker fire breath)

- Previous discussion found here: https://github.com/Hekili/hekili/pull/4114
- Opened on a new dedicated branch while cleaning up my repository.

### Features
- Buffs and debuffs
  - Checks buff table first
  - if not found then will check debuffs
  - If neither are found, return 0
- Extensions and reductions (via negative values)
- `removeBuff()` if extension brings an aura to 0 or less (it checks `.remains`)
- Useful return values
  - `1`: Aura was modified successfully (it was up, and the extension was applied, and the aura is not removed because of it)
    - This could instead return `aura.remains` as it would always be a positive value? Would pass all the same test cases as `1`, but maybe add additional functionality?
  - `0`: No operations were done, most likely due to aura not being up or the function call supplied a `0` in the duration parameter
  - `-1`: Aura was negatively extended, and will be removed due to it
- Instead of passing the table `buff.buff_name`, we should stick with passing the aura name as a string
  - While this is technically more CPU work, it keeps naming conventions in-line with all other similar functions such as `applyBuff()` and `addStack()`
  - If you are concerned with checking both tables, I could split this into 2 functions, `buffDuration( aura, duration )` and `debuffDuration( aura, duration, unit )`
- `Unit` parameter is optional, will default to `"target"`. It is not considered when checking buffs.

### Fully Commented Code
```LUA
-- Modify aura remaining duration function.
-- Extends or reduces the duration of an aura. 
-- Returns:
  --  1: Successfully extended (positive or negative value).
  --  0: Aura not active, no operations performed.
  -- -1: Aura removed due to a negative extension that reduced its duration to 0 or less.
local function auraDuration( aura, duration, unit )
    if not aura then
        Error( "Invalid arguments passed to auraDuration: '%s'.\n\n%s", tostring( aura ), debugstack() )
        return 0
    end

    -- Default parameters.
    duration = duration or 1 -- Defaults to +1 second if no value supplied.
    if duration == 0 then return 0 end -- Don't perform operations for a zero duration.
    unit = unit or "target" -- Default to "target" for debuffs if no unit is specified.

    -- Buff handling.
    local b = state.buff[ aura ]
    if b and b.remains > 0 then
        -- Modify the buff's duration.
        b.expires = b.expires + duration

        if b.remains <= 0 then
            state.removeBuff( aura )
            return -1 -- Buff removed.
        end

        return 1 -- Buff extended successfully.
    end

    -- Debuff handling.
    local d = state.debuff[ aura ]
    if d and d.remains > 0 then
        -- Modify the debuff's duration.
        d.expires = d.expires + duration

        if d.remains <= 0 then
            state.removeDebuff( unit, aura )
            return -1 -- Debuff removed.
        end

        return 1 -- Debuff extended successfully.
    end

    -- Aura not active (neither buff nor debuff).
    return 0
end

state.auraDuration = auraDuration
```


### Real Use Cases

#### Marksmanship Hunter

```LUA
        if tensileTrueshotExtension == 4 then
            -- If consuming 2 stacks @ 4, it still caps at 5. Don't roll over to 6
            buff.trueshot.expires = buff.trueshot.expires + 1
        else
            buff.trueshot.expires = buff.trueshot.expires + count
        end
```
```LUA
        if tensileTrueshotExtension == 4 then
            -- If consuming 2 stacks @ 4, it still caps at 5. Don't roll over to 6
            auraDuration( "trueshot" )
        else
           auraDuration( "trueshot", count )
        end
```

#### Devastation Evoker
```LUA
if talent.consume_flame.enabled and debuff.fire_breath.up then debuff.fire_breath.expires = debuff.fire_breath.expires - 2 end
```
```LUA
if talent.consume_flame.enabled then auraDuration( "fire_breath", -2, "target" ) end
```
This would also work due to `"target"` default
```LUA
if talent.consume_flame.enabled then auraDuration( "fire_breath", -2 ) end
```

#### Shadow Priest
```LUA
            if talent.expiation.enabled then
                    if debuff.shadow_word_pain.remains <= 6 then
                        removeDebuff( "shadow_word_pain" )
                    else
                        debuff.shadow_word_pain.expires = debuff.shadow_word_pain.expires - 6
                    end
            end
```
```LUA
 if talent.expiation.enabled then auraDuration( "shadow_word_pain", -6 )
```

#### Havoc Demon Hunter
(yes I know the actual code here has changed since I wrote the example, hopefully it still illustrates)
```LUA
local TriggerDemonic = setfenv( function( )

    if buff.metamorphosis.up then
        buff.metamorphosis.duration = buff.metamorphosis.duration + 7
        buff.metamorphosis.expires = buff.metamorphosis.expires + 7
    else
        applyBuff( "metamorphosis", 7 )
        if talent.inner_demon.enabled then
            applyBuff( "inner_demon" )
        end
        stat.haste = stat.haste + 10
        -- Fel-Scarred
        if talent.demonsurge.enabled then
            applyBuff( "demonsurge_annihilation", buff.metamorphosis.remains )
            applyBuff( "demonsurge_death_sweep", buff.metamorphosis.remains )
        end
    end

end, state )
```
```LUA
local TriggerDemonic = setfenv( function( )

    local transform = auraDuration( "metamorphosis", 7 )

    if transform == 0 then
        applyBuff( "metamorphosis", 7 )
        if talent.inner_demon.enabled then
            applyBuff( "inner_demon" )
        end
        stat.haste = stat.haste + 10
        -- Fel-Scarred
        if talent.demonsurge.enabled then
            applyBuff( "demonsurge_annihilation", buff.metamorphosis.remains )
            applyBuff( "demonsurge_death_sweep", buff.metamorphosis.remains )
        end
    end

end, state )
```