### PR TITLE
Allow ForecastPeriod to be configured for Primary and AoE toggles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+# IDEs and text editors
+.idea/
+*.swp
+
 # Actual Stuff in my folder.
 Libs/AceAddon-3.0
 Libs/AceBucket-3.0

--- a/Core.lua
+++ b/Core.lua
@@ -1650,7 +1650,7 @@ function Hekili.Update()
             if debug then Hekili:Debug( "Combat Timer: %.2f", state.time ) end
 
             local isMain = ( dispName == "Primary" and dispName == "AOE" )
-            local defaultMax = isMain and 15 or ( display.forecastPeriod or 15 )
+            local defaultMax = display.forecastPeriod or 15
 
             if class.file == "DEATHKNIGHT" then
                 defaultMax = max( defaultMax, 0.01 + 20 * state.haste )
@@ -1671,7 +1671,7 @@ function Hekili.Update()
 
                 local action, wait, depth
                 local isMain = ( dispName == "Primary" or dispName == "AOE" )
-                local defaultMax = 15
+                local defaultMax = display.forecastPeriod or 15
 
                 if class.file == "DEATHKNIGHT" then
                     defaultMax = max( defaultMax, 0.01 + 20 * state.haste )

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -1424,16 +1424,9 @@ return end
                                 width = "full",
                                 order = 2,
                                 disabled = function()
-                                    return name == "Multi"
+                                    return false
                                 end,
                                 hidden = function( info, val )
-                                    local n = #info
-                                    local display = info[2]
-
-                                    if display == "Primary" or display == "AOE" then
-                                        return true
-                                    end
-
                                     return false
                                 end,
                             },


### PR DESCRIPTION
Allow `forecastPeriod` to be configured for Primary and AoE displays.

This allows further UI customization. For example, only showing recommendations once they are ready to be cast, and hiding them as soon as they have been cast. I find this UI a lot more useful - it allows me to better focus on mechanics and positioning in the time between casts

This PR does not change the default behavior or forecastPeriod. It only allows gives users the option to customize it

Low-res screen recording after making the changes: 
![hekili-forecastperiod-gif](https://github.com/user-attachments/assets/a052c45c-287e-4677-b371-beb729b4cc85)
Higher res recording: https://limewire.com/d/rURts#otOK0ycNFf