### PR TITLE
Fix mystic touch IDs

### DIFF
--- a/TheWarWithin/MonkBrewmaster.lua
+++ b/TheWarWithin/MonkBrewmaster.lua
@@ -504,6 +504,11 @@ spec:RegisterAuras( {
         duration = 5.0,
         max_stack = 1,
     },
+    mystic_touch = {
+        id = 113746,
+        duration = 3600,
+        max_stack = 1
+    },
     ox_stance = {
         id = 455071,
         duration = 30,

--- a/TheWarWithin/MonkMistweaver.lua
+++ b/TheWarWithin/MonkMistweaver.lua
@@ -406,7 +406,9 @@ spec:RegisterAuras( {
         id = 117907,
     },
     mystic_touch = {
-        id = 8647,
+        id = 113746,
+        duration = 3600,
+        max_stack = 1
     },
     overflowing_mists = {
         id = 388513,

--- a/TheWarWithin/MonkWindwalker.lua
+++ b/TheWarWithin/MonkWindwalker.lua
@@ -529,7 +529,7 @@ spec:RegisterAuras( {
     mystic_touch = {
         id = 113746,
         duration = 3600,
-        max_stack = 1,
+        max_stack = 1
     },
     -- Reduces the Chi Cost of your abilities by $s1.
     ordered_elements = {


### PR DESCRIPTION
SpellID the the same across all 3 specs.
- Fixes https://github.com/Hekili/hekili/issues/4899
