### PR TITLE
fix: use the correct buff ID for Thrill of the Fight for VDH

### DIFF
--- a/TheWarWithin/DemonHunterVengeance.lua
+++ b/TheWarWithin/DemonHunterVengeance.lua
@@ -595,7 +595,7 @@ spec:RegisterAuras( {
         copy = "thrill_of_the_fight_attack_speed"
     },
     thrill_of_the_fight_damage = {
-        id = 442688,
+        id = 1227062,
         duration = 10,
         max_stack = 1
     },


### PR DESCRIPTION
The Adrachi Reaver Thrill of the Fight damage buff has different IDs for Havoc and Vengeance specializations. Use the correct ID for the Vengenace buff.