### PR TITLE
fix: always show the correct texture for an action

### DIFF
--- a/UI.lua
+++ b/UI.lua
@@ -1114,16 +1114,21 @@ do
                                 -- print( "Changing", GetTime() )
                             end ]]
 
-                            if action ~= b.lastAction or self.NewRecommendations or not b.Image then
-                                if ability.item then
-                                    b.Image = b.Recommendation.texture or ability.texture or select( 5, GetItemInfoInstant( ability.item ) )
-                                else
-                                    local override = options and rawget( options, action )
-                                    b.Image = override and override.icon or b.Recommendation.texture or ability.texture or GetSpellTexture( ability.id )
-                                end
+                            local image -- texture to be shown on the button for the current action
+
+                            if ability.item then
+                                image = b.Recommendation.texture or ability.texture or select( 5, GetItemInfoInstant( ability.item ) )
+                            else
+                                local override = options and rawget( options, action )
+                                image = override and override.icon or b.Recommendation.texture or ability.texture or GetSpellTexture( ability.id )
+                            end
+
+                            if action ~= b.lastAction or image ~= b.lastImage or self.NewRecommendations or not b.Image then
+                                b.Image = image
                                 b.Texture:SetTexture( b.Image )
                                 b.Texture:SetTexCoord( unpack( b.texCoords ) )
                                 b.lastAction = action
+                                b.lastImage = image
                             end
 
                             b.Texture:Show()


### PR DESCRIPTION
If an ability can have different textures but is invoked in a priority under only one name, then the display would show only the previous texture instead if the action was the same as before.

Fix this behavior by also saving the previous texture shown in the display and checking if it differs from the current texture to be displayed.

This comes up in the Guardian Druid priorities, and perhaps also in the Feral Druid priorities, if Maul or Ferocious Bite is recommended twice in a row. In the priorities, the same action `maul` or `ferocious_bite` is used for whether or not a Druid of the Claw Ravage proc has occurred.