### PR TITLE
Bestinslots fix + added spec field

### DIFF
--- a/Classes.lua
+++ b/Classes.lua
@@ -1276,7 +1276,6 @@ ns.isDefault = function( name, category )
     return false
 end
 
-
 function Hekili:NewSpecialization( specID, isRanged, icon )
 
     if not specID or specID < 0 then return end
@@ -1312,6 +1311,7 @@ function Hekili:NewSpecialization( specID, isRanged, icon )
         resources = {},
         resourceAuras = {},
         primaryResource = nil,
+        primaryStat = nil,
 
         talents = {},
         pvptalents = {},
@@ -1362,7 +1362,6 @@ function Hekili:NewSpecialization( specID, isRanged, icon )
     class.specs[ id ] = spec
     return spec
 end
-
 
 function Hekili:GetSpecialization( specID )
     if not specID then return class.specs[ 0 ] end
@@ -4041,7 +4040,7 @@ function Hekili:SpecializationChanged()
     end
 
     for i = 1, 4 do
-        local id, name, _, _, role = GetSpecializationInfo( i )
+        local id, name, _, _, role, primaryStat = GetSpecializationInfo( i )
 
         if not id then break end
 
@@ -4062,6 +4061,14 @@ function Hekili:SpecializationChanged()
                 state.role.tank = true
             else
                 state.role.healer = true
+            end
+
+            if primaryStat == 1 then
+                state.spec.primaryStat = "strength"
+            elseif primaryStat == 2 then
+                state.spec.primaryStat = "agility"
+            else
+                state.spec.primaryStat = "intellect"
             end
 
             state.spec[ state.spec.key ] = true

--- a/TheWarWithin/Items.lua
+++ b/TheWarWithin/Items.lua
@@ -1046,12 +1046,18 @@ all:RegisterAbilities( {
     },
 
     bestinslots = {
-        cast = 5,
+        cast = function() return time > 0 and 0 or 5 end,
         cooldown = 120,
-        gcd = "spell",
+        gcd = function() return time > 0 and "off" or "spell" end,
 
         item = function() return equipped.bestinslots_caster and 232805 or 232526 end,
         toggle = "cooldowns",
+
+        -- During combat, usable. Outside of combat, only usable if your weapon type doesn't match your mainstat
+        usable = function()
+            if time > 0 then return true end
+            return equipped.bestinslots_caster and spec.primaryStat ~= "intellect" or equipped.bestinslots_melee and spec.primaryStat == "intellect" or false
+        end,
 
         proc = "secondary",
         self_buff = "cheating",

--- a/TheWarWithin/Items.lua
+++ b/TheWarWithin/Items.lua
@@ -1047,11 +1047,11 @@ all:RegisterAbilities( {
 
     bestinslots = {
         cast = function() return time > 0 and 0 or 5 end,
-        cooldown = 120,
+        cooldown = function() return time > 0 and 120 or 30 end,
         gcd = function() return time > 0 and "off" or "spell" end,
 
         item = function() return equipped.bestinslots_caster and 232805 or 232526 end,
-        toggle = "cooldowns",
+        toggle = function() return time > 0 and "cooldowns" or "default" end,
 
         -- During combat, usable. Outside of combat, only usable if your weapon type doesn't match your mainstat
         usable = function()


### PR DESCRIPTION
This PR addresses the new Best-In-Slots item. The issue with this item is that its active ability has 2 different forms based on whether or not you're in combat.

- In combat 
  - off-GCD main hand cast
  - shares 30 sec CD with trinkets
  - grants a stat buff
  - Goes on a 2 min CD
- Out of combat
  - 5 second cast
  - Changes weapon type between int and str/agi
  - Triggers 30 second CD

The additional spec field, `spec.primaryStat` comes from: https://warcraft.wiki.gg/wiki/API_GetSpecializationInfo

It allows for an easy solution to out-of-combat best-in-slots use (check if you have the right weapon type for your mainstat), and also allows the field to be referenced in the future if needed.

While I was able to test `spec.primaryStat`, I do not have this item so would like to see someone test it before merging.

Fixes https://github.com/Hekili/hekili/issues/4522

![image](https://github.com/user-attachments/assets/e274f7b9-0366-4f14-af47-a08c8a280a2b)
