### PR TITLE
Improve vampiric strike modelling

### DIFF
--- a/TheWarWithin/DeathKnightUnholy.lua
+++ b/TheWarWithin/DeathKnightUnholy.lua
@@ -588,11 +588,14 @@ spec:RegisterAuras( {
         copy = 377589
     },
     -- https://www.wowhead.com/spell=434153
-    -- Gift of the San'layn The effectiveness of Essence of the Blood Queen is increased by 100%. Scourge Strike has been replaced with Vampiric Strike.  
+    -- Gift of the San'layn The effectiveness of Essence of the Blood Queen is increased by 100%. Scourge Strike has been replaced with Vampiric Strike.
     gift_of_the_sanlayn = {
         id = 434153,
         duration = 15,
-        max_stack = 1
+        max_stack = 1,
+        onRemove = function()
+            removeBuff( "vampiric_strike" )
+        end
     },
     -- Dealing $w1 Frost damage every $t1 sec.
     -- https://wowhead.com/spell=274074
@@ -631,7 +634,7 @@ spec:RegisterAuras( {
         max_stack = 1
     },
     -- https://www.wowhead.com/spell=194879
-    -- Icy Talons Attack speed increased by 18%.  
+    -- Icy Talons Attack speed increased by 18%.
     icy_talons = {
         id = 194879,
         duration = 10,
@@ -644,7 +647,7 @@ spec:RegisterAuras( {
         max_stack = 5
     },
     -- https://www.wowhead.com/spell=460049
-    -- Infliction of Sorrow Scourge Strike consumes your Virulent Plague to deal 100% of their remaining damage to the target.  
+    -- Infliction of Sorrow Scourge Strike consumes your Virulent Plague to deal 100% of their remaining damage to the target.
     infliction_of_sorrow = {
         id = 460049,
         duration = 15,
@@ -1563,7 +1566,7 @@ spec:RegisterAbilities( {
                 active_dot.undeath = min( active_enemies, active_dot.undeath + 1 )
             end
 
-            if buff.vampiric_strike.up or buff.gift_of_the_sanlayn.up then
+            if buff.vampiric_strike.up then
                 gain( 0.01 * health.max, "health" )
                 applyBuff( "essence_of_the_blood_queen" ) -- TODO: mod haste
 
@@ -1571,7 +1574,10 @@ spec:RegisterAbilities( {
                     dot.virulent_plague.expires = dot.virulent_plague.expires + 3
                 end
 
-                removeBuff( "vampiric_strike" )
+                -- Vampiric Strike is consumed unless it's from Gift of the San'layn.
+                if not buff.gift_of_the_sanlayn.up then
+                    removeBuff( "vampiric_strike" )
+                end
             end
 
             if buff.infliction_of_sorrow.up then
@@ -1684,7 +1690,10 @@ spec:RegisterAbilities( {
 
             if talent.unholy_pact.enabled then applyBuff( "unholy_pact" ) end
 
-            if talent.gift_of_the_sanlayn.enabled then applyBuff( "gift_of_the_sanlayn" ) end
+            if talent.gift_of_the_sanlayn.enabled then
+                applyBuff( "gift_of_the_sanlayn" )
+                applyBuff( "vampiric_strike" )
+            end
 
             if azerite.helchains.enabled then applyBuff( "helchains" ) end
             if legendary.frenzied_monstrosity.enabled then
@@ -2181,7 +2190,7 @@ spec:RegisterAbilities( {
         handler = function ()
             PopWounds( 1, min( action.scourge_strike.max_targets, active_enemies, active_dot.festering_wound ) )
 
-            if buff.vampiric_strike.up or buff.gift_of_the_sanlayn.up then
+            if buff.vampiric_strike.up then
                 gain( 0.01 * health.max, "health" )
                 applyBuff( "essence_of_the_blood_queen" ) -- TODO: mod haste
 
@@ -2189,7 +2198,10 @@ spec:RegisterAbilities( {
                     dot.virulent_plague.expires = dot.virulent_plague.expires + 3
                 end
 
-                removeBuff( "vampiric_strike" )
+                -- Vampiric Strike is consumed unless it's from Gift of the San'layn.
+                if not buff.gift_of_the_sanlayn.up then
+                    removeBuff( "vampiric_strike" )
+                end
             end
 
             if talent.plaguebringer.enabled then


### PR DESCRIPTION
Same as previous PR, but without the APL stuff. I will fix that separately when I have some time, but this allows the main issue to be fixed if you are doing a release soon.

Improve vampiric strike modelling
- `buff.gift_of_the_sanlayn` and `buff.vampiric_strike` are linked together, if and only if gift is up
  - Make `dark_transformation` handler forcibly apply `buff.vampiric_strike`
    - This is to deal with redundancies in the SimC APL that may or may not be removed
    - This part should be what **_directly_** fixes the issue linked below
  - When using `vampiric_strike`, we now only remove the buff if `buff.gift_of_the_sanlayn` is NOT up
- Fixes https://github.com/Hekili/hekili/issues/4671
  - This happens because `buff.gift_of_the_sanlayn.up&buff.vampiric_strike.react` fails, the vampiric strike part is technically redundant, but SimC still has it in there. Even if it does get removed, these changes on our end aren't useless.