### PR TITLE
Item fixes: Hyperthread Wristwraps, Abyssal Trap / garbagemancer

### DIFF
--- a/BfA/Items.lua
+++ b/BfA/Items.lua
@@ -542,6 +542,7 @@ do
     all:RegisterGear( "pocketsized_computation_device", 167555 )
     all:RegisterGear( "cyclotronic_blast", 167672 )
     all:RegisterGear( "harmonic_dematerializer", 167677 )
+    all:RegisterGear( "hyperthread_wristwraps", 168989 )
 
     all:RegisterAura( "cyclotronic_blast", {
         id = 293491,
@@ -635,6 +636,9 @@ do
         cast = 0,
         cooldown = 120,
         gcd = "off",
+
+        item = 168989,
+        toggle = "cooldowns",
 
         handler = function ()
             -- Gain 5 seconds of CD for the last 3 spells.

--- a/TheWarWithin/Items.lua
+++ b/TheWarWithin/Items.lua
@@ -269,7 +269,7 @@ all:RegisterAbilities( {
         cooldown = 60,
         gcd = "off",
 
-        item = 235984,
+        item = 215170,
         toggle = "essences",
 
         proc = "damage",


### PR DESCRIPTION
### Hyperthread Wristwraps
This shows up under abilities instead of items which is not in line with other items. This change puts it under items.
### Garbacemancer's Last Resort
Abyssal trap was incorrectly using its ID, causing it to not work right. Ref: https://www.wowhead.com/item=215170/abyssal-trap