### PR TITLE
Resto druid minor fixes

### DIFF
--- a/TheWarWithin/DruidRestoration.lua
+++ b/TheWarWithin/DruidRestoration.lua
@@ -339,7 +339,7 @@ spec:RegisterAuras( {
         max_stack = 1,
         dot = "buff",
         friendly = true,
-        copy = "lifebloom"
+        -- copy = "lifebloom"
     },
     natures_swiftness = {
         id = 132158,
@@ -1049,7 +1049,6 @@ spec:RegisterAbilities( {
         spend = 0.10,
         spendType = "mana",
 
-        talent = "swiftmend",
         startsCombat = false,
         texture = 134914,
 


### PR DESCRIPTION
swiftmend not a talent, and don't use copy for lifebloom