### PR TITLE
Pack Leader Buff Names, Rain of Fire

### DIFF
--- a/TheWarWithin/HunterBeastMastery.lua
+++ b/TheWarWithin/HunterBeastMastery.lua
@@ -787,17 +787,17 @@ spec:RegisterAuras( {
         duration = function() return 30 - ( 5 * talent.better_together.rank ) end,
         max_stack = 1,
     },
-    howl_of_the_pack_leader_bear_ready = {
+    howl_of_the_pack_leader_bear = {
         id = 472325,
         duration = function() return 30 - ( 5 * talent.better_together.rank ) end,
         max_stack = 1,
     },
-    howl_of_the_pack_leader_boar_ready = {
+    howl_of_the_pack_leader_boar = {
         id = 472324,
         duration = function() return 30 - ( 5 * talent.better_together.rank ) end,
         max_stack = 1,
     },
-    howl_of_the_pack_leader_wyvern_ready = {
+    howl_of_the_pack_leader_wyvern = {
         id = 471878,
         duration = function() return 30 - ( 5 * talent.better_together.rank ) end,
         max_stack = 1,
@@ -1297,9 +1297,9 @@ local CallOfTheWildCDR = setfenv( function()
 end, state )
 
 local pack_leader_buff_cycle = {
-    "howl_of_the_pack_leader_wyvern_ready",
-    "howl_of_the_pack_leader_boar_ready",
-    "howl_of_the_pack_leader_bear_ready",
+    "howl_of_the_pack_leader_wyvern",
+    "howl_of_the_pack_leader_boar",
+    "howl_of_the_pack_leader_bear",
 }
 
 -- This variable represents the true index in the above table of the next buff that will be applied to you, whether by the natural cycle or by bestial wrath
@@ -1433,7 +1433,7 @@ end, state )
 
 -- SIMC expression
 spec:RegisterStateExpr( "howl_summon_ready", function ()
-    return buff.howl_of_the_pack_leader_bear_ready.up or buff.howl_of_the_pack_leader_boar_ready.up or buff.howl_of_the_pack_leader_wyvern_ready.up or false
+    return buff.howl_of_the_pack_leader_bear.up or buff.howl_of_the_pack_leader_boar.up or buff.howl_of_the_pack_leader_wyvern.up or false
 end )
 
 -- Abilities

--- a/TheWarWithin/HunterSurvival.lua
+++ b/TheWarWithin/HunterSurvival.lua
@@ -387,17 +387,17 @@ spec:RegisterAuras( {
         duration = function() return 30 - ( 5 * talent.better_together.rank ) end,
         max_stack = 1,
     },
-    howl_of_the_pack_leader_bear_ready = {
+    howl_of_the_pack_leader_bear = {
         id = 472325,
         duration = function() return 30 - ( 5 * talent.better_together.rank ) end,
         max_stack = 1,
     },
-    howl_of_the_pack_leader_boar_ready = {
+    howl_of_the_pack_leader_boar = {
         id = 472324,
         duration = function() return 30 - ( 5 * talent.better_together.rank ) end,
         max_stack = 1,
     },
-    howl_of_the_pack_leader_wyvern_ready = {
+    howl_of_the_pack_leader_wyvern = {
         id = 471878,
         duration = function() return 30 - ( 5 * talent.better_together.rank ) end,
         max_stack = 1,
@@ -762,9 +762,9 @@ spec:RegisterAuras( {
 } )
 
 local pack_leader_buff_cycle = {
-    "howl_of_the_pack_leader_wyvern_ready",
-    "howl_of_the_pack_leader_boar_ready",
-    "howl_of_the_pack_leader_bear_ready",
+    "howl_of_the_pack_leader_wyvern",
+    "howl_of_the_pack_leader_boar",
+    "howl_of_the_pack_leader_bear",
 }
 
 -- This variable represents the true index in the above table of the next buff that will be applied to you, whether by the natural cycle or by bestial wrath
@@ -911,7 +911,7 @@ end, state )
 
 -- SIMC expression
 spec:RegisterStateExpr( "howl_summon_ready", function ()
-    return buff.howl_of_the_pack_leader_bear_ready.up or buff.howl_of_the_pack_leader_boar_ready.up or buff.howl_of_the_pack_leader_wyvern_ready.up or false
+    return buff.howl_of_the_pack_leader_bear.up or buff.howl_of_the_pack_leader_boar.up or buff.howl_of_the_pack_leader_wyvern.up or false
 end )
 
 spec:RegisterHook( "spend", function( amt, resource )

--- a/TheWarWithin/PriestShadow.lua
+++ b/TheWarWithin/PriestShadow.lua
@@ -225,8 +225,8 @@ spec:RegisterTalents( {
     psychic_horror             = {  82652,  64044, 1 }, -- Terrifies the target in place, stunning them for 4 sec.
     psychic_link               = {  82670, 199484, 1 }, -- Your direct damage spells inflict 25% of their damage on all other targets afflicted by your Vampiric Touch within 46 yards. Does not apply to damage from Shadowy Apparitions, Shadow Word: Pain, and Vampiric Touch.
     screams_of_the_void        = {  82649, 375767, 2 }, -- Devouring Plague causes your Shadow Word: Pain and Vampiric Touch to deal damage 40% faster on all targets for 3 sec.
-    shadow_crash               = {  82669, 205385, 1 }, -- Aim a bolt of slow-moving Shadow energy at the destination, dealing 10,237 Shadow damage to all enemies within 8 yds. Generates 6 Insanity. This spell is cast at a selected location.
-    shadow_crash_2             = {  82669, 457042, 1 }, -- Hurl a bolt of slow-moving Shadow energy at your target, dealing 10,237 Shadow damage to all enemies within 8 yds. Generates 6 Insanity. This spell is cast at your target.
+    shadow_crash_ground        = {  82669, 205385, 1 }, -- Aim a bolt of slow-moving Shadow energy at the destination, dealing 10,237 Shadow damage to all enemies within 8 yds. Generates 6 Insanity. This spell is cast at a selected location.
+    shadow_crash_targeted      = {  82669, 457042, 1 }, -- Hurl a bolt of slow-moving Shadow energy at your target, dealing 10,237 Shadow damage to all enemies within 8 yds. Generates 6 Insanity. This spell is cast at your target.
     shadowy_apparitions        = {  82666, 341491, 1 }, -- Mind Blast, Devouring Plague, and Void Bolt conjure Shadowy Apparitions that float towards all targets afflicted by your Vampiric Touch for 4,604 Shadow damage. Critical strikes increase the damage by 100%.
     shadowy_insight            = {  82662, 375888, 1 }, -- Shadow Word: Pain periodic damage has a chance to reset the remaining cooldown on Mind Blast and cause your next Mind Blast to be instant.
     silence                    = {  82651,  15487, 1 }, -- Silences the target, preventing them from casting spells for 4 sec. Against non-players, also interrupts spellcasting and prevents any spell in that school from being cast for 4 sec.
@@ -288,6 +288,9 @@ spec:RegisterPvpTalents( {
     void_volley          = 5447, -- (357711)
 } )
 
+spec:RegisterHook( "TALENTS_UPDATED", function()
+    talent.shadow_crash = talent.shadow_crash_targeted.enabled and talent.shadow_crash_targeted or talent.shadow_crash_ground
+end )
 
 spec:RegisterTotem( "mindbender", 136214 )
 spec:RegisterTotem( "shadowfiend", 136199 )
@@ -2043,7 +2046,7 @@ spec:RegisterAbilities( {
 
     -- Talent: Hurl a bolt of slow-moving Shadow energy at the destination, dealing $205386s1 Shadow damage to all targets within $205386A1 yards and applying Vampiric Touch to $391286s1 of them.    |cFFFFFFFFGenerates $/100;s2 Insanity.|r
     shadow_crash = {
-        id = function() return talent.shadow_crash_2.enabled and 457042 or 205385 end,
+        id = function() return talent.shadow_crash_targeted.enabled and 457042 or 205385 end,
         cast = 0,
         cooldown = 20,
         gcd = "spell",
@@ -2052,10 +2055,8 @@ spec:RegisterAbilities( {
         spend = -6,
         spendType = "insanity",
 
-        talent = function()
-            return talent.shadow_crash_2.enabled and "shadow_crash_2" or "shadow_crash"
-        end,
-        startsCombat = function() return talent.shadow_crash_2.enabled end,
+        talent = "shadow_crash",
+        startsCombat = function() return talent.shadow_crash_targeted.enabled end,
 
         velocity = 2,
 

--- a/TheWarWithin/WarlockDestruction.lua
+++ b/TheWarWithin/WarlockDestruction.lua
@@ -213,8 +213,8 @@ spec:RegisterTalents( {
     pyrogenics                     = {  71975, 387095, 1 }, -- Enemies affected by your Rain of Fire take 3% increased damage from your Fire spells.
     raging_demonfire               = {  72063, 387166, 1 }, -- Channel Demonfire fires an additional 2 bolts. Each bolt increases the remaining duration of Immolate on all targets hit by 0.5 sec.
     rain_of_chaos                  = {  71960, 266086, 1 }, -- While your initial Infernal is active, every Soul Shard you spend has a 15% chance to summon an additional Infernal that lasts 8 sec.
-    rain_of_fire                   = {  72069, 1214467, 1 }, -- Calls down a rain of hellfire upon your target, dealing 42,138 Fire damage over 6.1 sec to enemies in the area. This spell is cast at your target.
-    rain_of_fire_2                 = {  72069,   5740, 1 }, -- Calls down a rain of hellfire the target location, dealing 42,138 Fire damage over 6.1 sec to enemies in the area. This spell is cast at a selected location.
+    rain_of_fire_targeted          = {  72069, 1214467, 1 }, -- Calls down a rain of hellfire upon your target, dealing 42,138 Fire damage over 6.1 sec to enemies in the area. This spell is cast at your target.
+    rain_of_fire_ground            = {  72069,   5740, 1 }, -- Calls down a rain of hellfire the target location, dealing 42,138 Fire damage over 6.1 sec to enemies in the area. This spell is cast at a selected location.
     reverse_entropy                = {  71980, 205148, 1 }, -- Your spells have a chance to grant you 15% Haste for 8 sec.
     ritual_of_ruin                 = {  71970, 387156, 1 }, -- Every 15 Soul Shards spent grants Ritual of Ruin, making your next Chaos Bolt or Rain of Fire consume no Soul Shards and have its cast time reduced by 50%.
     roaring_blaze                  = {  72065, 205184, 1 }, -- Conflagrate increases your Soul Fire, Immolate, Incinerate, and Conflagrate damage to the target by 25% for 8 sec.
@@ -1807,7 +1807,7 @@ spec:RegisterAbilities( {
 
     -- Calls down a rain of hellfire, dealing ${$42223m1*8} Fire damage over $d to enemies in the area.
     rain_of_fire = {
-        id = 5740,
+        id = function() return talent.rain_of_fire_targeted.enabled and 1214467 or 5740 end,
         cast = 0,
         cooldown = 0,
         gcd = "spell",
@@ -1822,7 +1822,7 @@ spec:RegisterAbilities( {
 
         usable = function() return raid_event.adds.remains > 4 end,
         talent = function()
-            return talent.rain_of_fire_2.enabled and "rain_of_fire_2" or "rain_of_fire"
+            return talent.rain_of_fire_targeted.enabled and "rain_of_fire_targeted" or "rain_of_fire_ground"
         end,
         startsCombat = true,
 

--- a/TheWarWithin/WarlockDestruction.lua
+++ b/TheWarWithin/WarlockDestruction.lua
@@ -272,6 +272,9 @@ spec:RegisterPvpTalents( {
     soul_rip         = 5607, -- (410598) Fracture the soul of up to 3 target players within 20 yds into the shadows, reducing their damage done by 25% and healing received by 25% for 8 sec. Souls are fractured up to 20 yds from the player's location. Players can retrieve their souls to remove this effect.
 } )
 
+spec:RegisterHook( "TALENTS_UPDATED", function()
+    talent.rain_of_fire = talent.rain_of_fire_targeted.enabled and talent.rain_of_fire_targeted or talent.rain_of_fire_ground
+end )
 
 -- Auras
 spec:RegisterAuras( {
@@ -1821,9 +1824,7 @@ spec:RegisterAbilities( {
 
 
         usable = function() return raid_event.adds.remains > 4 end,
-        talent = function()
-            return talent.rain_of_fire_targeted.enabled and "rain_of_fire_targeted" or "rain_of_fire_ground"
-        end,
+        talent = "rain_of_fire",
         startsCombat = true,
 
         handler = function ()


### PR DESCRIPTION
## Pack Leader
Wrong buff name: `Warnings: [#1] Unknown buff in [Survival:plcleave:4]: howl_of_the_pack_leader_wyvern`

I thought they were using `_ready` but they are not
## Rain of Fire
corrected spell ID, fixes https://github.com/Hekili/hekili/issues/4419