### PR TITLE
Augmentation: Add missing aura definition

### DIFF
--- a/TheWarWithin/EvokerAugmentation.lua
+++ b/TheWarWithin/EvokerAugmentation.lua
@@ -602,6 +602,11 @@ spec:RegisterAuras( {
         no_ticks = true,
         friendly = true
     },
+    upheaval = {
+        id = 431620,
+        duration = 8,
+        max_stack = 1
+    },
     -- Damage taken from area-of-effect attacks reduced by $w1%.; Movement speed increased by $w2%.
     zephyr = {
         id = 374227,


### PR DESCRIPTION
Debuff was being applied, but it wasn't registered, causing LUA errors.

- Fixes https://github.com/Hekili/hekili/issues/4795