### PR TITLE
Updated Snapshot Formatting

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -1623,6 +1623,10 @@ function Hekili.Update()
                 numRecs = 1
             end
 
+            if debug then 
+            Hekili:Debug( "Combat Timer: %.2f", state.time )
+            end
+
             for i = 1, numRecs do
                 local chosen_depth = 0
 

--- a/Hekili.lua
+++ b/Hekili.lua
@@ -278,7 +278,10 @@ function Hekili:SaveDebugSnapshot( dispName )
             insert( v.log, 1, prevString )
 
             -- Store aura data.
-            local auraString = "\nplayer_buffs:"
+            local auraString = "\n### Auras ###\n"
+            auraString =  auraString .. "\nplayer_buffs:"
+            auraString = auraString .. "\n   id      - name                                 - stacks - remaining duration\n"
+
             local now = GetTime()
 
             local class = Hekili.Class
@@ -292,10 +295,11 @@ function Hekili:SaveDebugSnapshot( dispName )
                 local key = aura and aura.key
                 if key and not state.auras.player.buff[ key ] then key = key .. " [MISSING]" end
 
-                auraString = format( "%s\n   %6d - %-40s - %3d - %-6.2f", auraString, spellId, key or ( "*" .. formatKey( name ) ), count > 0 and count or 1, expirationTime > 0 and ( expirationTime - now ) or 3600 )
+                auraString = format( "%s   %-7d - %-36s - %3d    - %.2f\n", auraString, spellId, key or ( "*" .. formatKey( name ) ), count > 0 and count or 1, expirationTime > 0 and ( expirationTime - now ) or 3600 )
             end
 
-            auraString = auraString .. "\n\nplayer_debuffs:"
+            auraString = auraString .. "\n\nplayer_debuffs:\n"
+            -- auraString = auraString .. "\n   id      - name                                 - stacks - remaining duration\n"
 
             for i = 1, 40 do
                 local name, _, count, debuffType, duration, expirationTime, source, _, _, spellId, canApplyAura, isBossDebuff, castByPlayer = UnpackAuraData( GetDebuffDataByIndex( "player", i ) )
@@ -306,13 +310,14 @@ function Hekili:SaveDebugSnapshot( dispName )
                 local key = aura and aura.key
                 if key and not state.auras.player.debuff[ key ] then key = key .. " [MISSING]" end
 
-                auraString = format( "%s\n   %6d - %-40s - %3d - %-6.2f", auraString, spellId, key or ( "*" .. formatKey( name ) ), count > 0 and count or 1, expirationTime > 0 and ( expirationTime - now ) or 3600 )
+                auraString = format( "%s   %-7d - %-36s - %3d    - %.2f\n", auraString, spellId, key or ( "*" .. formatKey( name ) ), count > 0 and count or 1, expirationTime > 0 and ( expirationTime - now ) or 3600 )
             end
 
             if not UnitExists( "target" ) then
                 auraString = auraString .. "\n\ntarget_auras:  target does not exist"
             else
-                auraString = auraString .. "\n\ntarget_buffs:"
+                auraString = auraString .. "\n\ntarget_buffs:\n"
+                -- auraString = auraString .. "\n   id      - name                                 - stacks - remaining duration\n"
 
                 for i = 1, 40 do
                     local name, _, count, debuffType, duration, expirationTime, source, _, _, spellId, canApplyAura, isBossDebuff, castByPlayer = UnpackAuraData( GetBuffDataByIndex( "target", i ) )
@@ -323,10 +328,11 @@ function Hekili:SaveDebugSnapshot( dispName )
                     local key = aura and aura.key
                     if key and not state.auras.target.buff[ key ] then key = key .. " [MISSING]" end
 
-                    auraString = format( "%s\n   %6d - %-40s - %3d - %-6.2f", auraString, spellId, key or ( "*" .. formatKey( name ) ), count > 0 and count or 1, expirationTime > 0 and ( expirationTime - now ) or 3600 )
+                    auraString = format( "%s   %-7d - %-36s - %3d    - %.2f\n", auraString, spellId, key or ( "*" .. formatKey( name ) ), count > 0 and count or 1, expirationTime > 0 and ( expirationTime - now ) or 3600 )
                 end
 
-                auraString = auraString .. "\n\ntarget_debuffs:"
+                auraString = auraString .. "\n\ntarget_debuffs:\n"
+                -- auraString = auraString .. "\n   id      - name                                 - stacks - remaining duration\n"
 
                 for i = 1, 40 do
                     local name, _, count, debuffType, duration, expirationTime, source, _, _, spellId, canApplyAura, isBossDebuff, castByPlayer = UnpackAuraData( GetDebuffDataByIndex( "target", i, "PLAYER" ) )
@@ -337,12 +343,12 @@ function Hekili:SaveDebugSnapshot( dispName )
                     local key = aura and aura.key
                     if key and not state.auras.target.debuff[ key ] then key = key .. " [MISSING]" end
 
-                    auraString = format( "%s\n   %6d - %-40s - %3d - %-6.2f", auraString, spellId, key or ( "*" .. formatKey( name ) ), count > 0 and count or 1, expirationTime > 0 and ( expirationTime - now ) or 3600 )
+                    auraString = format( "%s   %-7d - %-36s - %3d    - %.2f\n", auraString, spellId, key or ( "*" .. formatKey( name ) ), count > 0 and count or 1, expirationTime > 0 and ( expirationTime - now ) or 3600 )
                 end
             end
 
             insert( v.log, 1, auraString )
-            insert( v.log, 1, "targets:  " .. ( Hekili.TargetDebug or "no data" ) )
+            insert( v.log, 1, "\n### Targets ###\n\ndetected_targets:  " .. ( Hekili.TargetDebug or "no data" ) )
             insert( v.log, 1, self:GenerateProfile() )
 
 

--- a/Options.lua
+++ b/Options.lua
@@ -9846,40 +9846,55 @@ break end
     end
 
 
-    return format( "build: %s\n" ..
-        "level: %d (%d)\n" ..
-        "class: %s\n" ..
-        "spec: %s\n\n" ..
-        "talents: %s\n\n" ..
-        "pvptalents: %s\n\n" ..
-        "covenant: %s\n\n" ..
-        "conduits: %s\n\n" ..
-        "soulbinds: %s\n\n" ..
-        "sets: %s\n\n" ..
-        "gear: %s\n\n" ..
-        "legendaries: %s\n\n" ..
-        "itemIDs: %s\n\n" ..
-        "settings: %s\n\n" ..
-        "toggles: %s\n\n" ..
-        "keybinds: %s\n\n" ..
-        "warnings: %s\n\n",
-        self.Version or "no info",
-        UnitLevel( 'player' ) or 0, UnitEffectiveLevel( 'player' ) or 0,
-        class.file or "NONE",
-        spec or "none",
-        talents or "none",
-        pvptalents or "none",
-        covenant or "none",
-        conduits or "none",
-        soulbinds or "none",
-        sets or "none",
-        gear or "none",
-        legendaries or "none",
-        items or "none",
-        settings or "none",
-        toggles or "none",
-        keybinds or "none",
-        warnings or "none" )
+    return format(
+    "build: %s\n" ..
+    "level: %d (%d)\n" ..
+    "class: %s\n" ..
+    "spec: %s\n\n" ..
+
+    "### Talents ###\n\n" ..
+    "In-Game Import: %s\n" ..
+
+    "\nPvP Talents: %s\n\n" ..
+
+    "### Legacy Content ###\n\n" ..
+    "covenant: %s\n" ..
+    "conduits: %s\n" ..
+    "soulbinds: %s\n" ..
+    "legendaries: %s\n\n" ..
+
+    "### Gear & Items ###\n\n" ..
+    "sets:\n    %s\n\n" ..
+    "gear:\n    %s\n\n" ..
+    "itemIDs: %s\n\n" ..
+
+    "### Settings ###\n\n" ..
+    "Settings:\n    %s\n\n" ..
+
+    "Toggles:\n    %s\n\n" ..
+
+    "Keybinds:%s\n\n" ..
+
+    "### Warnings ###\n\n%s\n",
+    self.Version or "no info",
+    UnitLevel( 'player' ) or 0, UnitEffectiveLevel( 'player' ) or 0,
+    class.file or "NONE",
+    spec or "none",
+    talents or "none",
+    pvptalents or "none",
+    covenant or "none",
+    conduits or "none",
+    soulbinds or "none",
+    legendaries or "none",
+    sets or "none",
+    gear or "none",
+    items or "none",
+    settings or "none",
+    toggles or "none",
+    keybinds or "none",
+    warnings or "none"
+)
+
 end
 
 


### PR DESCRIPTION
Some ideas for minor reformatting on snapshots.

## Comments
### Main Points (implemented in this PR)
- Regroup the "profile" section at the top a bit
  - Use sections
    - Group all legacy content outputs together
    - Group Gear outputs together
  - Column headers for the first aura table
  - Consistency 
  - Spacing
    -  Especially auras .. added 1 additional space on the ID since we now have 7 digit IDs in TWW
  - Newlines
  - Add a combat timer print (`state.time`, the same one used in APL) to the beginning of a recommendation set. Can be useful to know if someone's snapshot was halfway through a raid boss or not

### Other ideas NYI
- Clearly display actual target (vs other nameplates)
  - A quick print of the target info
    - current hp %
    - TTD
    - NPC ID
    - Casting status
- Pet / Totem status table, similar to the auras one
- A quick output of all currently disabled abilities (inclusive of `toggle` and `preference` reasons)
- Display the 1st recommendation, in name only, of all other active displays
- Replicate the standardized spacing of the auras onto other sections
  - toggle list
  - settings list

## Old Snapshot Excerpt

```
Enhancement; Primary - Surging Totem(0.00), Primordial Wave(0.97), Crash Lightning(1.95)
build: v11.1.0-1.0.8
level: 80 (80)
class: SHAMAN
spec: enhancement

talents: CcQAL+iDLHPJSLC+6fqMJ8tubOzMjZGmBzMGzMbmx2sNDAAAAAAAAAA2gNYGLasNgMTwGAmlJzALLmZmZYGzYYZmZyCLjlxMDAwMA
    amplification_core = 1/1
    ashen_catalyst = 1/1
    astral_shift = 1/1
    brimming_with_life = 1/1
    call_of_the_elements = 1/1
    capacitor_totem = 1/1
    chain_lightning = 1/1
    cleanse_spirit = 1/1
    crash_lightning = 1/1
    crashing_storms = 1/1
    doom_winds = 1/1
    earth_elemental = 1/1
    earth_shield = 1/1
    earthsurge = 1/1
    elemental_blast = 1/1
    elemental_orbit = 1/1
    elemental_warding = 1/1
    elemental_weapons = 1/1
    enhanced_imbues = 1/1
    feral_spirit = 1/1
    fire_and_ice = 1/1
    flowing_spirits = 1/1
    flurry = 1/1
    forceful_winds = 1/1
    hot_hand = 2/2
    imbuement_mastery = 1/1
    improved_maelstrom_weapon = 1/1
    lashing_flames = 1/1
    lava_burst = 1/1
    lava_lash = 1/1
    legacy_of_the_frost_witch = 2/2
    lively_totems = 1/1
    maelstrom_weapon = 1/1
    molten_assault = 1/1
    molten_thunder = 1/1
    natures_fury = 1/1
    natures_guardian = 1/1
    overflowing_maelstrom = 1/1
    planes_traveler = 1/1
    primordial_bond = 1/1
    primordial_storm = 1/1
    primordial_wave = 1/1
    purge = 1/1
    raging_maelstrom = 1/1
    reactivity = 1/1
    refreshing_waters = 1/1
    seasoned_winds = 1/1
    spirit_walk = 1/1
    spirit_wolf = 1/1
    splintered_elements = 2/2
    static_charge = 1/1
    stone_bulwark_totem = 1/1
    sundering = 1/1
    supportive_imbuements = 1/1
    surging_totem = 1/1
    swift_recall = 1/1
    thundershock = 1/1
    thunderstorm = 1/1
    totemic = 1/1
    totemic_focus = 1/1
    totemic_projection = 1/1
    totemic_rebound = 1/1
    totemic_recall = 1/1
    totemic_surge = 1/1
    unrelenting_storms = 1/1
    unruly_winds = 1/1
    whirling_elements = 1/1
    wind_barrier = 1/1
    wind_rush_totem = 1/1
    wind_shear = 1/1
    windfury_weapon = 1/1
    winds_of_alakir = 1/1

pvptalents: none

covenant: none

conduits: none

soulbinds: []

sets: tww2 = 2

gear: 85year_tenure_ring = 1
    blastborne_hauberk = 1
    blastborne_links = 1
    bloodoath_signet = 1
    crowd_favorite = 1
    expeditionary_chopper = 1
    flamekeepers_footpads = 1
    gale_sovereigns_charged_hood = 1
    gale_sovereigns_zephyrs = 1
    galvanic_graffiti_cuffs = 1
    holybound_grips = 1
    hornadorned_chausses = 1
    mechanocore_amplifier = 1
    mightbeinvisible_cloak = 1
    mindbreaker_pendant = 1
    suspicious_energy_drink = 1
    tww2 = 2

legendaries: none

itemIDs: 144117, 178871, 221119, 221198, 221244, 224639, 228846, 228904, 229260, 229262, 232485, 232729, 233481, 235363, 235447, 235453

settings: aoe = 2
    custom1Name = Custom 1
    custom2Name = Custom 2
    cycle = false
    cycle_min = 6
    damage = true
    damageDots = false
    damageExpiration = 8
    damageOnScreen = true
    damagePets = false
    damageRange = 0
    enabled = true
    gcdSync = true
    nameplateRange = 10
    nameplates = true
    noFeignedCooldown = false
    package = Enhancement
    petbased = false
    placeboBar = 3
    potion = default
    rangeFilter = false
    filler_shock = false
    funnel_priority = false
    hostile_dispel = false
    pad_lava_lash = false
    pad_windstrike = true
    purge_icd = 12
    pwave_gcds = 3
    pwave_targets = 0

toggles: cooldowns = true 
    custom1 = false 
    custom2 = false 
    defensives = false [separate]
    essences = true [overridden]
    funnel = false 
    interrupts = false [separate]
    mode = automatic 
    potions = false 

keybinds: 
    astral_shift             = SE  [06]
    capacitor_totem          = S3  [06]
    chain_lightning          = 3   [01]
    crash_lightning          = R   [01]
    doom_winds               = SF  [06]
    earth_elemental          = SQ  [06]
    earth_shield             = N4  [04]
    elemental_blast          = E   [01]
    flame_shock              = T   [01]
    frost_shock              = SG  [06]
    ghost_wolf               = N2  [04], G   [11]
    healing_stream_totem     = S6  [06]
    healing_surge            = S1  [06]
    lava_burst               = E   [01]
    lava_lash                = 2   [01]
    lightning_bolt           = G   [01]
    primordial_wave          = F   [01]
    purge                    = N5  [04]
    stone_bulwark_totem      = SR  [06]
    stormstrike              = 1   [01]
    sundering                = Q   [01]
    surging_totem            = 4   [01]
    surging_totem_projection = 4   [01]
    tempest                  = G   [01]
    thunderstorm             = S4  [06]
    totemic_projection       = 5   [01]
    voltaic_blaze            = T   [01]
    wind_rush_totem          = S5  [06]
    wind_shear               = N1  [04]
    windstrike               = 1   [01]

warnings: none


targets:  Nameplates are enabled.
 - Checking nameplate list for nameplate1 [ Creature-0-4227-2552-16262-225982-0002D49CC8 ] Cleave Training Dummy.
    nameplate1   - -1 - Creature-0-4227-2552-16262-225982-0002D49CC8 - 300.00 - 1 - Cleave Training Dummy 

 - Checking nameplate list for nameplate7 [ Creature-0-4227-2552-16262-225982-0002549CC8 ] Cleave Training Dummy.
    nameplate7   - -1 - Creature-0-4227-2552-16262-225982-0002549CC8 - 1.00 - 3 - Cleave Training Dummy 

 - Checking nameplate list for nameplate4 [ Creature-0-4227-2552-16262-225982-0000549CC7 ] Cleave Training Dummy.
    nameplate4   - -1 - Creature-0-4227-2552-16262-225982-0000549CC7 - 300.00 - 2 - Cleave Training Dummy 

 - Checking nameplate list for nameplate6 [ Creature-0-4227-2552-16262-225982-0000D49CC8 ] Cleave Training Dummy.
    nameplate6   - -1 - Creature-0-4227-2552-16262-225982-0000D49CC8 - 300.00 - 2 - Cleave Training Dummy 


player_buffs:
   192106 - lightning_shield                         -   1 - 3591.28
   462854 - skyfury                                  -   1 - 3592.56
     2825 - bloodlust                                -   1 - 35.44 
   442983 - *viziers_savvy                           -   1 - 3600.00
   335151 - *sign_of_the_mists                       -   1 - 3600.00
   404468 - *flight_style_steady                     -   1 - 3600.00
   292361 - *embrace_of_paku                         -   1 - 3600.00
   383648 - earth_shield                             -   9 - 3593.82
   1218616 - winning_streak                           -   2 - 28.33 
   1214810 - *mechanocore_amplifier                   -   1 - 7.43  
   344179 - maelstrom_weapon                         -   1 - 28.33 
   382889 - flurry                                   -   3 - 14.90 
   461242 - lively_totems                            -   1 - 6.43  
   390371 - ashen_catalyst                           -   5 - 14.80 

player_debuffs:
    57724 - sated_actual                             -   1 - 595.44

target_buffs:

target_debuffs:
   188389 - flame_shock                              -   1 - 21.83 
   334168 - lashing_flames                           -   1 - 18.54 

previous_spells:
   1 - lava_lash
   2 - totemic_projection
   3 - flame_shock


New Recommendations for [ Primary ] requested at 02:20:06 ( 210772.99 ); using built-in ( Enhancement ) priority.
*** START OF NEW DISPLAY: Primary ***
Purged 447 marked values in 0.11ms.

RECOMMENDATION #1 ( Offset: 0.00, GCD: 0.00, Casting: 0.00 ).
```
## New Snapshot Excerpt
```
Enhancement; Primary - Surging Totem(0.00), Primordial Wave(0.94), Crash Lightning(1.88)
build: v11.1.0-1.0.8
level: 80 (80)
class: SHAMAN
spec: enhancement

### Talents ###

In-Game Import: CcQAL+iDLHPJSLC+6fqMJ8tubOzMjZGmBzMGzMbmx2sNDAAAAAAAAAA2gNYGLasNgMTwGAmlJzALLmZmZYGzYYZmZyCLjlxMDAwMA
    amplification_core = 1/1
    ashen_catalyst = 1/1
    astral_shift = 1/1
    brimming_with_life = 1/1
    call_of_the_elements = 1/1
    capacitor_totem = 1/1
    chain_lightning = 1/1
    cleanse_spirit = 1/1
    crash_lightning = 1/1
    crashing_storms = 1/1
    doom_winds = 1/1
    earth_elemental = 1/1
    earth_shield = 1/1
    earthsurge = 1/1
    elemental_blast = 1/1
    elemental_orbit = 1/1
    elemental_warding = 1/1
    elemental_weapons = 1/1
    enhanced_imbues = 1/1
    feral_spirit = 1/1
    fire_and_ice = 1/1
    flowing_spirits = 1/1
    flurry = 1/1
    forceful_winds = 1/1
    hot_hand = 2/2
    imbuement_mastery = 1/1
    improved_maelstrom_weapon = 1/1
    lashing_flames = 1/1
    lava_burst = 1/1
    lava_lash = 1/1
    legacy_of_the_frost_witch = 2/2
    lively_totems = 1/1
    maelstrom_weapon = 1/1
    molten_assault = 1/1
    molten_thunder = 1/1
    natures_fury = 1/1
    natures_guardian = 1/1
    overflowing_maelstrom = 1/1
    planes_traveler = 1/1
    primordial_bond = 1/1
    primordial_storm = 1/1
    primordial_wave = 1/1
    purge = 1/1
    raging_maelstrom = 1/1
    reactivity = 1/1
    refreshing_waters = 1/1
    seasoned_winds = 1/1
    spirit_walk = 1/1
    spirit_wolf = 1/1
    splintered_elements = 2/2
    static_charge = 1/1
    stone_bulwark_totem = 1/1
    sundering = 1/1
    supportive_imbuements = 1/1
    surging_totem = 1/1
    swift_recall = 1/1
    thundershock = 1/1
    thunderstorm = 1/1
    totemic = 1/1
    totemic_focus = 1/1
    totemic_projection = 1/1
    totemic_rebound = 1/1
    totemic_recall = 1/1
    totemic_surge = 1/1
    unrelenting_storms = 1/1
    unruly_winds = 1/1
    whirling_elements = 1/1
    wind_barrier = 1/1
    wind_rush_totem = 1/1
    wind_shear = 1/1
    windfury_weapon = 1/1
    winds_of_alakir = 1/1

PvP Talents: none

### Legacy Content ###

covenant: none
conduits: none
soulbinds: []
legendaries: none

### Gear & Items ###

sets:
    tww2 = 2

gear:
    85year_tenure_ring = 1
    blastborne_hauberk = 1
    blastborne_links = 1
    bloodoath_signet = 1
    crowd_favorite = 1
    expeditionary_chopper = 1
    flamekeepers_footpads = 1
    gale_sovereigns_charged_hood = 1
    gale_sovereigns_zephyrs = 1
    galvanic_graffiti_cuffs = 1
    holybound_grips = 1
    hornadorned_chausses = 1
    mechanocore_amplifier = 1
    mightbeinvisible_cloak = 1
    mindbreaker_pendant = 1
    suspicious_energy_drink = 1
    tww2 = 2

itemIDs: 144117, 178871, 221119, 221198, 221244, 224639, 228846, 228904, 229260, 229262, 232485, 232729, 233481, 235363, 235447, 235453

### Settings ###

Settings:
    aoe = 2
    custom1Name = Custom 1
    custom2Name = Custom 2
    cycle = false
    cycle_min = 6
    damage = true
    damageDots = false
    damageExpiration = 8
    damageOnScreen = true
    damagePets = false
    damageRange = 0
    enabled = true
    gcdSync = true
    nameplateRange = 10
    nameplates = true
    noFeignedCooldown = false
    package = Enhancement
    petbased = false
    placeboBar = 3
    potion = default
    rangeFilter = false
    filler_shock = false
    funnel_priority = false
    hostile_dispel = false
    pad_lava_lash = false
    pad_windstrike = true
    purge_icd = 12
    pwave_gcds = 3
    pwave_targets = 0

Toggles:
    cooldowns = true 
    custom1 = false 
    custom2 = false 
    defensives = false [separate]
    essences = true [overridden]
    funnel = false 
    interrupts = false [separate]
    mode = automatic 
    potions = false 

Keybinds:
    astral_shift             = SE  [06]
    capacitor_totem          = S3  [06]
    chain_lightning          = 3   [01]
    crash_lightning          = R   [01]
    doom_winds               = SF  [06]
    earth_elemental          = SQ  [06]
    earth_shield             = N4  [04]
    elemental_blast          = E   [01]
    flame_shock              = T   [01]
    frost_shock              = SG  [06]
    ghost_wolf               = N2  [04], G   [11]
    healing_stream_totem     = S6  [06]
    healing_surge            = S1  [06]
    lava_burst               = E   [01]
    lava_lash                = 2   [01]
    lightning_bolt           = G   [01]
    primordial_wave          = F   [01]
    purge                    = N5  [04]
    stone_bulwark_totem      = SR  [06]
    stormstrike              = 1   [01]
    sundering                = Q   [01]
    surging_totem            = 4   [01]
    surging_totem_projection = 4   [01]
    tempest                  = G   [01]
    thunderstorm             = S4  [06]
    totemic_projection       = 5   [01]
    voltaic_blaze            = T   [01]
    wind_rush_totem          = S5  [06]
    wind_shear               = N1  [04]
    windstrike               = 1   [01]

### Warnings ###

none


### Targets ###

detected_targets:  Nameplates are enabled.
 - Checking nameplate list for nameplate3 [ Creature-0-4227-2552-16262-225982-0000D49CC8 ] Cleave Training Dummy.
    nameplate3   - -1 - Creature-0-4227-2552-16262-225982-0000D49CC8 - 24.00 - 8 - Cleave Training Dummy 

 - Checking nameplate list for nameplate5 [ Creature-0-4227-2552-16262-225982-0000549CC7 ] Cleave Training Dummy.
    nameplate5   - -1 - Creature-0-4227-2552-16262-225982-0000549CC7 - 23.00 - 6 - Cleave Training Dummy 

 - Checking nameplate list for nameplate1 [ Creature-0-4227-2552-16262-225982-0000D49CC7 ] Cleave Training Dummy.
    nameplate1   - -1 - Creature-0-4227-2552-16262-225982-0000D49CC7 - 35.00 - 6 - Cleave Training Dummy 

 - Checking nameplate list for nameplate6 [ Creature-0-4227-2552-16262-225982-0002549CC8 ] Cleave Training Dummy.
    nameplate6   - -1 - Creature-0-4227-2552-16262-225982-0002549CC8 - 29.00 - 6 - Cleave Training Dummy 

 - Checking nameplate list for nameplate4 [ Creature-0-4227-2552-16262-225982-0002D49CC8 ] Cleave Training Dummy.
    nameplate4   - -1 - Creature-0-4227-2552-16262-225982-0002D49CC8 - 5.00 - 6 - Cleave Training Dummy 


### Auras ###

player_buffs:
   id      - name                                 - stacks - remaining duration
   462854  - skyfury                              -   1    - 129.38
   192106  - lightning_shield                     -   1    - 130.54
   2825    - bloodlust                            -   1    - 37.28
   442983  - *viziers_savvy                       -   1    - 3600.00
   335151  - *sign_of_the_mists                   -   1    - 3600.00
   404468  - *flight_style_steady                 -   1    - 3600.00
   292361  - *embrace_of_paku                     -   1    - 3600.00
   383648  - earth_shield                         -   9    - 133.11
   392375  - earthen_weapon                       -   1    - 3600.00
   344179  - maelstrom_weapon                     -   2    - 28.15
   333957  - feral_spirit                         -   1    - 3.07
   1214807 - *mechanocore_amplifier               -   1    - 6.01
   382889  - flurry                               -   3    - 14.86
   1218616 - winning_streak                       -   2    - 29.40
   390371  - ashen_catalyst                       -   6    - 14.50
   292463  - *embrace_of_paku                     -   1    - 11.40
   262652  - *forceful_winds                      -   1    - 14.40


player_debuffs:
   57724   - sated_actual                         -   1    - 597.28


target_buffs:


target_debuffs:
   188389  - flame_shock                          -   1    - 21.21
   334168  - lashing_flames                       -   1    - 17.91
   467390  - *flametongue_attack                  -   1    - 0.20


previous_spells:
   1 - lava_lash
   2 - totemic_projection
   3 - bloodlust


New Recommendations for [ Primary ] requested at 02:02:01 ( 209687.92 ); using built-in ( Enhancement ) priority.
*** START OF NEW DISPLAY: Primary ***
Purged 444 marked values in 0.11ms.
Feral Spirits: 1
Earthen Weapons: 1
Combat Timer: 5.06

RECOMMENDATION #1 ( Offset: 0.00, GCD: 0.00, Casting: 0.00 ).
```