### PR TITLE
Clean up after your pets ...

### DIFF
--- a/State.lua
+++ b/State.lua
@@ -2555,8 +2555,6 @@ local mt_stat = {
 }
 ns.metatables.mt_stat = mt_stat
 
-
-
 -- Table of pet data.
 local mt_default_pet, mt_pets
 do
@@ -2570,6 +2568,7 @@ do
     -- Table of default handlers for specific pets/totems.
     mt_default_pet = {
         __index = function( t, k )
+
             if k == "expires" then
                 local totemIcon = rawget( t, "icon" )
 
@@ -2672,16 +2671,46 @@ do
 
     mt_pets = {
         __index = function( t, k )
+            local guid = UnitGUID( "pet" )
+
+            if rawget( t, "__last_pet_guid" ) ~= guid then
+                rawset( t, "__last_pet_guid", guid )
+                rawset( t, "real_pet", nil )
+
+                for alias, petData in pairs( class.pets ) do
+                    local token = petData.token or alias
+                    local entry = rawget( t, token )
+                    if entry and type( entry ) == "table" then
+                        rawset( entry, "expires", 0 )
+                    end
+                end
+            end
+
             if not rawget( t, "real_pet" ) then
                 local key
                 local petID = UnitGUID( "pet" )
 
                 if petID then
                     petID = tonumber( petID:match( "%-(%d+)%-[0-9A-F]+$" ) )
-                    local model = class.pets[ petID ]
+                    local model, token
+                    -- Try direct alias match first
+                    model = class.pets[ petID ]
+                    if model then
+                        token = model.token or petID
+                    else
+                        -- Fall back to checking .id from each registered pet
+                        for k, v in pairs( class.pets ) do
+                            local id = type( v.id ) == "function" and v.id() or v.id
+                            if id == petID then
+                                model = v
+                                token = v.token or k
+                                break
+                            end
+                        end
+                    end
 
                     if model then
-                        key = model.token
+                        key = token
                         local spell = model.spell
                         local ability = spell and class.abilities[ spell ]
                         local lastCast = ability and ability.lastCast or 0
@@ -2693,9 +2722,15 @@ do
                             summonPet( key )
                         end
                     end
+
                 end
 
-                t.real_pet = key or "fake_pet"
+                t.real_pet = key or rawget( t, "real_pet" ) or "fake_pet"
+                if key == nil then
+                    if Hekili.ActiveDebug then
+                        Hekili:Debug( "Failed to resolve pet ID %s to any registered pet.", tostring( petID ) )
+                    end
+                end
             end
 
             if k == "up" or k == "exists" or k == "active" then
@@ -7781,8 +7816,6 @@ function state:IsReadyNow( action )
     return true
 end
 
-
-
 function state:ClashOffset( action )
     local a = class.abilities[ action ]
     if not a then return 0 end
@@ -7795,7 +7828,6 @@ function state:ClashOffset( action )
 
     return ns.callHook( "clash", option.clash, action )
 end
-
 
 for k, v in pairs( state ) do
     ns.commitKey( k )

--- a/TheWarWithin/WarlockDemonology.lua
+++ b/TheWarWithin/WarlockDemonology.lua
@@ -1753,7 +1753,7 @@ spec:RegisterAbilities( {
         debuff = "casting",
         readyTime = state.timeToInterrupt,
 
-        usable = function () return pet.exists, "requires felguard" end,
+        usable = function() return pet.felguard.alive, "requires a living felguard" end,
         handler = function ()
             interrupt()
             applyDebuff( "target", "axe_toss", 4 )
@@ -1917,7 +1917,7 @@ spec:RegisterAbilities( {
         startsCombat = true,
         readyTime = function() return max( buff.fiendish_wrath.remains, buff.felstorm.remains ) end,
 
-        usable = function() return pet.alive and pet.real_pet == "felguard", "requires a living felguard" end,
+        usable = function() return pet.felguard.alive, "requires a living felguard" end,
         handler = function ()
             applyBuff( "felstorm" )
             applyBuff( "demonic_strength" )
@@ -1986,7 +1986,7 @@ spec:RegisterAbilities( {
         startsCombat = true,
         nobuff = "felstorm",
 
-        usable = function() return pet.alive and pet.real_pet == "felguard", "requires a living felguard" end,
+        usable = function() return pet.felguard.alive, "requires a living felguard" end,
         handler = function()
             removeBuff( "felstorm" )
             applyBuff( "fiendish_wrath" )
@@ -2327,7 +2327,7 @@ spec:RegisterAbilities( {
 
         readyTime = function() return buff.fiendish_wrath.remains end,
 
-        usable = function() return pet.alive and pet.real_pet == "felguard", "requires a living felguard" end,
+        usable = function() return pet.felguard.alive, "requires a living felguard" end,
         handler = function()
             applyBuff( "felstorm" )
             if cooldown.guillotine.remains < 5 then setCooldown( "guillotine", 8 ) end


### PR DESCRIPTION
# Tidy up pet management code.
## Visible issues before changes
- Cycling through different pets would show them all alive in the state file if you summoned/dismissed each one consecutively
- Pets registered under an alias would fall back to `fake_pet` (such as felguard when you're **_not_** glyphed)
  - I assume everyone glyphs felguard and this is why the issue hasn't been noticed until now
- `pet.felguard.x` was dedge.
## Solutions
- Replace direct lookup with a reverse lookup that supports aliases
- Ensure that pets are wiped everytime the primary `pets` metatable index is accessed (such as summoning a new pet)
- Only assign `fake_pet` as a last resort, try aliases first
- Use raw access to avoid infinite loops (don't ask how I know)
- Add snapshot debug print for when an ID can't be resolved
- Cycling through pets now accurately updates the state pets/pet table.
## Bonus
Now that `pet.felguard.alive`/`up` works, replace demonology `usable` checks to be more explicit. This PR came about because abilities that relied on felguard were being marked usable when **_any_** pet was up.