### PR TITLE
Survival: Tip of the Spear Override, minor tweaks

### DIFF
--- a/TheWarWithin/HunterSurvival.lua
+++ b/TheWarWithin/HunterSurvival.lua
@@ -584,6 +584,8 @@ spec:RegisterAuras( {
         max_stack = 3,
         meta = {
             stack = function() return max( 0, ( state.buff.tip_of_the_spear.stack - ( action.wildfire_bomb.in_flight and 1 or 0 ) ) ) end,
+            stacks = function() return max( 0, ( state.buff.tip_of_the_spear.stack - ( action.wildfire_bomb.in_flight and 1 or 0 ) ) ) end,
+            react = function() return max( 0, ( state.buff.tip_of_the_spear.stack - ( action.wildfire_bomb.in_flight and 1 or 0 ) ) ) end,
         }
     },
     trailblazer = {

--- a/TheWarWithin/HunterSurvival.lua
+++ b/TheWarWithin/HunterSurvival.lua
@@ -1030,9 +1030,9 @@ spec:RegisterAbilities( {
             if talent.scattered_prey.enabled then applyBuff( "scattered_prey" ) end
             removeStack( "tip_of_the_spear" )
 
-            --[[if talent.frenzy_strikes.enabled then
+            if talent.frenzy_strikes.enabled then
                 gainChargeTime( "wildfire_bomb", min( 5, true_active_enemies ) * 3 )
-            end--]]
+            end
 
             if talent.merciless_blow.enabled then applyDebuff( "target", "merciless_blows" ) end
 
@@ -1154,7 +1154,11 @@ spec:RegisterAbilities( {
         end,
 
         finish = function ()
-            if talent.ruthless_marauder.enabled then applyBuff( "ruthless_marauder" ) end
+            if talent.ruthless_marauder.enabled then
+                applyBuff( "ruthless_marauder" )
+                -- Can generate up to 3, but since its RNG we need to lowball it
+                addStack( "tip_of_the_spear" )
+            end
         end,
     },
 

--- a/TheWarWithin/HunterSurvival.lua
+++ b/TheWarWithin/HunterSurvival.lua
@@ -581,7 +581,10 @@ spec:RegisterAuras( {
     tip_of_the_spear = {
         id = 260286,
         duration = 10,
-        max_stack = 3
+        max_stack = 3,
+        meta = {
+            stack = function() return max( 0, ( state.buff.tip_of_the_spear.stack - ( action.wildfire_bomb.in_flight and 1 or 0 ) ) ) end,
+        }
     },
     trailblazer = {
         id = 231390,
@@ -1457,6 +1460,8 @@ spec:RegisterAbilities( {
         impactSpells = {
             wildfire_bomb = true,
         },
+
+        copy = 265157
     },
 
     raptor_bite = {


### PR DESCRIPTION
After discussion with Thyminde, override the stack counter such that the APL will not try and spend a stack you don't really have.

This occurs because
- `wildfire_bomb` does not consume the stack on cast, but on impact
- This bomb, however, was selected assuming the stack was available
- Without this change, future recommendations can "steal" this stack which is reserved for the in_flight bomb.
- Also, added spell copy to bomb for damage, the damage event doesn't use the same ID

Additionally, added tip of the spear stack prediction to `fury_of_the_eagle`, and uncommented a patch note change that was reverted