### PR TITLE
fix: improve implementation of Tome of Light's Devotion tanking trinket

### DIFF
--- a/TheWarWithin/Items.lua
+++ b/TheWarWithin/Items.lua
@@ -790,9 +790,9 @@ all:RegisterAbilities( {
         gcd = "off",
 
         item = 219309,
-        toggle = "defensives",
+        toggle = "cooldowns",
 
-        proc = "absorb",
+        proc = "crit",
         self_buff = "radiance_tome",
 
         handler = function()

--- a/TheWarWithin/Items.lua
+++ b/TheWarWithin/Items.lua
@@ -786,21 +786,28 @@ all:RegisterAbilities( {
 
     tome_of_lights_devotion = {
         cast = 0,
-        cooldown = 120,
+        cooldown = 90,
         gcd = "off",
 
         item = 219309,
         toggle = "defensives",
 
         proc = "absorb",
-        self_buff = "radiance",
+        self_buff = "radiance_tome",
 
         handler = function()
-            applyBuff( "radiance" )
+            applyBuff( "radiance_tome" )
+            if buff.inner_resilience.up then
+                removeBuff( "inner_resilience" )
+                applyBuff( "inner_radiance" )
+            elseif buff.inner_radiance.up then
+                removeBuff( "inner_radiance" )
+                applyBuff( "inner_resilience" )
+            end
         end,
 
         auras = {
-            radiance = {
+            radiance_tome = {
                 id = 443534,
                 duration = 20,
                 max_stack = 1
@@ -814,6 +821,16 @@ all:RegisterAbilities( {
                 id = 450706,
                 duration = 20,
                 max_stack = 1
+            },
+            radiance_verses = {
+                id = 450699,
+                duration = 3600,
+                max_stack = 50,
+            },
+            resilience_verses = {
+                id = 450696,
+                duration = 3600,
+                max_stack = 50,
             },
             ward_of_devotion = {
                 id = 450719,


### PR DESCRIPTION
This patchset changes the implementation of Tome of Light's Devotion to match the current behavior as of WoW 11.1.5, and also reclassifies the trinket as a cooldown trinket providing critical strike rating, which is how it's treated in current practice by tanks who utilize this trinket.