### PR TITLE
Remove accidentally added "/rl" string in core.lua

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -1967,7 +1967,7 @@ function Hekili.Update()
 
                         local ability = class.abilities[ action ]
                         wait = ability.cast or 0
-/rl
+
                         slot.scriptType = "simc"
                         slot.script = nil
                         slot.hook = nil


### PR DESCRIPTION
This string appears to have been added unintentionally (likely during testing or debugging).