### PR TITLE
Anti-shoot-self-in-foot-feature

### DIFF
--- a/Options.lua
+++ b/Options.lua
@@ -8032,9 +8032,9 @@ n = tonumber( n ) + 1
                                             end
                                         end
 
-                                        -- 1. Internal Check
+                                        -- 1. Stress Test
                                         if type( stressTestResults ) == "string" and stressTestResults ~= "" then
-                                            table.insert( finalOutput, "|cffa0a0ffInternal Check:|r\n" .. stressTestResults )
+                                            table.insert( finalOutput, "|cffa0a0ffAutomatic Stress Test:|r " .. stressTestResults )
                                         end
                                         -- 2. Header
                                         if exportData.linked then
@@ -8047,7 +8047,7 @@ n = tonumber( n ) + 1
                                             table.insert( finalOutput, line )
                                         end
                                         if not exportData.linked and not exportData.unrelated and #output == 0 then
-                                            table.insert( finalOutput, "|cff00ff00Bleep bloop, you are a good egg.|r\nNo warnings or errors were detected during export." )
+                                            table.insert( finalOutput, "|cff00ff00No warnings or errors detected!|r\n" )
                                         end
 
                                         exportData.stress = table.concat( finalOutput, "\n\n" )

--- a/Options.lua
+++ b/Options.lua
@@ -7976,38 +7976,38 @@ n = tonumber( n ) + 1
                                     type = "input",
                                     name = "Priority Export String",
                                     desc = "Press CTRL+A to select, then CTRL+C to copy.",
-                                        get = function( info )
-                                            Hekili.PackExports = Hekili.PackExports or {}
+                                    get = function( info )
+                                        Hekili.PackExports = Hekili.PackExports or {}
 
-                                            -- Wipe old export for this pack
-                                            Hekili.PackExports[ pack ] = {
-                                                export = "",
-                                                stress = ""
-                                            }
+                                        -- Wipe old export for this pack
+                                        Hekili.PackExports[ pack ] = {
+                                            export = "",
+                                            stress = ""
+                                        }
 
-                                            local export = SerializeActionPack( pack )
-                                            Hekili.PackExports[ pack ].export = export
+                                        local export = SerializeActionPack( pack )
+                                        Hekili.PackExports[ pack ].export = export
 
-                                            -- Run the stress test
-                                            Hekili:RunStressTest()
+                                        -- Run the stress test
+                                        Hekili:RunStressTest()
 
-                                            -- Collect current warnings
-                                            local output = {}
-                                            for _, key in ipairs( Hekili.ErrorKeys ) do
-                                                local entry = Hekili.ErrorDB[ key ]
-                                                if entry then
-                                                    table.insert( output, string.format( "[%s (%dx)] %s\n%s", entry.last or "??", entry.n or 1, key, entry.text or "?" ) )
-                                                end
+                                        -- Collect current warnings
+                                        local output = {}
+                                        for _, key in ipairs( Hekili.ErrorKeys ) do
+                                            local entry = Hekili.ErrorDB[ key ]
+                                            if entry then
+                                                table.insert( output, string.format( "[%s (%dx)] %s\n%s", entry.last or "??", entry.n or 1, key, entry.text or "?" ) )
                                             end
+                                        end
 
-                                            if #output == 0 then
-                                                table.insert( output, "No warnings or errors detected." )
-                                            end
+                                        if #output == 0 then
+                                            table.insert( output, "No warnings or errors detected." )
+                                        end
 
-                                            Hekili.PackExports[ pack ].stress = table.concat( output, "\n\n" )
+                                        Hekili.PackExports[ pack ].stress = table.concat( output, "\n\n" )
 
-                                            return export
-                                        end,
+                                        return export
+                                    end,
 
                                     set = function() end,
                                     order = 1,

--- a/Options.lua
+++ b/Options.lua
@@ -8058,11 +8058,14 @@ n = tonumber( n ) + 1
                                     width = "full",
                                 },
                                 stressResults = {
-                                    type = "description",
-                                    name = function()
+                                    type = "input",
+                                    multiline = 20,
+                                    name = "Stress Test Results",
+                                    get = function()
                                         local info = Hekili.PackExports and Hekili.PackExports[ pack ]
                                         return info and info.stress or ""
                                     end,
+                                    set = function() end,
                                     fontSize = "medium",
                                     order = 2,
                                     width = "full",


### PR DESCRIPTION
Automatically run a stress test, and output the results + the warnings log when you try to get a pack export string.


View from a good APL
![image](https://github.com/user-attachments/assets/35211dd7-7270-448b-a428-a35e3cc1a613)

View from a bad APL
![image](https://github.com/user-attachments/assets/7a8f8682-ef31-47c2-a52b-3f5bc07a0d88)
