### PR TITLE
Enhance shaman surging totem + TWW mythic+ affix auras

### DIFF
--- a/Classes.lua
+++ b/Classes.lua
@@ -1401,6 +1401,38 @@ all:RegisterAuras( {
         duration = 3600,
     },
 
+    -- The War Within M+ Affix auras
+    -- Haste
+    cosmic_ascension = {
+        id = 461910,
+        duration = 30,
+        max_stack = 1
+    },
+    -- Crit
+    rift_essence = {
+        id = 465136,
+        duration = 30,
+        max_stack = 1
+    },
+    -- Mastery
+    void_essence = {
+        id = 463767,
+        duration = 30,
+        max_stack = 1
+    },
+    -- CDR & Vers
+    voidbinding = {
+        id = 462661,
+        duration = 30,
+        max_stack = 1
+    },
+    -- Priory of the Sacred Flame
+    blessing_of_the_sacred_flame = {
+        id = 435088,
+        duration = 1800,
+        max_stack = 1
+    },
+
     -- Can be used in GCD calculation.
     shadowform = {
         id = 232698,

--- a/TheWarWithin/ShamanEnhancement.lua
+++ b/TheWarWithin/ShamanEnhancement.lua
@@ -1304,8 +1304,8 @@ spec:RegisterHook( "reset_precast", function ()
     rawset( buff, "doom_winds_debuff", debuff.doom_winds_debuff )
     rawset( buff, "doom_winds_cd", debuff.doom_winds_debuff )
 
-    if totem.surging_totem.up then
-        setCooldown( "surging_totem", totem.surging_totem.remains + 0.1 )
+    if buff.voidbinding.up and totem.surging_totem.up then
+        setCooldown( "surging_totem", totem.surging_totem.remains )
     end
 end )
 


### PR DESCRIPTION
The fix for the surging totem cooldown during the m+ affix caused a UI issue. This PR adds the m+ affix buffs as global auras.

By syncing the totem _spell_ CD with the _totem_ expiry, only during the CDR buff, we should get the fix without the added UI issue.

Fixes https://github.com/Hekili/hekili/issues/4461