### PR TITLE
Standardize APL Expressions To Match Our Internal Code

### DIFF
--- a/Options.lua
+++ b/Options.lua
@@ -11642,7 +11642,6 @@ do
         { "set_bonus%.thewarwithin_season_2_4pc"            , "set_bonus.tww2 >= 4"                     },
         { "set_bonus%.tww2_2pc"                             , "set_bonus.tww2 >= 2"                     },
         { "set_bonus%.tww2_4pc"                             , "set_bonus.tww2 >= 4"                     },
-        { "set_bonus%.([%w_]+)_([24])pc"                    , "set_bonus.%1 >= %2"                      },
 
 
         { "equipped%.(%d+)", nil, function( item )

--- a/Options.lua
+++ b/Options.lua
@@ -11637,6 +11637,13 @@ do
         { "player"                                          , "player.unit"                             },
         { "gcd"                                             , "gcd.max"                                 },
         { "howl_summon%.([%w_]+)%.([%w_]+)"                 , "howl_summon.%1_%2"                       },
+        -- Standardize 2pc/4pc set bonus APL expressions
+        { "set_bonus%.thewarwithin_season_2_2pc"            , "set_bonus.tww2 >= 2"                     },
+        { "set_bonus%.thewarwithin_season_2_4pc"            , "set_bonus.tww2 >= 4"                     },
+        { "set_bonus%.tww2_2pc"                             , "set_bonus.tww2 >= 2"                     },
+        { "set_bonus%.tww2_4pc"                             , "set_bonus.tww2 >= 4"                     },
+        { "set_bonus%.([%w_]+)_([24])pc"                    , "set_bonus.%1 >= %2"                      },
+
 
         { "equipped%.(%d+)", nil, function( item )
             item = tonumber( item )

--- a/TheWarWithin/HunterBeastMastery.lua
+++ b/TheWarWithin/HunterBeastMastery.lua
@@ -1230,7 +1230,7 @@ spec:RegisterPets({
 
 --- The War Within
 spec:RegisterGear( "tww1", 212018, 212019, 212020, 212021, 212023 )
-spec:RegisterGear( "tww2", 229271, 229272, 229274, 229270, 229273 )
+spec:RegisterGear( "tww2", 229271, 229269, 229274, 229272, 229270 )
 spec:RegisterAuras( {
    -- 2-set
     jackpot = {

--- a/TheWarWithin/HunterMarksmanship.lua
+++ b/TheWarWithin/HunterMarksmanship.lua
@@ -811,7 +811,7 @@ spec:RegisterStateTable( "tar_trap", setmetatable( {}, {
 
 
 spec:RegisterGear( "tww1", 212018, 212019, 212020, 212021, 212023 )
-spec:RegisterGear( "tww2", 229271, 229272, 229274, 229270, 229273 )
+spec:RegisterGear( "tww2", 229271, 229269, 229274, 229272, 229270 )
 spec:RegisterAuras( {
     -- 2-set
     -- https://www.wowhead.com/spell=1218033

--- a/TheWarWithin/HunterSurvival.lua
+++ b/TheWarWithin/HunterSurvival.lua
@@ -672,7 +672,7 @@ spec:RegisterPets({
 } )
 
 -- The War Within
-spec:RegisterGear( "tww2", 229271, 229272, 229274, 229270, 229273 )
+spec:RegisterGear( "tww2", 229271, 229269, 229274, 229272, 229270 )
 spec:RegisterAuras( {
     -- 2-set
     -- https://www.wowhead.com/spell=1216874

--- a/TheWarWithin/MonkBrewmaster.lua
+++ b/TheWarWithin/MonkBrewmaster.lua
@@ -764,7 +764,7 @@ spec:RegisterHook( "reset_postcast", function( x )
 end )
 
 -- The War Within
-spec:RegisterGear( "tww2", 229298, 212045, 229301, 229299, 229297 )
+spec:RegisterGear( "tww2", 229301, 229299, 229298, 229297, 229296 )
 spec:RegisterAuras( {
     -- 2-set
     -- https://www.wowhead.com/ptr-2/spell=1217990/luck-of-the-draw

--- a/TheWarWithin/MonkMistweaver.lua
+++ b/TheWarWithin/MonkMistweaver.lua
@@ -644,7 +644,7 @@ spec:RegisterAuras( {
 } )
 
 -- The War Within
-spec:RegisterGear( "tww2", 229298, 212045, 229301, 229299, 229297 )
+spec:RegisterGear( "tww2", 229301, 229299, 229298, 229297, 229296 )
 
 -- Dragonflight
 spec:RegisterGear( "tier31", 207243, 207244, 207245, 207246, 207248, 217188, 217190, 217186, 217187, 217189 )

--- a/TheWarWithin/MonkWindwalker.lua
+++ b/TheWarWithin/MonkWindwalker.lua
@@ -788,7 +788,7 @@ spec:RegisterAuras( {
 } )
 
 -- The War Within
-spec:RegisterGear( "tww2", 229298, 212045, 229301, 229299, 229297 )
+spec:RegisterGear( "tww2", 229301, 229299, 229298, 229297, 229296 )
 spec:RegisterAuras( {
     -- 2-set
     -- https://www.wowhead.com/ptr-2/spell=1216182/winning-streak // https://www.wowhead.com/ptr-2/spell=1215717/monk-windwalker-11-1-class-set-2pc


### PR DESCRIPTION
All of our tier sets are registered as "tww2" but the APL writers dont love us. These translation entries stop us from needing to register additional set bonuses or gear `copy` fields on every spec.

Example:

Enhance: `set_bonus.tww2_4pc`
Marksmanship Hunter: `set_bonus.thewarwithin_season_2_4pc`
BM Hunter: `set_bonus.tww2>=2` (works as-is with our code)

Additionally, fixes hunter and monk incorrect IDs.

With this PR, I hand-checked every single class against SimC `item_set_bonus_ptr.inc`, all classes are now correct.