### PR TITLE
Fix Alter Time

### DIFF
--- a/TheWarWithin/MageArcane.lua
+++ b/TheWarWithin/MageArcane.lua
@@ -1226,28 +1226,55 @@ end )
 spec:RegisterAbilities( {
     -- Alters the fabric of time, returning you to your current location and health when cast a second time, or after 10 seconds. Effect negated by long distance or death.
     alter_time = {
-        id = function () return buff.alter_time.down and 342247 or 342245 end,
+        id = 342245,
         cast = 0,
         cooldown = function () return talent.master_of_time.enabled and 50 or 60 end,
-        gcd = "spell",
+        gcd = "off",
         school = "arcane",
+
+        texture = 609811,
 
         spend = 0.01,
         spendType = "mana",
+        nobuff = "alter_time",
 
-        toggle = "defensives",
+        talent = "alter_time",
         startsCombat = false,
 
+        toggle = "defensives",
+
         handler = function ()
-            if buff.alter_time.down then
-                applyBuff( "alter_time" )
-            else
-                removeBuff( "alter_time" )
-                if talent.master_of_time.enabled then setCooldown( "blink", 0 ) end
-            end
+            applyBuff( "alter_time" )
+            setCooldown( "alter_time_return", 0 )
         end,
 
-        copy = { 342247, 342245 },
+        copy = { 342247, 342245 }
+    },
+
+    alter_time_return = {
+        id = 342247,
+        cast = 0,
+        cooldown = function () return talent.master_of_time.enabled and 50 or 60 end,
+        gcd = "off",
+        school = "arcane",
+
+        texture = 985088,
+
+        spend = 0.01,
+        spendType = "mana",
+        buff = "alter_time",
+
+        talent = "alter_time",
+        startsCombat = false,
+
+        toggle = "defensives",
+
+        handler = function ()
+            removeBuff( "alter_time" )
+            if talent.master_of_time.enabled then setCooldown( "blink", 0 ) end
+        end,
+
+        copy = { 342247, 342245 }
     },
 
     -- Talent: Launches bolts of arcane energy at the enemy target, causing 1,617 Arcane damage. For each Arcane Charge, deals 36% additional damage and hits 1 additional nearby target for 40% of its damage. Consumes all Arcane Charges.

--- a/TheWarWithin/MageFire.lua
+++ b/TheWarWithin/MageFire.lua
@@ -1222,25 +1222,52 @@ spec:RegisterStateTable( "incanters_flow_time_to", setmetatable( {}, {
 spec:RegisterAbilities( {
     -- Talent: Alters the fabric of time, returning you to your current location and health when cast a second time, or after 10 seconds. Effect negated by long distance or death.
     alter_time = {
-        id = function () return buff.alter_time.down and 342247 or 342245 end,
+        id = 342245,
         cast = 0,
         cooldown = function () return talent.master_of_time.enabled and 50 or 60 end,
         gcd = "off",
         school = "arcane",
 
+        texture = 609811,
+
         spend = 0.01,
         spendType = "mana",
+        nobuff = "alter_time",
 
         talent = "alter_time",
         startsCombat = false,
 
+        toggle = "defensives",
+
         handler = function ()
-            if buff.alter_time.down then
-                applyBuff( "alter_time" )
-            else
-                removeBuff( "alter_time" )
-                if talent.master_of_time.enabled then setCooldown( "blink", 0 ) end
-            end
+            applyBuff( "alter_time" )
+            setCooldown( "alter_time_return", 0 )
+        end,
+
+        copy = { 342247, 342245 }
+    },
+
+    alter_time_return = {
+        id = 342247,
+        cast = 0,
+        cooldown = function () return talent.master_of_time.enabled and 50 or 60 end,
+        gcd = "off",
+        school = "arcane",
+
+        texture = 985088,
+
+        spend = 0.01,
+        spendType = "mana",
+        buff = "alter_time",
+
+        talent = "alter_time",
+        startsCombat = false,
+
+        toggle = "defensives",
+
+        handler = function ()
+            removeBuff( "alter_time" )
+            if talent.master_of_time.enabled then setCooldown( "blink", 0 ) end
         end,
 
         copy = { 342247, 342245 }


### PR DESCRIPTION
# Fix Alter Time for Mages
- Fixes https://github.com/Hekili/hekili/issues/4874

Primary issue is that the IDs for the initial alter, and the return alter were backwards. Improved the solution by separating into 2 different spells which fixes the issue with weird cooldowns and icons between the 2.