### PR TITLE
Fix Chat Command scoping issue

### DIFF
--- a/Options/ChatCommands.lua
+++ b/Options/ChatCommands.lua
@@ -13,6 +13,8 @@ local insert, remove, sort, wipe = table.insert, table.remove, table.sort, table
 
 local tableCopy =  ns.tableCopy
 
+local ACD = LibStub( "AceConfigDialog-3.0" )
+
 function Hekili:countPriorities()
     local priorities = {}
     local spec = state.spec.id


### PR DESCRIPTION
`/hek fix pack` was failing due to undefined ACD, forgot to bring it over from the `Options.lua` chop chop