### PR TITLE
Force Lava Lash target swap indicator to obey uers cycle settings for Flame Shock debuff portion

### DIFF
--- a/TheWarWithin/ShamanEnhancement.lua
+++ b/TheWarWithin/ShamanEnhancement.lua
@@ -2328,7 +2328,7 @@ spec:RegisterAbilities( {
         end,
 
         indicator = function()
-            if debuff.flame_shock.down and active_dot.flame_shock > 0 and active_enemies > 1 then return "cycle" end
+            if settings.cycle and debuff.flame_shock.down and active_dot.flame_shock > 0 and active_enemies > 1 then return "cycle" end
         end,
 
         handler = function ()


### PR DESCRIPTION
The lashing flames indicator already obeys it because it's registered under `cycle = `, but the flame shock debuff part doesn't because of the registration under `indicator =`. This should probably check for the users settings.

Fixes https://github.com/Hekili/hekili/issues/4877