### PR TITLE
Bloodiest talons you've ever seen

### DIFF
--- a/TheWarWithin/DruidFeral.lua
+++ b/TheWarWithin/DruidFeral.lua
@@ -1296,7 +1296,7 @@ spec:RegisterHook( "reset_precast", function ()
     debuff.thrash_cat.pmultiplier = nil
 
     eclipse.reset()
-    spec.SwarmOnReset()
+    if talent.adaptive_swarm.enabled then spec.SwarmOnReset() end
 
     -- Bloodtalons
     if talent.bloodtalons.enabled then
@@ -1337,6 +1337,7 @@ spec:RegisterHook( "reset_precast", function ()
                     Hekili:Debug( "        %s: %.2f", bt, buff[ bt ].remains )
                 end
             end
+            Hekili:Debug( "\n")
         end
 
 


### PR DESCRIPTION
# Final fix for bloodtalons, fully tested
Fixes https://github.com/Hekili/hekili/issues/4699
## Fixes applied
- Allow `bt_swipe` to dynamically point to `brutal_slash` or `swipe_cat`. 
  - The issue with the previous version is what it was built on `.lastCast`, and even though `brutal_slash`/`swipe_cat` are copies / binded, casting `brutal_slash` does **_not_** update `action.swipe_cast.lastCast`, so the generator was failing to maintain the `bt_swipe` buff after casting `brutal_slash`.
   - While this **_did_** work predictively, it fell apart after an actual cast
  - Updated `reset_precast` code as well to support this function
- Added a check to the generator to only generate if the cast is **_after_** the most recent application of `buff.bloodtalons`
  - This allows gaining bloodtalons to wipe out previous triggers, the expected behaviour
  - Ensure `reset_precast` follows this as well
- This solution is fully, properly tested this time. I added a new snapshot output for Bloodtalons, the examples below of which show the full process of bloodtalons being modeled correctly now
## Snapshot Debug
- Added snapshot debug output for bloodtalons that runs once per reset.
- Made adaptive swam snapshot output only trigger if you have it talented
Pre-Combat
```
New Recommendations for [ Primary ] requested at 13:24:51 ( 213078.07 ); using built-in ( Feral ) priority.
*** START OF NEW DISPLAY: Primary ***
Purged 480 marked values in 0.11ms.

*** Bloodtalons Status ***
    Bloodtalons Down
    Active BT Buffs: 0

Combat Timer: 0.00
```
After casting Rake
```
previous_spells:
   1 - rake
....
*** Bloodtalons Status ***
    Bloodtalons Down
    Active BT Buffs: 1
        bt_rake: 3.58

Combat Timer: 0.43
```
After casting Rake -> Thrash

```
previous_spells:
   1 - thrash_cat
   2 - rake
...
*** Bloodtalons Status ***
    Bloodtalons Down
    Active BT Buffs: 2
        bt_thrash: 3.56
        bt_rake: 2.34

Combat Timer: 1.67
```

After casting Rake -> Thrash -> Brutal Slash

```
previous_spells:
   1 - brutal_slash
   2 - thrash_cat
   3 - rake
...
*** Bloodtalons Status ***
    Stacks: 3
    Remains: 29.48
    Active BT Buffs: 0

Combat Timer: 2.85
```

Casting Brutal Slash by itself
```
previous_spells:
   1 - brutal_slash
...
*** Bloodtalons Status ***
    Bloodtalons Down
    Active BT Buffs: 1
        bt_swipe: 3.60

Combat Timer: 0.28
```
