### PR TITLE
Implement Hero Trees (I swear this isn't patch 11.1)

### DIFF
--- a/Constants.lua
+++ b/Constants.lua
@@ -211,9 +211,251 @@ ns.getSpecializationKey = function ( id )
     return SpecializationKeys[ id ] or "none"
 end
 
-
 ns.getSpecializationID = function ( index )
     return GetSpecializationInfo( index or GetSpecialization() or 0 )
+end
+
+ns.HeroTrees = {
+    [31] = {
+        name = "sanlayn",
+        keyTalent = "vampiric_strike",
+        specIDs = { 250, 252 }
+    },
+    [32] = {
+        name = "rider_of_the_apocalypse",
+        keyTalent = "riders_champion",
+        specIDs = { 251, 252 }
+    },
+    [33] = {
+        name = "deathbringer",
+        keyTalent = "reapers_mark",
+        specIDs = { 250, 251 }
+    },
+
+    [34] = {
+        name = "fel_scarred",
+        keyTalent = "demonsurge",
+        specIDs = { 577, 581 }
+    },
+    [35] = {
+        name = "aldrachi_reaver",
+        keyTalent = "art_of_the_glaive",
+        specIDs = { 577, 581 }
+    },
+
+    [21] = {
+        name = "druid_of_the_claw",
+        keyTalent = "ravage",
+        specIDs = { 103, 104 }
+    },
+    [22] = {
+        name = "wildstalker",
+        keyTalent = "thriving_growth",
+        specIDs = { 103, 105 }
+    },
+    [23] = {
+        name = "keeper_of_the_grove",
+        keyTalent = "dream_surge",
+        specIDs = { 102, 105 }
+    },
+    [24] = {
+        name = "elunes_chosen",
+        keyTalent = "boundless_moonlight",
+        specIDs = { 102, 104 }
+    },
+    [36] = {
+        name = "scalecommander",
+        keyTalent = {
+            [1467] = "mass_disintegrate",
+            [1468] = "mass_eruption"
+        },
+        specIDs = { 1467, 1468 }
+    },
+    [37] = {
+        name = "flameshaper",
+        keyTalent = "engulf",
+        specIDs = { 1467, 1473 }
+    },
+    [38] = {
+        name = "chronowarden",
+        keyTalent = "chrono_flame",
+        specIDs = { 1468, 1473 }
+    },
+
+    [42] = {
+        name = "sentinel",
+        keyTalent = "sentinel",
+        specIDs = { 254, 255 }
+    },
+    [43] = {
+        name = "pack_leader",
+        keyTalent = "howl_of_the_pack_leader",
+        specIDs = { 253, 255 }
+    },
+    [44] = {
+        name = "dark_ranger",
+        keyTalent = "black_arrow",
+        specIDs = { 253, 254 }
+    },
+
+    [39] = {
+        name = "sunfury",
+        keyTalent = "spellfire_spheres",
+        specIDs = { 62, 63 }
+    },
+    [40] = {
+        name = "spellslinger",
+        keyTalent = "splintering_sorcery",
+        specIDs = { 62, 64 }
+    },
+    [41] = {
+        name = "frostfire",
+        keyTalent = "frostfire_mastery",
+        specIDs = { 63, 64 }
+    },
+
+    [64] = {
+        name = "conduit_of_the_celestials",
+        keyTalent = "celestial_conduit",
+        specIDs = { 269, 270 }
+    },
+    [65] = {
+        name = "shado_pan",
+        keyTalent = "flurry_strikes",
+        specIDs = { 268, 269 }
+    },
+    [66] = {
+        name = "master_of_harmony",
+        keyTalent = "aspect_of_harmony",
+        specIDs = { 268, 270 }
+    },
+
+    [48] = {
+        name = "templar",
+        keyTalent = "lights_guidance",
+        specIDs = { 66, 70 }
+    },
+    [49] = {
+        name = "lightsmith",
+        keyTalent = "holy_armaments",
+        specIDs = { 65, 66 }
+    },
+    [50] = {
+        name = "herald_of_the_sun",
+        keyTalent = "dawnlight",
+        specIDs = { 65, 70 }
+    },
+
+    [18] = {
+        name = "voidweaver",
+        keyTalent = "entropic_rift",
+        specIDs = { 257, 258 }
+    },
+    [19] = {
+        name = "archon",
+        keyTalent = "power_surge",
+        specIDs = { 256, 258 }
+    },
+    [20] = {
+        name = "oracle",
+        keyTalent = "premonition",
+        specIDs = { 256, 257 }
+    },
+
+    [51] = {
+        name = "trickster",
+        keyTalent = "unseen_blade",
+        specIDs = { 260, 261 }
+    },
+    [52] = {
+        name = "fatebound",
+        keyTalent = "hand_of_fate",
+        specIDs = { 259, 260 }
+    },
+    [53] = {
+        name = "deathstalker",
+        keyTalent = "deathstalkers_mark",
+        specIDs = { 259, 261 }
+    },
+
+    [54] = {
+        name = "totemic",
+        keyTalent = "surging_totem",
+        specIDs = { 262, 264 }
+    },
+    [55] = {
+        name = "stormbringer",
+        keyTalent = "tempest",
+        specIDs = { 262, 263 }
+    },
+    [56] = {
+        name = "farseer",
+        keyTalent = "call_of_the_ancestors",
+        specIDs = { 263, 264 }
+    },
+
+    [57] = {
+        name = "soul_harvester",
+        keyTalent = "demonic_soul",
+        specIDs = { 265, 266 }
+    },
+    [58] = {
+        name = "hellcaller",
+        keyTalent = "wither",
+        specIDs = { 265, 267 }
+    },
+    [59] = {
+        name = "diabolist",
+        keyTalent = "diabolic_ritual",
+        specIDs = { 266, 267 }
+    },
+
+    [60] = {
+        name = "slayer",
+        keyTalent = "slayers_dominance",
+        specIDs = { 71, 72 }
+    },
+    [61] = {
+        name = "mountain_thane",
+        keyTalent = "lightning_strikes",
+        specIDs = { 71, 73 }
+    },
+    [62] = {
+        name = "colossus",
+        keyTalent = "demolish",
+        specIDs = { 72, 73 }
+    }
+}
+
+-- Get full info for a Hero Tree by its Hero Spec ID (31–66)
+ns.getHeroTree = function ( heroID )
+    return ns.HeroTrees[ heroID ]
+end
+
+-- Get the name of the currently active Hero Tree
+ns.getActiveHeroTreeName = function ()
+    local id = C_ClassTalents and C_ClassTalents.GetActiveHeroTalentSpec()
+    if not id or id == 0 then return nil end -- 0 is the API return for no tree
+    local tree = ns.HeroTrees[ id ]
+    return tree and tree.name or nil
+end
+
+-- Get the key talent from the currently active Hero Tree (with per-spec support)
+ns.getActiveHeroTreeKeyTalent = function ()
+    local id = C_ClassTalents and C_ClassTalents.GetActiveHeroTalentSpec()
+    if not id then return nil end
+
+    local tree = ns.HeroTrees[ id ]
+    if not tree then return nil end
+
+    local keyTalent = tree.keyTalent
+
+    if type( keyTalent ) == "table" then
+        local specID = state.spec.id or ns.getSpecializationID()
+        return keyTalent[ specID ]
+    end
+
+    return keyTalent
 end
 
 

--- a/Options.lua
+++ b/Options.lua
@@ -9870,11 +9870,11 @@ do
     end
 end
 
-
 function Hekili:GenerateProfile()
     local s = state
 
     local spec = s.spec.key
+    local heroTree = state.hero_tree.current or "none"
 
     local talents = self:GetLoadoutExportString()
 
@@ -10011,7 +10011,8 @@ break end
     "build: %s\n" ..
     "level: %d (%d)\n" ..
     "class: %s\n" ..
-    "spec: %s\n\n" ..
+    "spec: %s\n" ..
+    "hero tree: %s\n\n" ..
 
     "### Talents ###\n\n" ..
     "In-Game Import: %s\n" ..
@@ -10041,6 +10042,7 @@ break end
     UnitLevel( 'player' ) or 0, UnitEffectiveLevel( 'player' ) or 0,
     class.file or "NONE",
     spec or "none",
+    heroTree or "none",
     talents or "none",
     pvptalents or "none",
     covenant or "none",
@@ -10057,7 +10059,6 @@ break end
 )
 
 end
-
 
 do
     local Options = {

--- a/State.lua
+++ b/State.lua
@@ -132,7 +132,21 @@ state.off_hand = {
 
 state.gcd = {}
 
-state.hero_tree = setmetatable( {}, { __index = function( t, k ) return state.talent[ k ].enabled end } ) -- TODO: Update hero tree detection for 11.0 launch.
+state.hero_tree = setmetatable( {}, {
+    __index = function( t, k )
+
+        if state.level < 71 then
+            return false
+        end
+
+        if k == "current" then
+            return ns.getActiveHeroTreeName()
+        end
+
+        return ns.getActiveHeroTreeName() == k
+    end
+} )
+
 
 state.history = {
     casts = {},

--- a/TheWarWithin/WarlockDestruction.lua
+++ b/TheWarWithin/WarlockDestruction.lua
@@ -136,7 +136,7 @@ spec:RegisterTalents( {
     eternal_servitude              = {  94824, 449707, 1 }, -- Fel Domination cooldown is reduced by 90 sec.
     feast_of_souls                 = {  94823, 449706, 1 }, -- When you kill a target, you have a chance to generate a Soul Shard that is guaranteed to be a Succulent Soul.
     fel_armor                      = {  71950, 386124, 2 }, -- When Soul Leech absorbs damage, 5% of damage taken is absorbed and spread out over 5 sec. Reduces damage taken by 1.5%.
-    fel_domination                 = {  71931, 333889, 1 }, -- Your next Imp, Voidwalker, Incubus, Succubus, Felhunter, or Felguard Summon spell is free and has its casting time reduced by 90%. 
+    fel_domination                 = {  71931, 333889, 1 }, -- Your next Imp, Voidwalker, Incubus, Succubus, Felhunter, or Felguard Summon spell is free and has its casting time reduced by 90%.
     fel_pact                       = {  71932, 386113, 1 }, -- Reduces the cooldown of Fel Domination by 60 sec.
     fel_synergy                    = {  71924, 389367, 2 }, -- Soul Leech also heals you for 8% and your pet for 25% of the absorption it grants.
     fiendish_stride                = {  71948, 386110, 1 }, -- Reduces the damage dealt by Burning Rush by 10%. Burning Rush increases your movement speed by an additional 20%.
@@ -153,7 +153,7 @@ spec:RegisterTalents( {
     nightmare                      = {  71916, 386648, 1 }, -- Increases the amount of damage required to break your fear effects by 60%.
     pact_of_gluttony               = {  71926, 386689, 1 }, -- Healthstones you conjure for yourself are now Demonic Healthstones and can be used multiple times in combat. Demonic Healthstones cannot be traded.  Demonic Healthstone Instantly restores 35% health. 60 sec cooldown.
     quietus                        = {  94846, 449634, 1 }, -- Soul Anathema damage increased by 25% and is dealt 20% faster. Consuming Demonic Core activates Shared Fate or Feast of Souls.
-    resolute_barrier               = {  71915, 389359, 2 }, -- Attacks received that deal at least 5% of your health decrease Unending Resolve's cooldown by 10 sec. Cannot occur more than once every 30 sec. 
+    resolute_barrier               = {  71915, 389359, 2 }, -- Attacks received that deal at least 5% of your health decrease Unending Resolve's cooldown by 10 sec. Cannot occur more than once every 30 sec.
     sargerei_technique             = {  93179, 405955, 2 }, -- Incinerate damage increased by 5%.
     sataiels_volition              = {  94838, 449637, 1 }, -- Wild Imp damage increased by 5% and Wild Imps that are imploded have an additional 5% chance to grant a Demonic Core.
     shadow_of_death                = {  94857, 449638, 1 }, -- Your Summon Demonic Tyrant spell is empowered by the demonic entity within you, causing it to grant 3 Soul Shards that each contain a Succulent Soul.
@@ -231,7 +231,8 @@ spec:RegisterTalents( {
     abyssal_dominion               = {  94831, 429581, 1 }, -- Summon Infernal becomes empowered, dealing 40% increased damage. When your Summon Infernal ends, it fragments into two smaller Infernals at 50% effectiveness that lasts 10 sec.
     annihilans_bellow              = {  94836, 429072, 1 }, -- Howl of Terror cooldown is reduced by 15 sec and range is increased by 5 yds.
     cloven_souls                   = {  94849, 428517, 1 }, -- Enemies damaged by your Overlord have their souls cloven, increasing damage taken by you and your pets by 5% for 15 sec.
-    cruelty_of_kerxan              = {  94848, 429902, 1, "diabolist" }, -- Summon Infernal grants Diabolic Ritual and reduces its duration by 3 sec.
+    cruelty_of_kerxan              = {  94848, 429902, 1 }, -- Summon Infernal grants Diabolic Ritual and reduces its duration by 3 sec.
+    diabolic_ritual                = {  94855, 428514, 1, "diabolist" }, -- Spending a Soul Shard on a damaging spell grants Diabolic Ritual for 20 sec. While Diabolic Ritual is active, each Soul Shard spent on a damaging spell reduces its duration by 1 sec. When Diabolic Ritual expires you gain Demonic Art, causing your next Hand of Gul'dan to summon an Overlord, Mother of Chaos, or Pit Lord that unleashes a devastating attack against your enemies.
     flames_of_xoroth               = {  94833, 429657, 1 }, -- Fire damage increased by 2% and damage dealt by your demons is increased by 2%.
     gloom_of_nathreza              = {  94843, 429899, 1 }, -- Enemies marked by your Havoc take 5% increased damage from your single target spells.
     infernal_bulwark               = {  94852, 429130, 1 }, -- Unending Resolve grants Soul Leech equal to 10% of your maximum health and increases the maximum amount Soul Leech can absorb by 10% for 8 sec.
@@ -260,11 +261,11 @@ spec:RegisterTalents( {
 } )
 
 -- PvP Talents
-spec:RegisterPvpTalents( { 
-    bane_of_havoc    =  164, -- (461917) 
+spec:RegisterPvpTalents( {
+    bane_of_havoc    =  164, -- (461917)
     bloodstones      = 5696, -- (1218692) Your Healthstones are replaced with Bloodstones which increase their user's haste by 30% for 12 sec instead of healing.
     bonds_of_fel     = 5401, -- (353753) Encircle enemy players with Bonds of Fel. If any affected player leaves the 8 yd radius they explode, dealing 112,580 Fire damage split amongst all nearby enemies.
-    fel_fissure      =  157, -- (200586) 
+    fel_fissure      =  157, -- (200586)
     gateway_mastery  = 5382, -- (248855) Increases the range of your Demonic Gateway by 20 yards, and reduces the cast time by 30%. Reduces the time between how often players can take your Demonic Gateway by 30 sec.
     impish_instincts = 5580, -- (409835) Taking direct Physical damage reduces the cooldown of Demonic Circle by 3 sec. Cannot occur more than once every 5 sec.
     nether_ward      = 3508, -- (212295) Surrounds the caster with a shield that lasts 3 sec, reflecting all harmful spells cast on you.
@@ -1239,7 +1240,7 @@ spec:RegisterGear( "tww2", 229325, 229323, 229328, 229326, 229324 )
 spec:RegisterAuras( {
 -- 2-set
 -- https://www.wowhead.com/ptr-2/spell=1217798/jackpot
--- Hitting a Jackpot! increases your Mastery by 3% and your spells gain maximum benefit from Mastery: Chaotic Energies for 10 sec. 
+-- Hitting a Jackpot! increases your Mastery by 3% and your spells gain maximum benefit from Mastery: Chaotic Energies for 10 sec.
     jackpot = {
         id = 1217798,
         duration = 10,


### PR DESCRIPTION
# Overview
This PR fully implements a `hero_tree` state metatable using a mapping table. This solution should be future-proof (ish), requiring only updates to the table in `Constants.lua` if hero trees ever change on major patches or expansions.

Fixes https://github.com/Hekili/hekili/issues/3591 ...... :)

## State.lua
The old meta table here was functionally just a `talent.arg.enabled` lookup. The new table properly checks to see if you have the hero tree selected or not.
### Indexes
- `current`: Just returns the name string of the current hero tree (`chronowarden`, `dark_ranger`)
- `k`: Performs a lookup to see if that tree is enabled or not, falling back to `none` if any issues
- All indexes have an early-stop if the user is below level 71 and instantly returns `none`
## Constants.lua
The mapping table is defined here, leaning heavily on actual API calls.
### Table ns.HeroTrees
- The key is based on the actual number returned by the API call 
  - [reference](https://warcraft.wiki.gg/wiki/API_C_ClassTalents.GetActiveHeroTalentSpec)
- `keyTalent`: This is the talent that, when selected, indicates you have the hero tree active. While this isn't used to find the tree, it will be used later when I iterate on the Skeleton Generator again.
  - Hand-implemented by cross referencing the class files
- `name`: The Simulationcraft syntax name to support any/all APL expressions for hero trees
### Helper functions
- `ns.getHeroTree( id )`: Return the info we have stored for that tree
- `ns.getActiveHeroTreeName()`: Used in State metatable to actually determine the tree for APL or LUA-code purposes
- `ns.getActiveHeroTreeKeyTalent`: Might be used by skeleton generator. If I end up not needing it, I will remove this function with that PR.
## Options.lua
 Snapshot output. :)

Valid tree:
```
Augmentation; Primary - blistering_scales(0.00), living_flame(1.36), prescience(3.17)
build: v11.1.0-1.0.19
level: 74 (74)
class: EVOKER
spec: augmentation
hero tree: chronowarden
```

invalid tree (level 60):
```
Vengeance; Primary - arcane_torrent(0.00), infernal_strike(0.00), metamorphosis(0.00)
build: v11.1.0-1.0.19
level: 60 (60)
class: DEMONHUNTER
spec: vengeance
hero tree: none
```
## Class/spec files
The tagging of hero talents shouldn't be needed anymore, but those can be tidied up when I iterate on Skeleton Generator.

Also Destro had the wrong talent flagged and was completely missing ritual, so I fixed that.