### PR TITLE
Allow addon UI to work on 11.2 PTR

### DIFF
--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -4678,7 +4678,7 @@ found = true end
         while( true ) do
             local id, name, description, texture, role = GetSpecializationInfo( i )
 
-            if not id then break end
+            if not id or id == 0 then break end
             if description then description = description:match( "^(.-)\n" ) end
 
             local spec = class.specs[ id ]


### PR DESCRIPTION
`GetSpecializationInfo` now returns 0 as a specID when it doesn't work (such as checking an invalid index, like the 4th spec of Hunter), so the guardrails in the addon will no longer be sufficient. Lets addon UI work on PTR, and obviously is mandatory for the actual 11.2 release.

ref: https://github.com/Gethe/wow-ui-source/blob/c18b697f1053d526c1d5418a82f94f5281fd7637/Interface/AddOns/Blizzard_APIDocumentationGenerated/SpecializationInfoDocumentation.lua#L203

![image](https://github.com/user-attachments/assets/3503a3f6-857e-42ec-9b86-bdceae13bc2a)
