### PR TITLE
More shadow fixes?

### DIFF
--- a/Classes.lua
+++ b/Classes.lua
@@ -2574,7 +2574,7 @@ all:RegisterAuras( {
             local amount = UnitGetTotalAbsorbs( unit )
 
             if amount > 0 then
-                t.name = ABSORB
+                -- t.name = ABSORB
                 t.count = 1
                 t.expires = now + 10
                 t.applied = now - 5

--- a/TheWarWithin/Priorities/PriestShadow.simc
+++ b/TheWarWithin/Priorities/PriestShadow.simc
@@ -33,7 +33,7 @@ actions.aoe+=/variable,name=holding_crash,op=set,value=(variable.max_vts-active_
 actions.aoe+=/variable,name=manual_vts_applied,op=set,value=(active_dot.vampiric_touch+8*!variable.holding_crash)>=variable.max_vts|!variable.is_vt_possible
 
 # TODO: Add holding condition for weird fight times to potion with execute
-actions.cds+=/potion,if=(buff.voidform.up&buff.power_infusion.up|buff.dark_ascension.up)&(fight_remains>=320|time_to_bloodlust>=320|buff.bloodlust.react)|boss&fight_remains<=30
+actions.cds+=/potion,if=(buff.voidform.up&buff.power_infusion.up|buff.dark_ascension.up)&(fight_remains>=320|buff.bloodlust.up)|boss&fight_remains<=30
 actions.cds+=/fireblood,if=buff.power_infusion.up&(buff.voidform.up|buff.dark_ascension.up)|boss&fight_remains<=8
 actions.cds+=/berserking,if=buff.power_infusion.up&(buff.voidform.up|buff.dark_ascension.up)|boss&fight_remains<=12
 actions.cds+=/blood_fury,if=buff.power_infusion.up&(buff.voidform.up|buff.dark_ascension.up)|boss&fight_remains<=15


### PR DESCRIPTION
- `all_absorbs`
  - Remove `t.name`, it was throwing LUA warnings in snapshots. Works perfectly without it, using `debuff.all_absorbs.up`, and as such works with the `priest.force_devour_matter` metatable reference
- APL
  - Remove `time_to_bloodlust` which was throwing LUA warnings
  - Replace `.react` with `.up`
- Priest LUA file
  - For some reason the main aura registration was far down in the file, moved it up above the all the hooks, just in case, since some of them reference auras
  - Fixed unfurling darkness **_buff_** duration