### PR TITLE
Fix holy priest divine image buff

### DIFF
--- a/TheWarWithin/PriestHoly.lua
+++ b/TheWarWithin/PriestHoly.lua
@@ -236,9 +236,9 @@ spec:RegisterAuras( {
         max_stack = 5
     },
     divine_image = {
-        id = 392990,
+        id = 405963,
         duration = 9,
-        max_stack = 1
+        max_stack = 2 
     },
     divine_word = {
         id = 372760,


### PR DESCRIPTION
https://www.wowhead.com/spell=405963/divine-image

After this change buff.divine_image.up finally works as expected in holy priest apl