### PR TITLE
Per-Ability DoT cap setting

### DIFF
--- a/Classes.lua
+++ b/Classes.lua
@@ -65,6 +65,7 @@ local specTemplate = {
             clash = 0,
             targetMin = 0,
             targetMax = 0,
+            dotCap = 0,
             boss = false
         }
     },

--- a/Options.lua
+++ b/Options.lua
@@ -4178,8 +4178,8 @@ self:ForceUpdate( "SPEC_PACKAGE_CHANGED" )
 
             dotCap = {
                 type = "range",
-                name = "DoT Cap",
-                desc = "If set above zero, this ability will not be recommended if there are this many or more active DoTs from this ability, unless the DoT is refreshable on your main target.\n\n" ..
+                name = "Maximum Applications",
+                desc = "If set above zero, this ability will not be recommended when it has been applied to this number of targets (or more). If the aura is refreshable on your current target, this limit is ignored.\n\n" ..
                        "Set to zero to ignore this limit.",
                 width = 1.5,
                 min = 0,
@@ -4353,9 +4353,9 @@ self:ForceUpdate( "SPEC_PACKAGE_CHANGED" )
 
                     dotCap = {
                         type = "range",
-                        name = "DoT Cap",
-                        desc = "If set above zero, this ability will not be recommended if there are this many or more active DoTs from this ability, unless the DoT is refreshable on your main target.\n\n" ..
-                               "Set to zero to ignore this limit.",
+                        name = "Maximum Applications",
+                        desc = "If set above zero, this ability will not be recommended when it has been applied to this number of targets (or more). If the aura is refreshable on your current target, this limit is ignored.\n\n" ..
+                        "Set to zero to ignore this limit.",
                         width = 1.5,
                         min = 0,
                         max = 100,

--- a/Options.lua
+++ b/Options.lua
@@ -4176,6 +4176,18 @@ self:ForceUpdate( "SPEC_PACKAGE_CHANGED" )
                 order = 3.2,
             },
 
+            dotCap = {
+                type = "range",
+                name = "DoT Cap",
+                desc = "If set above zero, this ability will not be recommended if there are this many or more active DoTs from this ability.\n" ..
+                       "Set to zero to ignore this limit.",
+                width = 1.5,
+                min = 0,
+                max = 100,
+                step = 1,
+                order = 3.25,
+            },
+
             clash = {
                 type = "range",
                 name = "Clash",
@@ -4339,18 +4351,29 @@ self:ForceUpdate( "SPEC_PACKAGE_CHANGED" )
                         order = 2.11,
                     },
 
+                    dotCap = {
+                        type = "range",
+                        name = "DoT Cap",
+                        desc = "If set above zero, this ability will not be recommended if there are this many or more active DoTs from this ability.\n" ..
+                               "Set to zero to ignore this limit.",
+                        width = 1.5,
+                        min = 0,
+                        max = 100,
+                        step = 1,
+                        order = 2.19,
+                    },
+
                     clash = {
                         type = "range",
                         name = "Clash",
                         desc = "If set above zero, the addon will pretend " .. k .. " has come off cooldown this much sooner than it actually has.  " ..
                             "This can be helpful when an ability is very high priority and you want the addon to prefer it over abilities that are available sooner.",
-                        width = 3,
+                        width = 1.5,
                         min = -1.5,
                         max = 1.5,
                         step = 0.05,
                         order = 2.2,
                     },
-
 
                     lineBreak3 = {
                         type = "description",

--- a/Options.lua
+++ b/Options.lua
@@ -4179,7 +4179,7 @@ self:ForceUpdate( "SPEC_PACKAGE_CHANGED" )
             dotCap = {
                 type = "range",
                 name = "DoT Cap",
-                desc = "If set above zero, this ability will not be recommended if there are this many or more active DoTs from this ability.\n" ..
+                desc = "If set above zero, this ability will not be recommended if there are this many or more active DoTs from this ability.\n\n" ..
                        "Set to zero to ignore this limit.",
                 width = 1.5,
                 min = 0,
@@ -4354,7 +4354,7 @@ self:ForceUpdate( "SPEC_PACKAGE_CHANGED" )
                     dotCap = {
                         type = "range",
                         name = "DoT Cap",
-                        desc = "If set above zero, this ability will not be recommended if there are this many or more active DoTs from this ability.\n" ..
+                        desc = "If set above zero, this ability will not be recommended if there are this many or more active DoTs from this ability.\n\n" ..
                                "Set to zero to ignore this limit.",
                         width = 1.5,
                         min = 0,

--- a/Options.lua
+++ b/Options.lua
@@ -4179,7 +4179,7 @@ self:ForceUpdate( "SPEC_PACKAGE_CHANGED" )
             dotCap = {
                 type = "range",
                 name = "DoT Cap",
-                desc = "If set above zero, this ability will not be recommended if there are this many or more active DoTs from this ability.\n\n" ..
+                desc = "If set above zero, this ability will not be recommended if there are this many or more active DoTs from this ability, unless the DoT is refreshable on your main target.\n\n" ..
                        "Set to zero to ignore this limit.",
                 width = 1.5,
                 min = 0,
@@ -4354,7 +4354,7 @@ self:ForceUpdate( "SPEC_PACKAGE_CHANGED" )
                     dotCap = {
                         type = "range",
                         name = "DoT Cap",
-                        desc = "If set above zero, this ability will not be recommended if there are this many or more active DoTs from this ability.\n\n" ..
+                        desc = "If set above zero, this ability will not be recommended if there are this many or more active DoTs from this ability, unless the DoT is refreshable on your main target.\n\n" ..
                                "Set to zero to ignore this limit.",
                         width = 1.5,
                         min = 0,

--- a/State.lua
+++ b/State.lua
@@ -7332,6 +7332,10 @@ do
         elseif option.targetMax > 0 and self.active_enemies > option.targetMax then
             return true, "active_enemies[" .. self.active_enemies .. "] is more than ability's maximum targets [" .. option.targetMax .. "]"
         end
+        -- New: DoT Cap
+        if option.dotCap and option.dotCap > 0 and state.active_dot[ spell ] and state.active_dot[ spell ] >= option.dotCap then
+            return true, "DoT cap reached (" .. state.active_dot[ spell ] .. "/" .. option.dotCap .. ")"
+        end
 
         return false
     end

--- a/State.lua
+++ b/State.lua
@@ -7334,7 +7334,10 @@ do
         end
         -- New: DoT Cap
         if option.dotCap and option.dotCap > 0 and state.active_dot[ spell ] and state.active_dot[ spell ] >= option.dotCap then
-            return true, "DoT cap reached (" .. state.active_dot[ spell ] .. "/" .. option.dotCap .. ")"
+            if state.dot[ spell ] and state.dot[ spell ].refreshable then
+                return false, "DoT cap reached, but target is refreshable"
+            end
+            return true, "DoT cap reached (" .. state.active_dot[ spell ] .. "/" .. option.dotCap .. ") and target is not refreshable"
         end
 
         return false

--- a/State.lua
+++ b/State.lua
@@ -7339,15 +7339,15 @@ do
             local aura = state.dot[ spell ]
             if activeDot and activeDot >= dotCap then
                 if aura and not aura.refreshable then
-                    return true, "current applications [" .. activeDot .. "] meet/exceed the ability's maximum targets [" .. dotCap .. "]"
+                    return true, "applications[" .. activeDot .. "] meet/exceed the ability's maximum targets [" .. dotCap .. "]"
                 end
             end
 
             if Hekili.ActiveDebug then
                 if activeDot < dotCap then
-                    Hekili:Debug( "    %s: current applications less than maximum applications [%d/%d].", spell, activeDot, dotCap )
+                    Hekili:Debug( "    %s: current applications fewer than maximum applications [%d/%d].", spell, activeDot, dotCap )
                 elseif aura and aura.refreshable then
-                    Hekili:Debug( "    %s: target refreshable despite max applications [%d/%d]", spell, activeDot, dotCap )
+                    Hekili:Debug( "    %s: target refreshable despite maximum applications [%d/%d]", spell, activeDot, dotCap )
                 end
             end
         end

--- a/State.lua
+++ b/State.lua
@@ -7333,16 +7333,27 @@ do
             return true, "active_enemies[" .. self.active_enemies .. "] is more than ability's maximum targets [" .. option.targetMax .. "]"
         end
         -- New: DoT Cap
-        if option.dotCap and option.dotCap > 0 and state.active_dot[ spell ] and state.active_dot[ spell ] >= option.dotCap then
-            if state.dot[ spell ] and state.dot[ spell ].refreshable then
-                return false, "DoT cap reached, but target is refreshable"
+        local dotCap = option.dotCap
+        if dotCap and dotCap > 0 then
+            local activeDot = state.active_dot[ spell ]
+            local aura = state.dot[ spell ]
+            if activeDot and activeDot >= dotCap then
+                if aura and not aura.refreshable then
+                    return true, "current applications [" .. activeDot .. "] meet/exceed the ability's maximum targets [" .. dotCap .. "]"
+                end
             end
-            return true, "DoT cap reached (" .. state.active_dot[ spell ] .. "/" .. option.dotCap .. ") and target is not refreshable"
+
+            if Hekili.ActiveDebug then
+                if activeDot < dotCap then
+                    Hekili:Debug( "    %s: current applications less than maximum applications [%d/%d].", spell, activeDot, dotCap )
+                elseif aura and aura.refreshable then
+                    Hekili:Debug( "    %s: target refreshable despite max applications [%d/%d]", spell, activeDot, dotCap )
+                end
+            end
         end
 
         return false
     end
-
 
     -- TODO:  Finish this, need to support toggles that knock spells to their own display vs. toggles that disable an ability entirely.
     function state:IsFiltered( spell )


### PR DESCRIPTION
# Add an ability option to manually set a DoT cap.
## Features
- Fully opt-in, all abilities are initialized as `0` which is ignored (in line with most other settings)
- Simple slider like other settings
- Provides snapshot info, only if the ability has a user-configured dot cap
  - disabled reason
  - If allowed, provides info about dot cap
- Use case
  - Allow user to hardcap dots such as `moonfire`, which can be useful in m+ content where the APL may try and force you to dot literally every mob, but at a certain point you need to just start your rotation
  - Addresses https://github.com/Hekili/hekili/issues/4581
- Does not interfere with other spells at all. Tested with some "regular" dot-less spells set to a cap of 1, no impact.
- If the dot is refreshable on your current target, the dot cap is ignored to avoid interfering with the APL
## Gaps
- If the dot you wish to limit does not have a name/alias/copy that matches the spell name, it likely won't work
  - Can be manually added in over time if/when they are noticed
- Users can screw it up, but hopefully the tooltip is adequate.
- The red asterisk for whether or not it's disabled in the menu shows dynamically based on state .. this could be weird if the ability is currently shown in the rotation and the handler knows that it will hit your selected dot cap?
- throws some warnings when, for example, you try to check a spell like wrath for which there is no dot/debuff called `wrath` for boomkin
  - Not sure how to get around this
  - It only matters if you actually set a dot cap for wrath
  - They are just warnings, no gameplay impact
- Do we maybe need to say in the tooltip that it's an experimental feature and that dots **_may_** not be automatically picked up, such as if their registered name is different?
## UI / How does it look
### Snapshot output
Disallowed due to dot cap reached
```
    Processing default action list [ Balance - default ].
        
        Current recommendation was NO ACTION at +10.00s.
        
        11.  moonfire ( default - 1 ) - ability disabled ( DoT cap reached (2/2) )
        Time spent on this action:  0.04ms
        TimeData:Balance-default-1:moonfire:x0:0.04:Ability Known, Enabled(0.04)
```
Allowed because dot cap was not reached
```
        11.  moonfire ( default - 1 )
            moonfire: DoT cap OK (0/2).
         - cycle aura appears to be down, so we're sticking with our current target.
        The action (moonfire) is usable at (0.00 + 0.00).
         - the action is ready before the current recommendation (at +0.00 vs. +10.00).
         - this entry has no criteria to test.
        Action chosen:  moonfire at 0.00!
        Texture shown:  %s
        Exiting default with recommendation of NO ACTION at +10.00s.
```
Allowed because dot is refreshable on target, even though dot cap was reached
```
        11.  moonfire ( default - 1 )
            moonfire: DoT cap reached (3), but refreshable.
         - we do not have another valid target for moonfire: 3 vs 3.
        The action (moonfire) is usable at (0.00 + 0.00).
         - the action is ready before the current recommendation (at +0.00 vs. +10.00).
         - this entry has no criteria to test.
        Action chosen:  moonfire at 0.00!
        Texture shown:  %s
        Exiting default with recommendation of NO ACTION at +10.00s.
```
With the dot cap set to 0
```
        11.  moonfire ( default - 1 )
         - we do not have another valid target for moonfire: 3 vs 3.
        The action (moonfire) is usable at (1.31 + 1.31).
         - the action is ready before the current recommendation (at +1.31 vs. +10.00).
         - this entry has no criteria to test.
        Action chosen:  moonfire at 1.31!
        Texture shown:  %s
        Time spent on this action:  0.11ms
        TimeData:Balance-default-1:moonfire:x0:0.11:Ability Known, Enabled(0.02):Post-TTR and Essential(0.03):Post Cycle(0.03):Post Usable(0.01):Post Ready/Clash(0.01):Post Stack(0.01):Pre-Recheck(0.00):Post Recheck(0.00):Action Stored(0.01)
        
```
### Screenshot
![image](https://github.com/user-attachments/assets/00013771-c8e2-4f01-8450-ef0f5cd95614)
![image](https://github.com/user-attachments/assets/c67afd25-925b-48c7-b6e4-e2762f75909b)

