### PR TITLE
Frost Mage Fixes

### DIFF
--- a/TheWarWithin/MageFrost.lua
+++ b/TheWarWithin/MageFrost.lua
@@ -1092,7 +1092,7 @@ spec:RegisterAbilities( {
 
             if talent.frostfire_mastery.enabled then
                 if buff.excess_frost.up then
-                    removeBuff( "excess_frost" )
+                    removeStack( "excess_frost" )
                     spec.abilities.ice_nova.handler()
                     reduceCooldown( "comet_storm", 3 )
                 end
@@ -1171,7 +1171,7 @@ spec:RegisterAbilities( {
             if buff.frostfire_empowerment.up then
                 if talent.flash_freezeburn.enabled then
                     applyBuff( "frost_mastery", nil, 6 )
-                    applyBuff( "excess_frost" )
+                    addStack( "excess_frost" )
                     applyBuff( "fire_mastery", nil, 6 )
                     addStack( "excess_fire" )
                 end
@@ -1252,7 +1252,7 @@ spec:RegisterAbilities( {
             if buff.frostfire_empowerment.up then
                 if talent.flash_freezeburn.enabled then
                     applyBuff( "frost_mastery", nil, 6 )
-                    applyBuff( "excess_frost" )
+                    addStack( "excess_frost" )
                     applyBuff( "fire_mastery", nil, 6 )
                     addStack( "excess_fire" )
                 end
@@ -1459,7 +1459,7 @@ spec:RegisterAbilities( {
             if talent.frostfire_mastery.enabled then
                 if buff.excess_fire.up then
                     removeStack( "excess_fire" )
-                    applyBuff( "excess_frost" )
+                    addStack( "excess_frost" )
                     BrainFreeze()
                 end
             end

--- a/TheWarWithin/MageFrost.lua
+++ b/TheWarWithin/MageFrost.lua
@@ -178,10 +178,10 @@ spec:RegisterAuras( {
         duration = function () return 12 * haste end,
         max_stack = 1,
         generate = function( t )
-            if query_time - action.blizzard.lastCast < 8 * haste then
+            if query_time - action.blizzard.lastCast < 12 * haste then
                 t.count = 1
                 t.applied = action.blizzard.lastCast
-                t.expires = t.applied + ( 8 * haste )
+                t.expires = t.applied + ( 12 * haste )
                 t.caster = "player"
                 return
             end
@@ -191,7 +191,9 @@ spec:RegisterAuras( {
             t.expires = 0
             t.caster = "nobody"
         end,
+
     },
+
     active_comet_storm = {
         duration = 2.6,
         max_stack = 1,
@@ -310,6 +312,11 @@ spec:RegisterAuras( {
         duration = 15,
         max_stack = 2,
     },
+    fire_mastery = {
+        id = 431040,
+        duration = 14,
+        max_stack = 6
+    },
     -- Talent: Movement slowed by $w1%.
     -- https://wowhead.com/beta/spell=228354
     flurry = {
@@ -355,6 +362,11 @@ spec:RegisterAuras( {
         type = "Magic",
         max_stack = 1,
         copy = 235235
+    },
+    frost_mastery = {
+        id = 431039,
+        duration = 14,
+        max_stack = 6
     },
     -- Talent: Frozen.
     -- https://wowhead.com/beta/spell=378760
@@ -893,7 +905,6 @@ local BrainFreeze = setfenv( function()
     applyBuff( "brain_freeze" )
 end, state )
 
-
 spec:RegisterHook( "reset_precast", function ()
     frost_info.last_target_virtual = frost_info.last_target_actual
 
@@ -920,6 +931,7 @@ spec:RegisterHook( "reset_precast", function ()
         active_dot.frost_nova > 0 and debuff.frost_nova.down then
         active_dot.frozen = active_dot.frozen + 1
     end
+
 end )
 
 spec:RegisterHook( "runHandler", function( action )
@@ -970,6 +982,7 @@ spec:RegisterAbilities( {
         handler = function ()
             applyDebuff( "target", "blizzard" )
             applyBuff( "active_blizzard" )
+
         end,
     },
 
@@ -1619,7 +1632,7 @@ spec:RegisterAbilities( {
             applyBuff( "shifting_power" )
         end,
 
-        tick  = function ()
+        tick = function ()
             local seen = {}
             for _, a in pairs( spec.abilities ) do
                 if not seen[ a.key ] and ( not talent.coldest_snap.enabled or a.key ~= "cone_of_cold" ) then

--- a/TheWarWithin/MageFrost.lua
+++ b/TheWarWithin/MageFrost.lua
@@ -923,10 +923,10 @@ spec:RegisterHook( "reset_precast", function ()
 end )
 
 spec:RegisterHook( "runHandler", function( action )
-    if buff.ice_floes.up then
-        local ability = class.abilities[ action ]
-        if ability and ability.cast > 0 and ability.cast < 10 then removeStack( "ice_floes" ) end
-    end
+
+    local ability = class.abilities[ action ]
+
+    if buff.ice_floes.up and ability and ability.cast > 0 and ability.cast < 10 then removeStack( "ice_floes" ) end
 
     if talent.frostfire_mastery.enabled and ability then
         if ability.school == "fire" or ability.school == "frostfire" then
@@ -1113,7 +1113,7 @@ spec:RegisterAbilities( {
             applyDebuff( "target", "winters_chill", nil, 2 )
             applyDebuff( "target", "flurry" )
             applyBuff( "bone_chilling", nil, 3 )
-            if talent.frostfire_mastery.enabled then 
+            if talent.frostfire_mastery.enabled then
                 if buff.frost_mastery.up then applyBuff( "frost_mastery", buff.frost_mastery.expires, min( buff.frost_mastery.stacks + 3, 6) )
                 else applyBuff( "frost_mastery", nil, 3 ) end
             end
@@ -1167,8 +1167,6 @@ spec:RegisterAbilities( {
 
         handler = function ()
             addStack( "icicles" )
-
-            if action.frostbolt.cast_time > 0 then removeStack( "ice_floes" ) end
 
             if buff.frostfire_empowerment.up then
                 if talent.flash_freezeburn.enabled then
@@ -1250,8 +1248,6 @@ spec:RegisterAbilities( {
 
         handler = function ()
             addStack( "icicles" )
-
-            if action.frostfire_bolt.cast_time > 0 then removeStack( "ice_floes" ) end
 
             if buff.frostfire_empowerment.up then
                 if talent.flash_freezeburn.enabled then


### PR DESCRIPTION
- Frostfire Masteries
  - `local ability` needs to be moved outside the if-structure as I am re-using it in the second if-structure below. This cleans up **_many_** LUA errors seen in Frost snapshots
  - Define both masteries in the Frost file to use `spec.auras` reference
- `excess_frost` was being added/removed via `applyBuff()`, this is leftover code from when the buff did not stack to 2. Changed to use `addStack()`
  - Fixes https://github.com/Hekili/hekili/issues/4516
- Corrected blizzard new duration