### PR TITLE
Fix Rain of Fire (for real this time)

### DIFF
--- a/TheWarWithin/WarlockDestruction.lua
+++ b/TheWarWithin/WarlockDestruction.lua
@@ -1838,7 +1838,7 @@ spec:RegisterAbilities( {
             end
         end,
 
-        copy = { 1214467, 5740 }
+        copy = { 5740, 1214467 }
     },
 
     --[[ Begins a ritual that sacrifices a random participant to summon a doomguard. Requires the caster and 4 additional party members to complete the ritual.


### PR DESCRIPTION
Fixes https://github.com/Hekili/hekili/issues/4469

I have no idea why this completely fixes it, but it does. It was the only difference between how shadow crash was built vs rain of fire.

`copy = { original_ground_id, fancy_new_targeted_id }` 

instead of 

`copy = { fancy_new_targeted_id, original_ground_id }` 

If you can explain why, I'd love to know. Something in the ability registration order of operations?