### PR TITLE
Hunter cleanup: Explosive Shot, Streamline

### DIFF
--- a/TheWarWithin/HunterBeastMastery.lua
+++ b/TheWarWithin/HunterBeastMastery.lua
@@ -184,7 +184,7 @@ spec:RegisterTalents( {
     kindling_flare          = { 102425, 459506, 1 }, -- Flare's radius is increased by 50%.
     kodo_tranquilizer       = { 102415, 459983, 1 }, -- Tranquilizing Shot removes up to 1 additional Magic effect from up to 2 nearby targets.
     lone_survivor           = { 102391, 388039, 1 }, -- Reduce the cooldown of Survival of the Fittest by 30 sec, and increase its duration by 2.0 sec. Reduce the cooldown of Counter Shot and Muzzle by 2 sec.
-    lunar_storm             = {  94978, 450385, 1 }, -- Every 30 sec your next Wildfire Bomb launches a celestial arrow that conjures a 12 yd radius Lunar Storm at the target's location dealing 84,698 Arcane damage. For the next 12 sec, a random enemy affected by Sentinel within your Lunar Storm gets struck for 79,404 Arcane damage every 0.4 sec. Any target struck by this effect takes 10% increased damage from you and your pet for 8 sec. 
+    lunar_storm             = {  94978, 450385, 1 }, -- Every 30 sec your next Wildfire Bomb launches a celestial arrow that conjures a 12 yd radius Lunar Storm at the target's location dealing 84,698 Arcane damage. For the next 12 sec, a random enemy affected by Sentinel within your Lunar Storm gets struck for 79,404 Arcane damage every 0.4 sec. Any target struck by this effect takes 10% increased damage from you and your pet for 8 sec.
     misdirection            = { 102419,  34477, 1 }, -- Misdirects all threat you cause to the targeted party or raid member, beginning with your next attack within 30 sec and lasting for 8 sec.
     moment_of_opportunity   = { 102426, 459488, 1 }, -- When a trap triggers, you gain 30% movement speed for 3 sec. Can only occur every 1 min.
     natural_mending         = { 102401, 270581, 1 }, -- Every 10 Focus you spend reduces the remaining cooldown on Exhilaration by 1.0 sec.
@@ -201,12 +201,12 @@ spec:RegisterTalents( {
     scatter_shot            = { 102421, 213691, 1 }, -- A short-range shot that deals 3,499 damage, removes all harmful damage over time effects, and incapacitates the target for 4 sec. Any damage caused will remove the effect. Turns off your attack when used. Targets incapacitated by Scatter Shot deal 10% less damage to you for 8 sec after the effect ends.
     scouts_instincts        = { 102424, 459455, 1 }, -- You cannot be slowed below 80% of your normal movement speed while Aspect of the Cheetah is active.
     scrappy                 = { 102408, 459533, 1 }, -- Casting Kill Command reduces the cooldown of Intimidation and Binding Shot by 0.5 sec.
-    sentinel                = {  94976, 450369, 1 }, -- Your attacks have a chance to apply Sentinel on the target, stacking up to 10 times. While Sentinel stacks are higher than 3, applying Sentinel has a chance to trigger an implosion, causing a stack to be consumed on the target every sec to deal 66,318 Arcane damage. 
-    sentinel_precision      = {  94981, 450375, 1 }, -- Raptor Strike, Mongoose Bite and Wildfire Bomb deal 10% increased damage. 
+    sentinel                = {  94976, 450369, 1 }, -- Your attacks have a chance to apply Sentinel on the target, stacking up to 10 times. While Sentinel stacks are higher than 3, applying Sentinel has a chance to trigger an implosion, causing a stack to be consumed on the target every sec to deal 66,318 Arcane damage.
+    sentinel_precision      = {  94981, 450375, 1 }, -- Raptor Strike, Mongoose Bite and Wildfire Bomb deal 10% increased damage.
     sentinel_watch          = {  94970, 451546, 1 }, -- Whenever a Sentinel deals damage, the cooldown of Coordinated Assault is reduced by 1 sec, up to 15 sec.
     serrated_tips           = { 102384, 459502, 1 }, -- You gain 5% more critical strike from critical strike sources.
     sideline                = {  94990, 450378, 1 }, -- When Sentinel starts dealing damage, the target is snared by 40% for 3 sec.
-    specialized_arsenal     = { 102390, 459542, 1 }, -- Kill Command deals 10% increased damage. 
+    specialized_arsenal     = { 102390, 459542, 1 }, -- Kill Command deals 10% increased damage.
     survival_of_the_fittest = { 102422, 264735, 1 }, -- Reduces all damage you and your pet take by 30% for 8 sec.
     symphonic_arsenal       = {  94965, 450383, 1 }, -- Multi-Shot and Butchery discharge arcane energy from all targets affected by your Sentinel, dealing 76,228 Arcane damage to up to 5 targets within 8 yds of your Sentinel targets.
     tar_trap                = { 102393, 187698, 1 }, -- Hurls a tar trap to the target location that creates a 8 yd radius pool of tar around itself for 30 sec when the first enemy approaches. All enemies have 50% reduced movement speed while in the area of effect. Limit 1. Trap will exist for 1 min.
@@ -233,7 +233,7 @@ spec:RegisterTalents( {
     bloody_frenzy           = { 102339, 407412, 1 }, -- While Call of the Wild is active, your pets have the effects of Beast Cleave, and each time Call of the Wild summons a pet, all of your pets Stomp.
     brutal_companion        = { 102350, 386870, 1 }, -- When Barbed Shot causes Frenzy to stack up to 3, your pet will immediately use its special attack and deal 50% bonus damage.
     call_of_the_wild        = { 102336, 359844, 1 }, -- You sound the call of the wild, summoning 2 of your active pets for 20 sec. During this time, a random pet from your stable will appear every 4 sec to assault your target for 6 sec. Each time Call of the Wild summons a pet, the cooldown of Barbed Shot and Kill Command are reduced by 50%.
-    cobra_senses            = { 102344, 378244, 1 }, -- Cobra Shot Focus cost reduced by 5. Cobra Shot damage increased by 35%. 
+    cobra_senses            = { 102344, 378244, 1 }, -- Cobra Shot Focus cost reduced by 5. Cobra Shot damage increased by 35%.
     cobra_shot              = { 102354, 193455, 1 }, -- A quick shot causing 178,946 Physical damage. Reduces the cooldown of Kill Command by 1 sec.
     dire_beast              = { 102376, 120679, 1 }, -- Summons a powerful wild beast that attacks the target and roars, increasing your Haste by 5% for 8 sec. Generates 20 Focus.
     dire_cleave             = { 102337, 1217524, 1 }, -- When summoned, Dire Beasts gain Beast Cleave at 100% effectiveness for 8.0 sec.
@@ -246,7 +246,7 @@ spec:RegisterTalents( {
     kill_command            = { 102346,  34026, 1 }, -- Give the command to kill, causing your pet to savagely deal 127,922 Physical damage to the enemy.
     killer_cobra            = { 102375, 199532, 1 }, -- While Bestial Wrath is active, Cobra Shot resets the cooldown on Kill Command.
     killer_instinct         = { 102364, 273887, 2 }, -- Kill Command deals 50% increased damage against enemies below 35% health.
-    laceration              = { 102369, 459552, 1 }, -- When your pet attacks critically strike, they cause their target to bleed for 8% of the damage dealt over 6 sec. 
+    laceration              = { 102369, 459552, 1 }, -- When your pet attacks critically strike, they cause their target to bleed for 8% of the damage dealt over 6 sec.
     master_handler          = { 102372, 424558, 1 }, -- Each time Barbed Shot deals damage, the cooldown of Kill Command is reduced by 0.50 sec.
     multishot               = { 102363,   2643, 1 }, -- Fires several missiles, hitting all nearby enemies within 8 yds of your current target for 64,032 Physical damage and triggering Beast Cleave. Deals reduced damage beyond 5 targets.
     pack_tactics            = { 102374, 321014, 1 }, -- Passive Focus generation increased by 125%.
@@ -301,17 +301,17 @@ spec:RegisterTalents( {
 } )
 
 -- PvP Talents
-spec:RegisterPvpTalents( { 
+spec:RegisterPvpTalents( {
     chimaeral_sting     = 3604, -- (356719) Stings the target, dealing 117,636 Nature damage and initiating a series of venoms. Each lasts 3 sec and applies the next effect after the previous one ends.  Scorpid Venom: 90% reduced movement speed.  Spider Venom: Silenced.  Viper Venom: 20% reduced damage and healing.
     diamond_ice         = 5534, -- (203340) Victims of Freezing Trap can no longer be damaged or healed. Freezing Trap is now undispellable, but has a 4 sec duration.
     dire_beast_basilisk =  825, -- (1218223) Call of the Wild additionally summons a slow moving basilisk near your target for 30 sec that attacks the target for heavy damage.
     dire_beast_hawk     =  824, -- (208652) Summons a hawk to circle the target area, attacking all targets within 10 yards over the next 10 sec.
     explosive_powder    = 5689, -- (1218150) Bursting Shot now also knocks you back and snares enemies by an additional 20%.
     hunting_pack        = 3730, -- (203235) Aspect of the Cheetah has 50% reduced cooldown and grants its effects to allies within 15 yds.
-    interlope           = 1214, -- (248518) Misdirection now causes the next 3 hostile spells cast on your target within 10 sec to be redirected to your pet, but its cooldown is increased by 15 sec. Your pet must be within 20 yards of the target for spells to be redirected. 
-    kindred_beasts      = 5444, -- (356962) 
+    interlope           = 1214, -- (248518) Misdirection now causes the next 3 hostile spells cast on your target within 10 sec to be redirected to your pet, but its cooldown is increased by 15 sec. Your pet must be within 20 yards of the target for spells to be redirected.
+    kindred_beasts      = 5444, -- (356962)
     survival_tactics    = 3599, -- (202746) Feign Death reduces damage taken by 90% for 2 sec.
-    the_beast_within    =  693, -- (356976) 
+    the_beast_within    =  693, -- (356976)
     wild_kingdom        = 5441, -- (356707) Call in help from one of your dismissed Cunning pets for 10 sec. Your current pet is dismissed to rest and heal 30% of maximum health.
 } )
 
@@ -503,7 +503,7 @@ spec:RegisterAuras( {
     bleak_arrows = {
             id = 467718,
             duration = 60.0,
-            max_stack = 1   
+            max_stack = 1
     },--]]
     -- Talent: Bleeding for $w1 Physical damage every $t1 sec.  Taking $s2% increased damage from the Hunter's pet.
     -- https://wowhead.com/beta/spell=321538
@@ -767,7 +767,7 @@ spec:RegisterAuras( {
         max_stack = 1
     },
     -- https://www.wowhead.com/spell=472640
-    -- Hogstrider Your next Cobra Shot strikes X additional targets and its damage is increased by 100%.  
+    -- Hogstrider Your next Cobra Shot strikes X additional targets and its damage is increased by 100%.
     hogstrider = {
         id = 472640,
         duration = 20,
@@ -818,7 +818,7 @@ spec:RegisterAuras( {
         max_stack = 1
     },
     -- https://www.wowhead.com/spell=472743
-    -- Lead From the Front The damage of your Pack Leader Beasts is increased by 25%.  
+    -- Lead From the Front The damage of your Pack Leader Beasts is increased by 25%.
     lead_from_the_front = {
         id = 472743,
         duration = 12,
@@ -1925,7 +1925,7 @@ spec:RegisterAbilities( {
         startsCombat = true,
 
         handler = function ()
-            applyDebuff( "target", "explosive_shot" )
+            applyDebuff( "target", "explosive_shot", debuff.explosive_shot.remains + spec.auras.explosive_shot.duration )
         end,
     },
 

--- a/TheWarWithin/HunterMarksmanship.lua
+++ b/TheWarWithin/HunterMarksmanship.lua
@@ -988,10 +988,8 @@ spec:RegisterAbilities( {
             if talent.bullet_hell.enabled then reduceCooldown( "volley", 0.5 * action.aimed_shot.max_targets ) end
 
             -- Trick Shots
-            if buff.trick_shots.up then
-                if buff.volley.down then
-                    removeBuff( "trick_shots" )
-                end
+            if buff.trick_shots.up and buff.volley.down then
+                removeBuff( "trick_shots" )
             end
 
             --- Legacy / PvP stuff
@@ -1560,9 +1558,9 @@ spec:RegisterAbilities( {
             if talent.salvo.enabled then
                 if active_enemies < 3 then
                     spec.abilities.explosive_shot.handler()
-                    if active_enemies > 1 then active_dot.explosive_shot = active_dot.explosive_shot + 1 end
+                    if active_enemies > 1 then active_dot.explosive_shot = min( true_active_enemies, active_dot.explosive_shot + 1 ) end
                 else
-                   active_dot.explosive_shot = active_dot.explosive_shot + 2
+                   active_dot.explosive_shot = min( true_active_enemies, active_dot.explosive_shot + 2 )
                 end
             end
 

--- a/TheWarWithin/HunterMarksmanship.lua
+++ b/TheWarWithin/HunterMarksmanship.lua
@@ -969,14 +969,16 @@ spec:RegisterAbilities( {
             removeDebuff( "target", "spotters_mark" )
             removeBuff ( "moving_target" )
             if talent.precise_shots.enabled then addStack( "precise_shots", nil, 1 + talent.windrunner_quiver.rank ) end
-            if debuff.explosive_shot.up and talent.precision_detonation.enabled then removeDebuff( "target", "explosive_shot" ) end
             if debuff.spotters_mark.up then SpottersMarkConsumer( action.aimed_shot.max_targets ) end
 
             if buff.lock_and_load.up then
                 removeBuff( "lock_and_load" )
                 if talent.magnetic_gunpowder.enabled then reduceCooldown( "explosive_shot", 8 ) end
                 if set_bonus.tww2 >= 4 then spec.abilities.explosive_shot.handler() end
+            else
+                removeBuff( "streamline" )
             end
+            if debuff.explosive_shot.up and talent.precision_detonation.enabled then removeDebuff( "target", "explosive_shot" ) end
 
             if buff.double_tap.up then
                 removeBuff( "double_tap" )
@@ -989,7 +991,7 @@ spec:RegisterAbilities( {
             if buff.trick_shots.up then
                 if buff.volley.down then
                     removeBuff( "trick_shots" )
-                    end
+                end
             end
 
             --- Legacy / PvP stuff
@@ -1264,7 +1266,8 @@ spec:RegisterAbilities( {
         startsCombat = true,
 
         handler = function ()
-            applyDebuff( "target", "explosive_shot" )
+            -- It does technically trigger the explosion, but we just need to model the debuff presence
+            applyDebuff( "target", "explosive_shot", debuff.explosive_shot.remains + spec.auras.explosive_shot.duration )
             if talent.precision_detonation.enabled then addStack( "streamline" ) end
         end,
     },
@@ -1552,9 +1555,15 @@ spec:RegisterAbilities( {
             applyBuff( "volley" )
             applyBuff( "trick_shots", 6 )
             if talent.double_tap.enabled then applyBuff( "double_tap" ) end
+
+            -- There are weird situations where it doesn't do the below .. but this is usually what happens
             if talent.salvo.enabled then
-                applyDebuff( "target", "explosive_shot" )
-                if active_enemies > 1 and active_dot.explosive_shot < active_enemies then active_dot.explosive_shot = active_dot.explosive_shot + 1 end
+                if active_enemies < 3 then
+                    spec.abilities.explosive_shot.handler()
+                    if active_enemies > 1 then active_dot.explosive_shot = active_dot.explosive_shot + 1 end
+                else
+                   active_dot.explosive_shot = active_dot.explosive_shot + 2
+                end
             end
 
             if pvptalent.rangers_finesse.enabled then

--- a/TheWarWithin/HunterSurvival.lua
+++ b/TheWarWithin/HunterSurvival.lua
@@ -1164,7 +1164,7 @@ spec:RegisterAbilities( {
             removeStack ( "tip_of_the_spear" )
             if buff.bombardier.up then
                 removeBuff( "bombardier" )
-                active_dot.explosive_shot = active_dot.explosive_shot + 2
+                active_dot.explosive_shot = min( true_active_enemies, active_dot.explosive_shot + 2 )
             end
             if talent.grenade_juggler.enabled then reduceCooldown( "wildfire_bomb", 2 ) end
         end,

--- a/TheWarWithin/HunterSurvival.lua
+++ b/TheWarWithin/HunterSurvival.lua
@@ -245,7 +245,7 @@ spec:RegisterAuras( {
     bombardier = {
         id = 459859,
         duration = 60.0,
-        max_stack = 2
+        max_stack = 1
     },
     -- Disoriented.
     bursting_shot = {
@@ -571,12 +571,12 @@ spec:RegisterAuras( {
     -- Building up to an Explosive Shot...
     sulfurlined_pockets = {
         id = 459830,
-        duration = 120.0,
-        max_stack = 3
+        duration = 3600,
+        max_stack = 2
     },
     sulfurlined_pockets_ready = {
         id = 459834,
-        duration = 180,
+        duration = 3600,
         max_stack = 1
     },
     terms_of_engagement = {
@@ -783,7 +783,7 @@ end, state )
 
 local TriggerBombardier = setfenv( function()
     setCooldown( "explosive_shot", 1 ) -- There is a slight delay before you actually get it
-    applyBuff( "bombardier", nil, 2 )
+    applyBuff( "bombardier", nil, 1 )
 end, state )
 
 spec:RegisterCombatLogEvent( function( _, subtype, _,  sourceGUID, sourceName, _, _, destGUID, destName, destFlags, _, spellID, spellName )
@@ -1160,12 +1160,12 @@ spec:RegisterAbilities( {
         startsCombat = true,
 
         handler = function ()
-            applyDebuff( "target", "explosive_shot" )
+            applyDebuff( "target", "explosive_shot", debuff.explosive_shot.remains + spec.auras.explosive_shot.duration )
             removeStack ( "tip_of_the_spear" )
-            -- If triggered by Kill Command, don't consume Bombardier or reduce WfB's cooldown.
-            if buff.sulfurlined_pockets_ready.up and buff.sulfurlined_pockets_ready.v1 == 259489 then return end
-
-            removeStack( "bombardier" )
+            if buff.bombardier.up then
+                removeBuff( "bombardier" )
+                active_dot.explosive_shot = active_dot.explosive_shot + 2
+            end
             if talent.grenade_juggler.enabled then reduceCooldown( "wildfire_bomb", 2 ) end
         end,
     },
@@ -1276,13 +1276,6 @@ spec:RegisterAbilities( {
             removeBuff( "deadly_duo" )
 
             if talent.howl_of_the_pack_leader.enabled then howl_summon.trigger_summon( false ) end
-
-            if buff.sulfurlined_pockets_ready.up then
-                buff.sulfurlined_pockets_ready.v1 = 259489
-                class.abilities.explosive_shot.handler()
-                buff.sulfurlined_pockets_ready.v1 = 0
-                removeBuff( "sulfurlined_pockets_ready" )
-            end
 
             if talent.bloodseeker.enabled then
                 applyBuff( "predator", 8 )


### PR DESCRIPTION
Improved modelling for `explosive_shot`. Any handler which use it are now following the explicit order of operations that takes place in game regarding explosions, debuff re-applications, etc. 

- Some of them had stuff in the wrong order
- Modelled the debuff extension explicitly just to be sure in case the pandemic window is too short
- Removed survival `kill_command` triggering the effect, as this talent is now an RNG talent which we shouldn't model as if it happens every time.

Additionally, fixed errors in the following:
- Marksmanship `aimed_shot`, wasn't consuming `streamline`, moved the `precise_detonation` trigger to be **_after_** the tier set application of `explosive_shot` which is how it happens in game
- Survival `bombardier`, wrong stack count (change in 11.1 I think), added active_dot spreading
- Survival `sulfurlined_pockets`, wrong stack count