### PR TITLE
Fix Unfurling darkness again (again [again] )

### DIFF
--- a/State.lua
+++ b/State.lua
@@ -5936,6 +5936,11 @@ function state.PlayerDebuffUp( debuff )
     return aura and aura.expires > GetTime()
 end
 
+function state.PlayerDebuffRemains( debuff )
+    local aura = state.auras.player.debuff[ debuff ]
+    return aura and aura.expires > GetTime() and aura.expires - GetTime() or 0
+end
+
 function state.TargetBuffUp( buff )
     local aura = state.auras.target.buff[ buff ]
     return aura and aura.expires > GetTime()

--- a/TheWarWithin/PriestShadow.lua
+++ b/TheWarWithin/PriestShadow.lua
@@ -1019,7 +1019,9 @@ spec:RegisterHook( "reset_precast", function ()
         applyBuff( "shadowform" )
     end
 
-    if debuff.unfurling_darkness_cd.up then applyBuff( "unfurling_darkness_cd", debuff.unfurling_darkness_cd.remains ) end
+    local unfurlCD = auras.player.debuff.unfurling_darkness_cd
+
+    if unfurlCD.up then applyBuff( "unfurling_darkness_cd", unfurlCD.expires - query_time ) end
 
     if pet.mindbender.active then
         applyBuff( "mindbender", pet.mindbender.remains )

--- a/TheWarWithin/PriestShadow.lua
+++ b/TheWarWithin/PriestShadow.lua
@@ -1019,9 +1019,7 @@ spec:RegisterHook( "reset_precast", function ()
         applyBuff( "shadowform" )
     end
 
-    local unfurlCD = auras.player.debuff.unfurling_darkness_cd
-
-    if unfurlCD.up then applyBuff( "unfurling_darkness_cd", unfurlCD.expires - query_time ) end
+    applyBuff( "unfurling_darkness_cd", state.PlayerDebuffRemains( "unfurling_darkness_cd" ) )
 
     if pet.mindbender.active then
         applyBuff( "mindbender", pet.mindbender.remains )


### PR DESCRIPTION
Added new state function to sync the `buff.unfurling_darkness_cd` with the player debuff using `state.auras.player.debuff.unfurling_darkness_cd`. Tested in game, the "buff" finally stays synced.

Fixes https://github.com/Hekili/hekili/issues/4655