### PR TITLE
Monk: WW Dynamic toggles, Brew Tier Set fix

### DIFF
--- a/TheWarWithin/MonkBrewmaster.lua
+++ b/TheWarWithin/MonkBrewmaster.lua
@@ -1201,7 +1201,7 @@ spec:RegisterAbilities( {
             if conduit.walk_with_the_ox.enabled and cooldown.invoke_niuzao.remains > 0 then reduceCooldown( "invoke_niuzao", 0.5 ) end
 
             if set_bonus.tww2 >= 4 and buff.opportunistic_strike.up then
-                reduceCooldown( "blackout_kick" )
+                reduceCooldown( "blackout_kick", 2 )
                 removeStack( "opportunistic_strike" )
             end
 

--- a/TheWarWithin/MonkWindwalker.lua
+++ b/TheWarWithin/MonkWindwalker.lua
@@ -1250,7 +1250,7 @@ spec:RegisterAbilities( {
         spend = function () return 20 * ( 1 - ( buff.the_emperors_capacitor.stack * 0.05 ) ) end,
         spendPerSec = function () return 20 * ( 1 - ( buff.the_emperors_capacitor.stack * 0.05 ) ) end,
 
-        toggle = function() if talent.last_emperors_capacitor.enabled then return "cooldowns" end end,
+        toggle = function() if talent.power_of_the_thunder_king.enabled then return "cooldowns" end end,
 
         startsCombat = false,
 

--- a/TheWarWithin/MonkWindwalker.lua
+++ b/TheWarWithin/MonkWindwalker.lua
@@ -1250,7 +1250,7 @@ spec:RegisterAbilities( {
         spend = function () return 20 * ( 1 - ( buff.the_emperors_capacitor.stack * 0.05 ) ) end,
         spendPerSec = function () return 20 * ( 1 - ( buff.the_emperors_capacitor.stack * 0.05 ) ) end,
 
-        toggle = function() if talent.power_of_the_thunder_king.enabled then return "cooldowns" end end,
+        toggle = function() if raid and talent.power_of_the_thunder_king.enabled then return "cooldowns" end end,
 
         startsCombat = false,
 

--- a/TheWarWithin/MonkWindwalker.lua
+++ b/TheWarWithin/MonkWindwalker.lua
@@ -1898,6 +1898,8 @@ spec:RegisterAbilities( {
         talent = "strike_of_the_windlord",
         startsCombat = true,
 
+        toggle = function() if raid then return "cooldowns" end end,
+
         handler = function ()
             applyDebuff( "target", "strike_of_the_windlord" )
             -- if talent.darting_hurricane.enabled then addStack( "darting_hurricane", nil, 2 ) end

--- a/TheWarWithin/MonkWindwalker.lua
+++ b/TheWarWithin/MonkWindwalker.lua
@@ -1250,6 +1250,8 @@ spec:RegisterAbilities( {
         spend = function () return 20 * ( 1 - ( buff.the_emperors_capacitor.stack * 0.05 ) ) end,
         spendPerSec = function () return 20 * ( 1 - ( buff.the_emperors_capacitor.stack * 0.05 ) ) end,
 
+        toggle = function() if talent.last_emperors_capacitor.enabled then return "cooldowns" end end,
+
         startsCombat = false,
 
         handler = function ()


### PR DESCRIPTION
# Windwalker
## Crackling Jade Lightning
This change puts crackling jade lightning on the cooldowns toggle if the user takes the Capacitor talent along with the AoE lightning cleave talent, but only in raid instances. This provide an easy way for users to hold a juiced up AoE lightning for add spawns.
## Strike of the Windlord
This change puts this ability on the cooldowns toggle, but only in raid instances, for the same reason as above: Easy way to hold for add spawns. 
# Brewmaster
Forgot to supply a value for the `reduceCooldown( "blackout_kick" )` call which was causing LUA errors. Now correctly calls `reduceCooldown( "blackout_kick", 2 )`. Fixes https://github.com/Hekili/hekili/issues/4524