### PR TITLE
fix: GetGreatestTimeToPct() shouldn't return TTD

### DIFF
--- a/Targets.lua
+++ b/Targets.lua
@@ -1303,7 +1303,8 @@ do
 
         for k, v in pairs(db) do
             if not CheckEnemyExclusion( k ) and v.lastHealth > percent then
-                time = max( time, max( 0, v.deathTime ) )
+                local scale = ( percent - v.deathPercent ) / ( v.lastHealth - v.deathPercent )
+                time = max( time, max( 0, v.deathTime * scale ) )
                 validUnit = true
             end
         end


### PR DESCRIPTION
`Hekili:GetGreatestTimeToPct( percent )` was incorrectly just returning the greatest TTD of mobs whose health exceeds `percent`. Scale that number appropriately so that it actually returns the greatest "time-to-percent" of mobs whose health exceeds `percent`.