### PR TITLE
11.2 Prep - Convert register gear to new version - DK + DH

### DIFF
--- a/TheWarWithin/DeathKnightBlood.lua
+++ b/TheWarWithin/DeathKnightBlood.lua
@@ -1184,123 +1184,122 @@ spec:RegisterAuras( {
     },
 } )
 
-
--- The War Within
-spec:RegisterGear( "tww2", 229253, 229251, 229256, 229254, 229252 )
-spec:RegisterAuras( {
-    -- https://www.wowhead.com/spell=1218601
-    -- Luck of the Draw! Damage increased by 15%. Death Strike costs 10 less Runic Power and strikes 2 additional nearby targets.
-    luck_of_the_draw = {
-        id = 1218601,
-        duration = function() if set_bonus.tww2 >= 4 then return 12 end
-            return 10
-        end,
-        max_stack = 1,
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229253, 229251, 229256, 229254, 229252 },
+        auras = {
+            luck_of_the_draw = {
+                id = 1218601,
+                duration = function()
+                    if set_bonus.tww2 >= 4 then return 12 end
+                    return 10
+                end,
+                max_stack = 1
+            },
+            murderous_frenzy = {
+                id = 1222698,
+                duration = 6,
+                max_stack = 1
+            }
+        }
     },
-    -- https://www.wowhead.com/spell=1222698
-    -- Murderous Frenzy Your Haste is increased by 12%.
-    murderous_frenzy = {
-        id = 1222698,
-        duration = 6,
-        max_stack = 1,
+    tww1 = {
+        items = { 212005, 212003, 212002, 212001, 212000 },
+        auras = {
+            unbreakable = {
+                id = 457468,
+                duration = 3600,
+                max_stack = 1
+            },
+            unbroken = {
+                id = 457473,
+                duration = 6,
+                max_stack = 1
+            },
+            piledriver = {
+                id = 457506,
+                duration = 3600,
+                max_stack = 10
+            },
+            icy_vigor = {
+                id = 457189,
+                duration = 8,
+                max_stack = 1
+            },
+            unholy_commander = {
+                id = 456698,
+                duration = 8,
+                max_stack = 1
+            }
+        }
     },
+    -- Dragonflight
+    tier31 = {
+        items = { 207198, 207199, 207200, 207201, 207203 },
+        auras = {
+            ashen_decay_proc = {
+                id = 425721,
+                duration = 20,
+                max_stack = 1
+            },
+            ashen_decay = {
+                id = 425719,
+                duration = 8,
+                max_stack = 1,
+                copy = "ashen_decay_debuff"
+            }
+        }
+    },
+    tier30 = {
+        items = { 202464, 202462, 202461, 202460, 202459, 217223, 217225, 217221, 217222, 217224 },
+        auras = {
+            vampiric_strength = {
+                id = 408356,
+                duration = 5,
+                max_stack = 1
+            }
+        }
+    },
+    tier29 = {
+        items = { 200405, 200407, 200408, 200409, 200410 },
+        auras = {
+            vigorous_lifeblood = {
+                id = 394570,
+                duration = 10,
+                max_stack = 1
+            }
+        }
+    },
+    -- Legacy
+    acherus_drapes = { items = { 132376 } },
+    cold_heart = { items = { 151796 } }, -- chilled_heart stacks NYI
+    consorts_cold_core = { items = { 144293 } },
+    death_march = { items = { 144280 } },
+    draugr_girdle_of_the_everlasting_king = { items = { 132441 } },
+    koltiras_newfound_will = { items = { 132366 } },
+    lanathels_lament = { items = { 133974 } },
+    perseverance_of_the_ebon_martyr = { items = { 132459 } },
+    rethus_incessant_courage = { items = { 146667 } },
+    seal_of_necrofantasia = { items = { 137223 } },
+    service_of_gorefiend = { items = { 132367 } },
+    shackles_of_bryndaor = { items = { 132365 } }, -- NYI (Death Strike heals refund RP...)
+    skullflowers_haemostasis = {
+        items = { 144281 },
+        auras = {
+            haemostasis = {
+                id = 235559,
+                duration = 3600,
+                max_stack = 5
+            }
+        }
+    },
+    soul_of_the_deathlord = { items = { 151740 } },
+    soulflayers_corruption = { items = { 151795 } },
+    the_instructors_fourth_lesson = { items = { 132448 } },
+    toravons_whiteout_bindings = { items = { 132458 } },
+    uvanimor_the_unbeautiful = { items = { 137037 } }
 } )
-spec:RegisterGear( "tww1", 212005, 212003, 212002, 212001, 212000 )
-spec:RegisterAuras( {
-    unbreakable = {
-        id = 457468,
-        duration = 3600,
-        max_stack = 1
-    },
-    unbroken = {
-        id = 457473,
-        duration = 6,
-        max_stack = 1
-    },
-    piledriver = {
-        id = 457506,
-        duration = 3600,
-        max_stack = 10
-    },
-
-    icy_vigor = {
-        id = 457189,
-        duration = 8,
-        max_stack = 1
-    },
-
-    unholy_commander = {
-        id = 456698,
-        duration = 8,
-        max_stack = 1
-    }
-})
-
--- Tier 29
-spec:RegisterGear( "tier29", 200405, 200407, 200408, 200409, 200410 )
--- TODO: Proactively count Bone Shields consumed and proactively model Vigorous Lifeblood proc.
-spec:RegisterAura( "vigorous_lifeblood", {
-    id = 394570,
-    duration = 10,
-    max_stack = 1
-} )
-
--- Tier 30
-spec:RegisterGear( "tier30", 202464, 202462, 202461, 202460, 202459, 217223, 217225, 217221, 217222, 217224 )
--- 2 pieces (Blood) : Heart Strike and Blood Boil deal 20% increased damage and have a 10% chance to grant Vampiric Blood for 5 sec.
--- 4 pieces (Blood) : When you would gain Vampiric Blood you are infused with Vampiric Strength, granting you 10% Strength for 5 sec. Your Heart Strike and Blood Boil extend the duration of Vampiric Strength by 0.5 sec.
-spec:RegisterAura( "vampiric_strength", {
-    id = 408356,
-    duration = 5,
-    max_stack = 1
-} )
-
-spec:RegisterGear( "tier31", 207198, 207199, 207200, 207201, 207203 )
--- (2) Consuming Runic Power has a chance to cause your next Heart Strike to apply Ashen Decay, reducing damage dealt to you by $425719s1% and increasing your damage dealt to afflicted targets by $425719s2% for $425719d.
--- (4) Soul Reaper's execute damage and Abomination Limb's damage applies Ashen Decay to enemy targets, and Heart Strike and Blood Boil's direct damage extends Ashen Decay by ${$s1/1000}.1 sec.
-spec:RegisterAuras( {
-    ashen_decay_proc = {
-        id = 425721,
-        duration = 20,
-        max_stack = 1
-    },
-    ashen_decay = {
-        id = 425719,
-        duration = 8,
-        max_stack = 1,
-        copy = "ashen_decay_debuff"
-    }
-} )
-
-
-
-
--- Legacy Legendaries
-spec:RegisterGear( "acherus_drapes", 132376 )
-spec:RegisterGear( "cold_heart", 151796 ) -- chilled_heart stacks NYI
-spec:RegisterGear( "consorts_cold_core", 144293 )
-spec:RegisterGear( "death_march", 144280 )
--- spec:RegisterGear( "death_screamers", 151797 )
-spec:RegisterGear( "draugr_girdle_of_the_everlasting_king", 132441 )
-spec:RegisterGear( "koltiras_newfound_will", 132366 )
-spec:RegisterGear( "lanathels_lament", 133974 )
-spec:RegisterGear( "perseverance_of_the_ebon_martyr", 132459 )
-spec:RegisterGear( "rethus_incessant_courage", 146667 )
-spec:RegisterGear( "seal_of_necrofantasia", 137223 )
-spec:RegisterGear( "service_of_gorefiend", 132367 )
-spec:RegisterGear( "shackles_of_bryndaor", 132365 ) -- NYI (Death Strike heals refund RP...)
-spec:RegisterGear( "skullflowers_haemostasis", 144281 )
-    spec:RegisterAura( "haemostasis", {
-        id = 235559,
-        duration = 3600,
-        max_stack = 5
-    } )
-
-spec:RegisterGear( "soul_of_the_deathlord", 151740 )
-spec:RegisterGear( "soulflayers_corruption", 151795 )
-spec:RegisterGear( "the_instructors_fourth_lesson", 132448 )
-spec:RegisterGear( "toravons_whiteout_bindings", 132458 )
-spec:RegisterGear( "uvanimor_the_unbeautiful", 137037 )
 
 
 spec:RegisterTotem( "ghoul", 1100170 ) -- Texture ID

--- a/TheWarWithin/DemonHunterHavoc.lua
+++ b/TheWarWithin/DemonHunterHavoc.lua
@@ -913,6 +913,100 @@ spec:RegisterAuras( {
     },
 } )
 
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229316, 229314, 229319, 229317, 229315 },
+        auras = {
+            winning_streak = {
+                id = 1217011,
+                duration = 3600,
+                max_stack = 10
+            },
+            necessary_sacrifice = {
+                id = 1217055,
+                duration = 15,
+                max_stack = 10
+            },
+            winning_streak_temporary = {
+                id = 1220706,
+                duration = 7,
+                max_stack = 10
+            }
+        }
+    },
+    tww1 = {
+        items = { 212068, 212066, 212065, 212064, 212063 },
+        auras = {
+            blade_rhapsody = {
+                id = 454628,
+                duration = 12,
+                max_stack = 1
+            }
+        }
+    },
+    -- Dragonflight
+    tier31 = {
+        items = { 207261, 207262, 207263, 207264, 207266, 217228, 217230, 217226, 217227, 217229 }
+    },
+    tier30 = {
+        items = { 202527, 202525, 202524, 202523, 202522 },
+        auras = {
+            seething_fury = {
+                id = 408737,
+                duration = 6,
+                max_stack = 1
+            },
+            seething_potential = {
+                id = 408754,
+                duration = 60,
+                max_stack = 5
+            }
+        }
+    },
+    tier29 = {
+        items = { 200345, 200347, 200342, 200344, 200346 },
+        auras = {
+            seething_chaos = {
+                id = 394934,
+                duration = 6,
+                max_stack = 1
+            }
+        }
+    },
+    -- Legacy Tier Sets
+    tier21 = {
+        items = { 152121, 152123, 152119, 152118, 152120, 152122 },
+        auras = {
+            havoc_t21_4pc = {
+                id = 252165,
+                duration = 8
+            }
+        }
+    },
+    tier20 = { items = { 147130, 147132, 147128, 147127, 147129, 147131 } },
+    tier19 = { items = { 138375, 138376, 138377, 138378, 138379, 138380 } },
+    -- Class Hall Set
+    class = { items = { 139715, 139716, 139717, 139718, 139719, 139720, 139721, 139722 } },
+    -- Legion/Trinkets/Legendaries
+    convergence_of_fates = { items = { 140806 } },
+    achor_the_eternal_hunger = { items = { 137014 } },
+    anger_of_the_halfgiants = { items = { 137038 } },
+    cinidaria_the_symbiote = { items = { 133976 } },
+    delusions_of_grandeur = { items = { 144279 } },
+    kiljaedens_burning_wish = { items = { 144259 } },
+    loramus_thalipedes_sacrifice = { items = { 137022 } },
+    moarg_bionic_stabilizers = { items = { 137090 } },
+    prydaz_xavarics_magnum_opus = { items = { 132444 } },
+    raddons_cascading_eyes = { items = { 137061 } },
+    sephuzs_secret = { items = { 132452 } },
+    the_sentinels_eternal_refuge = { items = { 146669 } },
+    soul_of_the_slayer = { items = { 151639 } },
+    chaos_theory = { items = { 151798 } },
+    oblivions_embrace = { items = { 151799 } }
+} )
+
+
 spec:RegisterStateExpr( "soul_fragments", function ()
     return GetSpellCastCount(232893) -- only works with Reaver hero tree
 end )
@@ -1002,67 +1096,6 @@ spec:RegisterHook( "UNIT_ELIMINATED", function( id )
     initiative_actual[ id ] = nil
 end )
 
--- Gear Sets
-spec:RegisterGear( "tier29", 200345, 200347, 200342, 200344, 200346 )
-spec:RegisterAura( "seething_chaos", {
-    id = 394934,
-    duration = 6,
-    max_stack = 1
-} )
-
--- Tier 30
-spec:RegisterGear( "tier30", 202527, 202525, 202524, 202523, 202522 )
--- 2 pieces (Havoc) : Every 175 Fury you spend, gain Seething Fury, increasing your Agility by 8% for 6 sec.
--- TODO: Track Fury spent toward Seething Fury.  New expressions: seething_fury_threshold, seething_fury_spent, seething_fury_deficit.
-spec:RegisterAura( "seething_fury", {
-    id = 408737,
-    duration = 6,
-    max_stack = 1
-} )
--- 4 pieces (Havoc) : Each time you gain Seething Fury, gain 15 Fury and the damage of your next Eye Beam is increased by 15%, stacking 5 times.
-spec:RegisterAura( "seething_potential", {
-    id = 408754,
-    duration = 60,
-    max_stack = 5
-} )
-
-spec:RegisterGear( "tier31", 207261, 207262, 207263, 207264, 207266, 217228, 217230, 217226, 217227, 217229 )
--- (2) Blade Dance automatically triggers Throw Glaive on your primary target for $s3% damage and each slash has a $s2% chance to Throw Glaive an enemy for $s1% damage.
--- (4) Throw Glaive reduces the remaining cooldown of The Hunt by ${$s1/1000}.1 sec, and The Hunt's damage over time effect lasts ${$s2/1000} sec longer.
-
-spec:RegisterGear( "tww2", 229316, 229314, 229319, 229317, 229315 )
-
-spec:RegisterAuras( {
-    -- 2-set
-    -- Winning Streak! Increase the DPS of Blade Dance and Chaos Strike by 3% stacking pu to 10 times. Blade Dance and Chaos Strike have 15% chance of removing Winning Streak! .
-    winning_streak = {
-        id = 1217011,
-        duration = 3600,
-        max_stack = 10
-        },
-    --4-set
-    -- Winning Streak persists for 7s after being cancelled. Entering Demon Form sacrifices all Winning Streak! stacks to gain 0% (?) Crit Strike Chance per stack consumed. Lasts 15s
-    necessary_sacrifice = {
-    id = 1217055,
-    duration = 15,
-    max_stack = 10
-    },
-    -- https://www.wowhead.com/spell=1220706
-    -- Winning Streak! Ending a Winning Streak! Blade Dance and Chaos Strike damage increased by 6%.
-    winning_streak_temporary = {
-        id = 1220706,
-        duration = 7,
-        max_stack = 10
-    },
-
-} )
-
-spec:RegisterGear( "tww1", 212068, 212066, 212065, 212064, 212063 )
-spec:RegisterAura( "blade_rhapsody", {
-    id = 454628,
-    duration = 12,
-    max_stack = 1
-} )
 
 -- Abilities that may trigger Demonsurge.
 local demonsurge = {
@@ -1202,38 +1235,6 @@ spec:RegisterHook( "spend", function( amt, resource )
         end
     end
 end )
-
-
-
-
-spec:RegisterGear( "tier19", 138375, 138376, 138377, 138378, 138379, 138380 )
-spec:RegisterGear( "tier20", 147130, 147132, 147128, 147127, 147129, 147131 )
-spec:RegisterGear( "tier21", 152121, 152123, 152119, 152118, 152120, 152122 )
-    spec:RegisterAura( "havoc_t21_4pc", {
-        id = 252165,
-        duration = 8
-    } )
-
-spec:RegisterGear( "class", 139715, 139716, 139717, 139718, 139719, 139720, 139721, 139722 )
-
-spec:RegisterGear( "convergence_of_fates", 140806 )
-
-spec:RegisterGear( "achor_the_eternal_hunger", 137014 )
-spec:RegisterGear( "anger_of_the_halfgiants", 137038 )
-spec:RegisterGear( "cinidaria_the_symbiote", 133976 )
-spec:RegisterGear( "delusions_of_grandeur", 144279 )
-spec:RegisterGear( "kiljaedens_burning_wish", 144259 )
-spec:RegisterGear( "loramus_thalipedes_sacrifice", 137022 )
-spec:RegisterGear( "moarg_bionic_stabilizers", 137090 )
-spec:RegisterGear( "prydaz_xavarics_magnum_opus", 132444 )
-spec:RegisterGear( "raddons_cascading_eyes", 137061 )
-spec:RegisterGear( "sephuzs_secret", 132452 )
-spec:RegisterGear( "the_sentinels_eternal_refuge", 146669 )
-
-spec:RegisterGear( "soul_of_the_slayer", 151639 )
-spec:RegisterGear( "chaos_theory", 151798 )
-spec:RegisterGear( "oblivions_embrace", 151799 )
-
 
 do
     local wasWarned = false

--- a/TheWarWithin/DemonHunterVengeance.lua
+++ b/TheWarWithin/DemonHunterVengeance.lua
@@ -649,6 +649,59 @@ spec:RegisterAuras( {
     },
 } )
 
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229316, 229314, 229319, 229317, 229315 }
+    },
+    -- Dragonflight
+    tier31 = {
+        items = { 207261, 207262, 207263, 207264, 207266, 217228, 217230, 217226, 217227, 217229 },
+        auras = {
+            fiery_resolve = {
+                id = 425653,
+                duration = 8,
+                max_stack = 5
+            }
+        }
+    },
+    tier30 = {
+        items = { 202527, 202525, 202524, 202523, 202522 },
+        auras = {
+            fires_of_fel = {
+                id = 409645,
+                duration = 6,
+                max_stack = 1
+            },
+            recrimination = {
+                id = 409877,
+                duration = 30,
+                max_stack = 1
+            }
+        }
+    },
+    tier29 = {
+        items = { 200345, 200347, 200342, 200344, 200346 },
+        auras = {
+            decrepit_souls = {
+                id = 394958,
+                duration = 8,
+                max_stack = 1
+            }
+        }
+    },
+    -- Legacy Tier Sets
+    tier21 = { items = { 152121, 152123, 152119, 152118, 152120, 152122 } },
+    tier20 = { items = { 147130, 147132, 147128, 147127, 147129, 147131 } },
+    tier19 = { items = { 138375, 138376, 138377, 138378, 138379, 138380 } },
+
+    -- Class Hall
+    class = { items = { 139715, 139716, 139717, 139718, 139719, 139720, 139721, 139722 } },
+    -- Notable Trinkets
+    convergence_of_fates = { items = { 140806 } }
+} )
+
+
 spec:RegisterStateExpr( "soul_fragments", function ()
     return buff.soul_fragments.stack
 end )
@@ -841,38 +894,7 @@ spec:RegisterVariable( "incoming_souls", function()
     return souls
 end )--]]
 
--- The War Within
-spec:RegisterGear( "tww2", 229316, 229314, 229319, 229317, 229315 )
 
--- Dragonflight
-spec:RegisterGear( "tier29", 200345, 200347, 200342, 200344, 200346 )
-spec:RegisterAura( "decrepit_souls", {
-    id = 394958,
-    duration = 8,
-    max_stack = 1
-} )
-spec:RegisterGear( "tier30", 202527, 202525, 202524, 202523, 202522 )
--- 2 pieces (Vengeance) : Soul Fragments heal for 10% more and generating a Soul Fragment increases your Fire damage by 2% for 6 sec. Multiple applications may overlap.
--- TODO: Track each application to keep count for Recrimination.
-spec:RegisterAura( "fires_of_fel", {
-    id = 409645,
-    duration = 6,
-    max_stack = 1
-} )
--- 4 pieces (Vengeance) : Shear and Fracture deal Fire damage, and after consuming 20 Soul Fragments, your next cast of Shear or Fracture will apply Fiery Brand for 6 sec to its target.
-spec:RegisterAura( "recrimination", {
-    id = 409877,
-    duration = 30,
-    max_stack = 1
-} )
-spec:RegisterGear( "tier31", 207261, 207262, 207263, 207264, 207266, 217228, 217230, 217226, 217227, 217229 )
--- (2) When you attack a target afflicted by Sigil of Flame, your damage and healing are increased by 2% and your Stamina is increased by 2% for 8 sec, stacking up to 5.
--- (4) Sigil of Flame's periodic damage has a chance to flare up, shattering an additional Soul Fragment from a target and dealing $425672s1 additional damage. Each $s1 Fury you spend reduces its cooldown by ${$s2/1000}.1 sec.
-spec:RegisterAura( "fiery_resolve", {
-    id = 425653,
-    duration = 8,
-    max_stack = 5
-} )
 
 local furySpent = 0
 
@@ -896,12 +918,6 @@ spec:RegisterStateExpr( "fury_spent", function ()
     return furySpent
 end )
 
--- Legacy
-spec:RegisterGear( "tier19", 138375, 138376, 138377, 138378, 138379, 138380 )
-spec:RegisterGear( "tier20", 147130, 147132, 147128, 147127, 147129, 147131 )
-spec:RegisterGear( "tier21", 152121, 152123, 152119, 152118, 152120, 152122 )
-spec:RegisterGear( "class", 139715, 139716, 139717, 139718, 139719, 139720, 139721, 139722 )
-spec:RegisterGear( "convergence_of_fates", 140806 )
 
 local ConsumeSoulFragments = setfenv( function( amt )
     if talent.soul_furnace.enabled then


### PR DESCRIPTION
Convert RegisterGear to the new format ahead of the 11.2 branch, making it easy to insert the new tier sets.