### PR TITLE
Support in_flight_to_target

### DIFF
--- a/State.lua
+++ b/State.lua
@@ -2317,7 +2317,7 @@ do
             elseif k == "executing" then return t:IsCasting( action ) or ( t.prev[ 1 ][ action ] and t.gcd.remains > 0 )
             elseif k == "full_recharge_time" or k == "time_to_max_charges" then return cooldown.full_recharge_time
             elseif k == "hardcast" then return false -- will set to true if/when a spell is hardcast.
-            elseif k == "in_flight" then return model and model.in_flight or false
+            elseif k == "in_flight" or k == "in_flight_to_target" then return model and model.in_flight or false
             elseif k == "in_flight_remains" then return model and model.in_flight_remains or 0
             elseif k == "in_range" then return model.in_range
             elseif k == "recharge" then return cooldown.recharge
@@ -5345,7 +5345,7 @@ local mt_default_action = {
             if type( a ) == "string" then return a end
             return class.primaryResource
 
-        elseif k == "in_flight" then
+        elseif k == "in_flight" or k == "in_flight_to_target" then
             if ability.flightTime then
                 return ability.lastCast + max( ability.flightTime, 0.25 ) > state.query_time
             end

--- a/TheWarWithin/EvokerDevastation.lua
+++ b/TheWarWithin/EvokerDevastation.lua
@@ -1381,6 +1381,7 @@ spec:RegisterAbilities( {
         spend = 0.12,
         spendType = "mana",
 
+        velocity = 45,
         startsCombat = true,
 
         damage = function () return 1.61 * stat.spell_power * ( talent.engulfing_blaze.enabled and 1.4 or 1 ) end,
@@ -1391,7 +1392,6 @@ spec:RegisterAbilities( {
             -- Many Color, Essence and Empower interactions have been moved to the runHandler hook
             if buff.burnout.up then removeStack( "burnout" )
             else removeBuff( "ancient_flame" ) end
-            if talent.ruby_embers.enabled then addStack( "living_flame" ) end
 
             if talent.ruby_essence_burst.enabled and buff.dragonrage.up then
                 addStack( "essence_burst", nil, buff.leaping_flames.up and ( true_active_enemies > 1 or group or health.percent < 100 ) and 2 or 1 )
@@ -1402,7 +1402,11 @@ spec:RegisterAbilities( {
 
         end,
 
-        copy = { 361469, "chrono_flame", 431443 }
+        impact = function() 
+            if talent.ruby_embers.enabled then addStack( "living_flame" ) end
+        end,
+
+        copy = "living_flame_damage"
     },
 
     -- Talent: Reinforce your scales, reducing damage taken by 30%. Lasts 12 sec.


### PR DESCRIPTION
### in_flight_to_target
- New expression being used by some APLs which was not being picked up by the existing `in_flight`. 
- This (along with below changes to Devastation) fixes https://github.com/Hekili/hekili/issues/4501
- This may also inadvertently fix some unreported warlock issues as they are using it too.
![image](https://github.com/user-attachments/assets/be084738-e8d2-4ff5-8174-5a420c2540f2)
### Devastation
- Convert `living_flame` to a projectile to support current APL
- Ensure `living_flame_damage` copy to support current APL
  - All 3 specs have their own registration of living flame, so these changes to copy only affect Devastation, who does not have access to chronoflames anyways
