### PR TITLE
Tier sets

### DIFF
--- a/Options.lua
+++ b/Options.lua
@@ -11642,7 +11642,6 @@ do
         { "set_bonus%.thewarwithin_season_2_4pc"            , "set_bonus.tww2 >= 4"                     },
         { "set_bonus%.tww2_2pc"                             , "set_bonus.tww2 >= 2"                     },
         { "set_bonus%.tww2_4pc"                             , "set_bonus.tww2 >= 4"                     },
-        { "set_bonus%.([%w_]+)_([24])pc"                    , "set_bonus.%1 >= %2"                      },
 
 
         { "equipped%.(%d+)", nil, function( item )

--- a/Options.lua
+++ b/Options.lua
@@ -11637,6 +11637,13 @@ do
         { "player"                                          , "player.unit"                             },
         { "gcd"                                             , "gcd.max"                                 },
         { "howl_summon%.([%w_]+)%.([%w_]+)"                 , "howl_summon.%1_%2"                       },
+        -- Standardize 2pc/4pc set bonus APL expressions
+        { "set_bonus%.thewarwithin_season_2_2pc"            , "set_bonus.tww2 >= 2"                     },
+        { "set_bonus%.thewarwithin_season_2_4pc"            , "set_bonus.tww2 >= 4"                     },
+        { "set_bonus%.tww2_2pc"                             , "set_bonus.tww2 >= 2"                     },
+        { "set_bonus%.tww2_4pc"                             , "set_bonus.tww2 >= 4"                     },
+        { "set_bonus%.([%w_]+)_([24])pc"                    , "set_bonus.%1 >= %2"                      },
+
 
         { "equipped%.(%d+)", nil, function( item )
             item = tonumber( item )

--- a/Options.lua
+++ b/Options.lua
@@ -11637,12 +11637,6 @@ do
         { "player"                                          , "player.unit"                             },
         { "gcd"                                             , "gcd.max"                                 },
         { "howl_summon%.([%w_]+)%.([%w_]+)"                 , "howl_summon.%1_%2"                       },
-        -- Standardize 2pc/4pc set bonus APL expressions
-        { "set_bonus%.thewarwithin_season_2_2pc"            , "set_bonus.tww2 >= 2"                     },
-        { "set_bonus%.thewarwithin_season_2_4pc"            , "set_bonus.tww2 >= 4"                     },
-        { "set_bonus%.tww2_2pc"                             , "set_bonus.tww2 >= 2"                     },
-        { "set_bonus%.tww2_4pc"                             , "set_bonus.tww2 >= 4"                     },
-
 
         { "equipped%.(%d+)", nil, function( item )
             item = tonumber( item )

--- a/State.lua
+++ b/State.lua
@@ -4749,39 +4749,34 @@ do
     } )
 end
 
-
-
 -- Table of set bonuses. Some string manipulation to honor the SimC syntax.
 -- Currently returns 1 for true, 0 for false to be consistent with SimC conditionals.
 -- Won't catch fake set names. Should revise.
 local mt_set_bonuses = {
-    __index = function(t, k)
-        if type(k) == "number" then return 0 end
+    __index = function( t, k )
+        if type( k ) == "number" then return 0 end
 
-        -- if ( not class.artifacts[ k ] ) and ( state.bg or state.arena ) then return 0 end
+        -- Aliases to account for syntax differences across specs in SimC
+        local aliasMap = {
+            thewarwithin_season_2 = "tww2",
+            -- room for more in future tiers
+        }
 
-        local set, pieces, class = k:match("^(.-)_"), tonumber( k:match("_(%d+)pc") ), k:match("pc(.-)$")
+        -- Match suffix pattern like tww2_2pc, tww2_4pc, thewarwithin_season_2_2pc, etc.
+        local rawSet, pieces = k:match( "^([%w_]+)_([24])pc$" )
+        if rawSet and pieces then
+            local set = aliasMap[ rawSet ] or rawSet
+            pieces = tonumber( pieces )
 
-        if not pieces or not set then
-            -- This wasn't a tier set bonus.
-            return 0
-
-        else
-            if class then set = set .. class end
-
-            if not t[set] then
-                return 0
-            end
-
-            return t[set] >= pieces and 1 or 0
+            if not t[ set ] then return 0 end
+            return t[ set ] >= pieces and 1 or 0
         end
 
+        -- Non-matching or malformed key
         return 0
-
     end
 }
 ns.metatables.mt_set_bonuses = mt_set_bonuses
-
 
 local mt_equipped = {
     __index = function(t, k)

--- a/TheWarWithin/DemonHunterHavoc.lua
+++ b/TheWarWithin/DemonHunterHavoc.lua
@@ -1031,8 +1031,6 @@ spec:RegisterGear( "tier31", 207261, 207262, 207263, 207264, 207266, 217228, 217
 -- (4) Throw Glaive reduces the remaining cooldown of The Hunt by ${$s1/1000}.1 sec, and The Hunt's damage over time effect lasts ${$s2/1000} sec longer.
 
 spec:RegisterGear( "tww2", 229316, 229314, 229319, 229317, 229315 )
--- APL uses this syntax because ...
-spec:RegisterGear( "thewarwithin_season_2", 229316, 229314, 229319, 229317, 229315 )
 
 spec:RegisterAuras( {
     -- 2-set

--- a/TheWarWithin/HunterBeastMastery.lua
+++ b/TheWarWithin/HunterBeastMastery.lua
@@ -1230,7 +1230,7 @@ spec:RegisterPets({
 
 --- The War Within
 spec:RegisterGear( "tww1", 212018, 212019, 212020, 212021, 212023 )
-spec:RegisterGear( "tww2", 229271, 229272, 229274, 229270, 229273 )
+spec:RegisterGear( "tww2", 229271, 229269, 229274, 229272, 229270 )
 spec:RegisterAuras( {
    -- 2-set
     jackpot = {

--- a/TheWarWithin/HunterMarksmanship.lua
+++ b/TheWarWithin/HunterMarksmanship.lua
@@ -811,7 +811,7 @@ spec:RegisterStateTable( "tar_trap", setmetatable( {}, {
 
 
 spec:RegisterGear( "tww1", 212018, 212019, 212020, 212021, 212023 )
-spec:RegisterGear( "tww2", 229271, 229272, 229274, 229270, 229273 )
+spec:RegisterGear( "tww2", 229271, 229269, 229274, 229272, 229270 )
 spec:RegisterAuras( {
     -- 2-set
     -- https://www.wowhead.com/spell=1218033

--- a/TheWarWithin/HunterSurvival.lua
+++ b/TheWarWithin/HunterSurvival.lua
@@ -672,7 +672,7 @@ spec:RegisterPets({
 } )
 
 -- The War Within
-spec:RegisterGear( "tww2", 229271, 229272, 229274, 229270, 229273 )
+spec:RegisterGear( "tww2", 229271, 229269, 229274, 229272, 229270 )
 spec:RegisterAuras( {
     -- 2-set
     -- https://www.wowhead.com/spell=1216874

--- a/TheWarWithin/MonkBrewmaster.lua
+++ b/TheWarWithin/MonkBrewmaster.lua
@@ -764,7 +764,7 @@ spec:RegisterHook( "reset_postcast", function( x )
 end )
 
 -- The War Within
-spec:RegisterGear( "tww2", 229298, 212045, 229301, 229299, 229297 )
+spec:RegisterGear( "tww2", 229301, 229299, 229298, 229297, 229296 )
 spec:RegisterAuras( {
     -- 2-set
     -- https://www.wowhead.com/ptr-2/spell=1217990/luck-of-the-draw

--- a/TheWarWithin/MonkMistweaver.lua
+++ b/TheWarWithin/MonkMistweaver.lua
@@ -644,7 +644,7 @@ spec:RegisterAuras( {
 } )
 
 -- The War Within
-spec:RegisterGear( "tww2", 229298, 212045, 229301, 229299, 229297 )
+spec:RegisterGear( "tww2", 229301, 229299, 229298, 229297, 229296 )
 
 -- Dragonflight
 spec:RegisterGear( "tier31", 207243, 207244, 207245, 207246, 207248, 217188, 217190, 217186, 217187, 217189 )

--- a/TheWarWithin/MonkWindwalker.lua
+++ b/TheWarWithin/MonkWindwalker.lua
@@ -788,7 +788,7 @@ spec:RegisterAuras( {
 } )
 
 -- The War Within
-spec:RegisterGear( "tww2", 229298, 212045, 229301, 229299, 229297 )
+spec:RegisterGear( "tww2", 229301, 229299, 229298, 229297, 229296 )
 spec:RegisterAuras( {
     -- 2-set
     -- https://www.wowhead.com/ptr-2/spell=1216182/winning-streak // https://www.wowhead.com/ptr-2/spell=1215717/monk-windwalker-11-1-class-set-2pc


### PR DESCRIPTION
## `mt_set_bonus`

All of our tier sets are registered as `tww2`, but there are currently 3 different syntax versions existing in SimC.

- `set_bonus.tww2_4pc` (example: Enhance)
- `set_bonus.thewarwithin_season_2_4pc` (example: Marksmanship)
- `set_bonus.tww2>=2` (example: Beast Mastery)
  - This version works natively with our code

The change to the `mt_set_bonus` table will make `set_bonus.some_name_xpc` instead look up `set_bonus.our_internal_name >= x`. This allows us to keep 1 naming convention across all class files (no need for copies, set bonus registrations), and still respect varying SimC syntaxes **_without_** translating them in the APL itself

The Alias map can be expanded and serves to convert variations into a single name, ideally the name we use to register sets.

Thanks @johnnylam88 for the feedback and suggestion

## Class tier IDs
- Fixed tier set IDs for the following classes
  - Hunter
  - Monk
- Hand checked the IDs of every class against the SimC file `item_set_bonus_ptr.inc`, all classes are now correct.
- Remove manual registration of `thewarwithin_season_2` from Havoc, no longer needed
