### PR TITLE
Default Empowerment

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -1355,7 +1355,7 @@ function Hekili:GetPredictionFromAPL( dispName, packName, listName, slot, action
                                                         state.selection_time = state.delay
                                                         state.selected_action = rAction
 
-                                                        slot.empower_to = ability.empowered and ( ability.caption or state.args.empower_to or state.max_empower ) or nil
+                                                        slot.empower_to = ability.empowered and ( ability.caption or state.args.empower_to or ability.default_empowerment or state.max_empower ) or nil
 
                                                         if debug then
                                                             -- scripts:ImplantDebugData( slot )

--- a/Core.lua
+++ b/Core.lua
@@ -1355,7 +1355,7 @@ function Hekili:GetPredictionFromAPL( dispName, packName, listName, slot, action
                                                         state.selection_time = state.delay
                                                         state.selected_action = rAction
 
-                                                        slot.empower_to = ability.empowered and ( ability.caption or state.args.empower_to or ability.default_empowerment or state.max_empower ) or nil
+                                                        slot.empower_to = ability.empowered and ( ability.caption or state.args.empower_to or ability.empowerment_default or state.max_empower ) or nil
 
                                                         if debug then
                                                             -- scripts:ImplantDebugData( slot )

--- a/TheWarWithin/MonkWindwalker.lua
+++ b/TheWarWithin/MonkWindwalker.lua
@@ -1748,6 +1748,8 @@ spec:RegisterAbilities( {
         startsCombat = false,
         texture = 1029596,
 
+        empowerment_default = 1,
+        
         handler = function ()
         end,
     },


### PR DESCRIPTION
- Add fallback within Core `slot.empower_to` to also check for default, **_before_** falling back to max.
- Set WW slicing winds default to 1, as empowerment only changes distance and the WW APL does not have `empower_to` modifiers in it.

This makes WW correctly default to empower 1 instead of empower 3 for slicing winds, and will support more default empowerments in the future if other APLs decide not to include the modifer.