### PR TITLE
Frost Mage Winter's Chill Fixes

### DIFF
--- a/TheWarWithin/MageFrost.lua
+++ b/TheWarWithin/MageFrost.lua
@@ -690,6 +690,7 @@ local wc_spenders = {
     frostbolt = true,
     glacial_spike = true,
     ice_lance = true,
+    frostfire_bolt = true,
 }
 
 spec:RegisterStateExpr( "remaining_winters_chill", function ()

--- a/TheWarWithin/MageFrost.lua
+++ b/TheWarWithin/MageFrost.lua
@@ -1500,7 +1500,6 @@ spec:RegisterAbilities( {
 
         handler = function ()
             applyDebuff( "target", "ice_nova" )
-            removeDebuffStack( "target", "winters_chill" )
         end,
     },
 


### PR DESCRIPTION
- `frostfire_bolt` **_does_** consume winter's chill: Fixes https://github.com/Hekili/hekili/issues/4547
- `ice_nova` does **_not_** consume winter's chill: Fixes https://github.com/Hekili/hekili/issues/4545
  - Excess frost causes flurry to trigger an `ice_nova`, and so calling `ice_nova.handler()` from Flurry was mistakenly removing a winters chill stack from the initial 2 given by the `flurry.handler()`. This in turn caused the in-flight `glacial_spike` to make the addon think there would be 0 winters chill, when it should have assumed a count of 1 (and recommended `ice_lance` instead of `frostfire_bolt`