### PR TITLE
Updated Protection Warrior

### DIFF
--- a/TheWarWithin/WarriorProtection.lua
+++ b/TheWarWithin/WarriorProtection.lua
@@ -1429,7 +1429,7 @@ spec:RegisterAbilities( {
 
         readyTime = function()
             if buff.revenge.up then return 0 end
-            local threshold = settings.reserve_rage + 40
+            local threshold = settings.reserve_rage + 20
             return ( tanking and rage.current < threshold ) and rage[ "time_to_" .. threshold ] or 0
         end,
 


### PR DESCRIPTION
- Changed Revenge threshold to be settings.reserve_rage + 20 instead of 40. There is no reason for it to be 40 and it simply means there is no button to press, if you are between 20 and 40 rage with both Shield Slam and Thunder Clap on CD. It might make sense to change execute to 20 as well. Though I understand that the 40 setting is for the max damage of execute.