### PR TITLE
Classes.lua: Fix duplicate NPC key and type error in spellFilters

### DIFF
--- a/TheWarWithin/Classes.lua
+++ b/TheWarWithin/Classes.lua
@@ -102,19 +102,16 @@ local spellFilters = {
                 name = "Choking Waters",
                 interrupt = true,
             },
+            [ 272581 ] = {
+                name = "Water Bolt",
+                spell_reflection = true,
+            },
         },
         [ 128969 ] = {
             name = "Ashvane Commander",
             [ 275826 ] = {
                 name = "Bolstering Shout",
                 interrupt = true,
-            },
-        },
-        [ 129367 ] = {
-            name = "Bilge Rat Tempest",
-            [ 272581 ] = {
-                name = "Water Bolt",
-                spell_reflection = true,
             },
         },
         [ 129370 ] = {
@@ -1381,7 +1378,7 @@ do
 
     for zoneID, zoneData in pairs( spellFilters ) do
         for npcID, npcData in pairs( zoneData ) do
-            if npcID ~= "name" then
+            if npcID ~= "name" and type(npcData) == "table" then
                 for spellID, spellData in pairs( npcData ) do
                     if spellID ~= "name" and spellData.interrupt then
                         interruptibleFilters[ spellID ] = true


### PR DESCRIPTION
- Merge duplicate [129367] entries for "Bilge Rat Tempest" in Siege of Boralus.
- Added type check for npcData in interruptibleFilters loop to prevent string/table assignment errors.