### PR TITLE
feat: output the texture of a chosen action in snapshots

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -1188,6 +1188,7 @@ function Hekili:GetPredictionFromAPL( dispName, packName, listName, slot, action
                                                         if debug then
                                                             -- scripts:ImplantDebugData( slot )
                                                             self:Debug( "Action chosen:  %s at %.2f!", rAction, rWait )
+                                                            self:Debug( "Texture shown:  %s", slot.texture )
                                                         end
 
                                                         -- slot.indicator = ( entry.Indicator and entry.Indicator ~= "none" ) and entry.Indicator
@@ -1238,6 +1239,7 @@ function Hekili:GetPredictionFromAPL( dispName, packName, listName, slot, action
 
                                                             if debug then
                                                                 self:Debug( "Action chosen:  %s at %.2f!", rAction, state.delay )
+                                                                self:Debug( "Texture shown:  %s", slot.texture )
                                                             end
                                                         end
 
@@ -1358,6 +1360,7 @@ function Hekili:GetPredictionFromAPL( dispName, packName, listName, slot, action
                                                         if debug then
                                                             -- scripts:ImplantDebugData( slot )
                                                             self:Debug( "Action chosen:  %s at %.2f!", rAction, state.delay )
+                                                            self:Debug( "Texture shown:  %s", slot.texture )
                                                         end
 
                                                         if state.IsCycling( nil, true ) then


### PR DESCRIPTION
In the snapshots, when an action is chosen as a recommedation, also output the texture that should be shown in the display. This only increases the snapshot output by one line per recommendation, but is a good sanity check for debugging what we're supposed to see versus what we are seeing.