### PR TITLE
11.2 Prep - Convert register gear to new version - Druid + Evoker

### DIFF
--- a/TheWarWithin/DruidBalance.lua
+++ b/TheWarWithin/DruidBalance.lua
@@ -1038,6 +1038,88 @@ spec:RegisterAuras( {
     },
 } )
 
+spec:RegisterGear({
+    -- The War Within
+    tww1 = {
+        items = { 212059, 212057, 212056, 212055, 212054 }
+    },
+    tww2 = {
+        items = { 229310, 229308, 229306, 229307, 229305 }
+    },
+    -- Dragonflight
+    tier31 = {
+        items = { 207252, 207253, 207254, 207255, 207257 },
+        auras = {
+            dreamstate = {
+                id = 424248,
+                duration = 3600,
+                max_stack = 2,
+                copy = 450346
+            }
+        }
+    },
+    tier30 = {
+        items = { 202518, 202516, 202515, 202514, 202513 }
+    },
+    tier29 = {
+        items = { 200351, 200353, 200354, 200355, 200356, 217193, 217195, 217191, 217192, 217194 },
+        auras = {
+            gathering_starstuff = {
+                id = 394412,
+                duration = 15,
+                max_stack = 3
+            },
+            touch_the_cosmos = {
+                id = 394414,
+                duration = 15,
+                max_stack = 1
+            }
+        }
+    },
+
+    -- Legacy
+    tier21 = {
+        items = { 152127, 152129, 152125, 152124, 152126, 152128 },
+        auras = {
+            solar_solstice = {
+                id = 252767,
+                duration = 6,
+                max_stack = 1
+            }
+        }
+    },
+    tier20 = { items = { 147136, 147138, 147134, 147133, 147135, 147137 } },
+    tier19 = { items = { 138330, 138336, 138366, 138324, 138327, 138333 } },
+    class = { items = { 139726, 139728, 139723, 139730, 139725, 139729, 139727, 139724 } },
+    impeccable_fel_essence = { items = { 137039 } },
+    oneths_intuition = {
+        items = { 137092 },
+        auras = {
+            oneths_intuition = {
+                id = 209406,
+                duration = 3600,
+                max_stacks = 1
+            },
+            oneths_overconfidence = {
+                id = 209407,
+                duration = 3600,
+                max_stacks = 1
+            }
+        }
+    },
+    radiant_moonlight = { items = { 151800 } },
+    the_emerald_dreamcatcher = {
+        items = { 137062 },
+        auras = {
+            the_emerald_dreamcatcher = {
+                id = 224706,
+                duration = 5,
+                max_stack = 2
+            }
+        }
+    }
+} )
+
 -- Adaptive Swarm Stuff
 do
     local applications = {
@@ -1749,92 +1831,6 @@ spec:RegisterHook( "spend", function( amt, resource )
     end
 end )
 
---The War Within
-spec:RegisterGear( "tww1", 212059, 212057, 212056, 212055, 212054 )
-spec:RegisterGear( "tww2", 229310, 229308, 229306, 229307, 229305  )
-spec:RegisterAuras( {
-    -- 2-set
-    -- https://www.wowhead.com/spell=1218033
-    -- Jackpot! Auto shot damage increased by 200% and the time between auto shots is reduced by 0.5 sec.
-    --[[jackpot = {
-        id = 1218033,
-        duration = 10,
-        max_stack = 1,
-    },--]]
-
-} )
--- Tier 29
-spec:RegisterGear( "tier29", 200351, 200353, 200354, 200355, 200356, 217193, 217195, 217191, 217192, 217194 )
-spec:RegisterSetBonuses( "tier29_2pc", 393632, "tier29_4pc", 393633 )
-spec:RegisterAuras( {
-    gathering_starstuff = {
-        id = 394412,
-        duration = 15,
-        max_stack = 3,
-    },
-    touch_the_cosmos = {
-        id = 394414,
-        duration = 15,
-        max_stack = 1,
-    }
-} )
-
--- Tier 30
-spec:RegisterGear( "tier30", 202518, 202516, 202515, 202514, 202513 )
--- 2 pieces (Balance) : Sunfire radius increased by 3 yds. Sunfire, Moonfire and Shooting Stars damage increased by 20%.
--- 4 pieces (Balance) : Shooting Stars has a 20% chance to instead call down a Crashing Star, dealing (76.5% of Spell power) Astral damage to the target and generating 5 Astral Power.
-
-spec:RegisterGear( "tier31", 207252, 207253, 207254, 207255, 207257 )
--- (2) When Eclipse ends or when you enter combat, enter a Dreamstate, reducing the cast time of your next $s3 Starfires or Wraths by $s1% and increasing their damage by $s2%.
-spec:RegisterAuras( {
-    dreamstate = {
-        id = 424248,
-        duration = 3600,
-        max_stack = 2,
-        copy = 450346
-    },
-
-} )
-spec:RegisterHook( "runHandler_startCombat", function()
-    if set_bonus.tier31_2pc > 0 then applyBuff( "dreamstate", nil, 2 ) end
-end )
--- (4) Starsurge or Starfall increase your current Eclipse's Arcane or Nature damage bonus by an additional $s1%, up to $s2%.
-
-
--- Legion Sets (for now).
-spec:RegisterGear( "tier21", 152127, 152129, 152125, 152124, 152126, 152128 )
-    spec:RegisterAura( "solar_solstice", {
-        id = 252767,
-        duration = 6,
-        max_stack = 1,
-     } )
-
-spec:RegisterGear( "tier20", 147136, 147138, 147134, 147133, 147135, 147137 )
-spec:RegisterGear( "tier19", 138330, 138336, 138366, 138324, 138327, 138333 )
-spec:RegisterGear( "class", 139726, 139728, 139723, 139730, 139725, 139729, 139727, 139724 )
-
-spec:RegisterGear( "impeccable_fel_essence", 137039 )
-spec:RegisterGear( "oneths_intuition", 137092 )
-    spec:RegisterAuras( {
-        oneths_intuition = {
-            id = 209406,
-            duration = 3600,
-            max_stacks = 1,
-        },
-        oneths_overconfidence = {
-            id = 209407,
-            duration = 3600,
-            max_stacks = 1,
-        },
-    } )
-
-spec:RegisterGear( "radiant_moonlight", 151800 )
-spec:RegisterGear( "the_emerald_dreamcatcher", 137062 )
-    spec:RegisterAura( "the_emerald_dreamcatcher", {
-        id = 224706,
-        duration = 5,
-        max_stack = 2,
-    } )
 
 
 -- Abilities

--- a/TheWarWithin/DruidFeral.lua
+++ b/TheWarWithin/DruidFeral.lua
@@ -1009,6 +1009,89 @@ spec:RegisterAuras( {
     }
 } )
 
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229310, 229308, 229306, 229307, 229305 },
+        auras = {
+            winning_streak = {
+                id = 1217236,
+                duration = 10,
+                max_stack = 10
+            },
+            big_winner = {
+                id = 1217245,
+                duration = 6,
+                max_stack = 1
+            }
+        }
+    },
+    -- Dragonflight
+    tier31 = {
+        items = { 207252, 207253, 207254, 207255, 207257, 217193, 217195, 217191, 217192, 217194 },
+        auras = {
+            smoldering_frenzy = {
+                id = 422751,
+                duration = 8,
+                max_stack = 1
+            },
+            burning_frenzy = {
+                id = 422779,
+                duration = 10,
+                max_stack = 1
+            }
+        }
+    },
+    tier30 = {
+        items = { 202518, 202516, 202515, 202514, 202513 },
+        auras = {
+            shadows_of_the_predator = {
+                id = 408340,
+                duration = 20,
+                max_stack = 12
+            },
+            predator_revealed = {
+                id = 408468,
+                duration = 6,
+                tick_time = 1.5,
+                max_stack = 1
+            }
+        }
+    },
+    tier29 = {
+        items = { 200354, 200356, 200351, 200353, 200355 },
+        auras = {
+            sharpened_claws = {
+                id = 394465,
+                duration = 4,
+                max_stack = 1
+            }
+        }
+    },
+    -- Legacy
+    tier21 = {
+        items = { 152127, 152129, 152125, 152124, 152126, 152128 },
+        auras = {
+            apex_predator = {
+                id = 252752,
+                duration = 25
+            }
+        }
+    },
+    tier20 = { items = { 147136, 147138, 147134, 147133, 147135, 147137 } },
+    tier19 = { items = { 138330, 138336, 138366, 138324, 138327, 138333 } },
+    class = { items = { 139726, 139728, 139723, 139730, 139725, 139729, 139727, 139724 } },
+    ailuro_pouncers = { items = { 137024 } },
+    behemoth_headdress = { items = { 151801 } },
+    chatoyant_signet = { items = { 137040 } },
+    ekowraith_creator_of_worlds = { items = { 137015 } },
+    fiery_red_maimers = { items = { 144354 } },
+    luffa_wrappings = { items = { 137056 } },
+    soul_of_the_archdruid = { items = { 151636 } },
+    the_wildshapers_clutch = { items = { 137094 } }
+} )
+
+
 -- Snapshotting
 local tf_spells = { rake = true, rip = true, thrash_cat = true, lunar_inspiration = true, primal_wrath = true }
 local bt_spells = { rip = true, primal_wrath = true }
@@ -1484,86 +1567,6 @@ spec:RegisterStateExpr( "effective_stealth", function ()
     return buff.prowl.up or buff.incarnation.up or buff.shadowmeld.up or buff.sudden_ambush.up
 end )
 
--- The War Within
-spec:RegisterGear( "tww2", 229310, 229308, 229306, 229307, 229305  )
-spec:RegisterAuras( {
-    -- https://www.wowhead.com/ptr-2/spell=1217236/winning-streak
-    -- Your spells and abilities have a chance to activate a Winning Streak! increasing the damage of your Ferocious Bite, Rip, and Primal Wrath by 3% stacking up to 10 times. Ferocious Bite, Rip, and Primal Wrath have a 15% chance to remove Winning Streak!
-    winning_streak = {
-    id = 1217236,
-    duration = 10,
-    max_stack = 10,
-    },
-
-    big_winner = {
-    -- https://www.wowhead.com/ptr-2/spell=1217245/big-winner
-    id = 1217245,
-    duration = 6,
-    max_stack = 1,
-    },
-
-} )
-
--- Legendaries.  Ugh.
-spec:RegisterGear( "ailuro_pouncers", 137024 )
-spec:RegisterGear( "behemoth_headdress", 151801 )
-spec:RegisterGear( "chatoyant_signet", 137040 )
-spec:RegisterGear( "ekowraith_creator_of_worlds", 137015 )
-spec:RegisterGear( "fiery_red_maimers", 144354 )
-spec:RegisterGear( "luffa_wrappings", 137056 )
-spec:RegisterGear( "soul_of_the_archdruid", 151636 )
-spec:RegisterGear( "the_wildshapers_clutch", 137094 )
-
--- Dragonflight
-spec:RegisterGear( "tier29", 200354, 200356, 200351, 200353, 200355 )
-spec:RegisterAura( "sharpened_claws", {
-    id = 394465,
-    duration = 4,
-    max_stack = 1
-} )
-
--- Tier 30
-spec:RegisterGear( "tier30", 202518, 202516, 202515, 202514, 202513 )
--- 2 pieces (Feral) : Your auto-attacks have a 25% chance to grant Shadows of the Predator, increasing your Agility by 1%. Each application past 5 has an increasing chance to reset to 2 stacks.
-spec:RegisterAura( "shadows_of_the_predator", {
-    id = 408340,
-    duration = 20,
-    max_stack = 12
-} )
--- 4 pieces (Feral) : When a Shadows of the Predator application resets stacks, you gain 5% increased Agility and you generate 1 combo point every 1.5 secs for 6 sec.
-spec:RegisterAura( "predator_revealed", {
-    id = 408468,
-    duration = 6,
-    tick_time = 1.5,
-    max_stack = 1
-} )
-
-spec:RegisterGear( "tier31", 207252, 207253, 207254, 207255, 207257, 217193, 217195, 217191, 217192, 217194 )
--- (2) Feral Frenzy grants Smoldering Frenzy, increasing all damage you deal by $422751s1% for $422751d.
--- (4) Feral Frenzy's cooldown is reduced by ${$s1/-1000} sec. During Smoldering Frenzy, enemies burn for $422751s6% of damage you deal as Fire over $422779d.
-spec:RegisterAuras( {
-    smoldering_frenzy = {
-        id = 422751,
-        duration = 8,
-        max_stack = 1
-    },
-    burning_frenzy = {
-        id = 422779,
-        duration = 10,
-        max_stack = 1
-    }
-} )
-
--- Legion Sets (for now).
-spec:RegisterGear( "tier21", 152127, 152129, 152125, 152124, 152126, 152128 )
-    spec:RegisterAura( "apex_predator", {
-        id = 252752,
-        duration = 25
-     } ) -- T21 Feral 4pc Bonus.
-
-spec:RegisterGear( "tier20", 147136, 147138, 147134, 147133, 147135, 147137 )
-spec:RegisterGear( "tier19", 138330, 138336, 138366, 138324, 138327, 138333 )
-spec:RegisterGear( "class", 139726, 139728, 139723, 139730, 139725, 139729, 139727, 139724 )
 
 local function calculate_damage( coefficient, masteryFlag, armorFlag, critChanceMult )
     local feralAura = 1

--- a/TheWarWithin/DruidGuardian.lua
+++ b/TheWarWithin/DruidGuardian.lua
@@ -171,7 +171,7 @@ spec:RegisterTalents( {
     gore                          = {  82126, 210706, 1 }, -- Thrash, Swipe, Moonfire, and Maul have a 15% chance to reset the cooldown on Mangle, and to cause it to generate an additional 4 Rage.
     gory_fur                      = {  82132, 200854, 1 }, -- Mangle has a 15% chance to reduce the Rage cost of your next Ironfur by 25%.
     guardian_of_elune             = {  82140, 155578, 1 }, -- Mangle increases the duration of your next Ironfur by 3 sec, or the healing of your next Frenzied Regeneration by 20%.
-    improved_survival_instincts   = {  82128, 328767, 1 }, -- Survival Instincts now has 2 charges. 
+    improved_survival_instincts   = {  82128, 328767, 1 }, -- Survival Instincts now has 2 charges.
     incarnation                   = {  82136, 102558, 1 }, -- An improved Bear Form that grants the benefits of Berserk, causes Mangle to hit up to 3 targets, and increases maximum health by 30%. Lasts 30 sec. You may freely shapeshift in and out of this improved Bear Form for its duration.
     incarnation_guardian_of_ursoc = {  82136, 102558, 1 }, -- An improved Bear Form that grants the benefits of Berserk, causes Mangle to hit up to 3 targets, and increases maximum health by 30%. Lasts 30 sec. You may freely shapeshift in and out of this improved Bear Form for its duration.
     infected_wounds               = {  82162, 345208, 1 }, -- Mangle and Maul cause an Infected Wound in the target, reducing their movement speed by 50% for 12 sec.
@@ -205,7 +205,7 @@ spec:RegisterTalents( {
     aggravate_wounds              = {  94616, 441829, 1 }, -- Every Maul, Raze, Mangle, Thrash, or Swipe you cast extends the duration of your Dreadful Wounds by 0.6 sec, up to 8 additional sec.
     bestial_strength              = {  94611, 441841, 1 }, -- Maul and Raze damage increased by 20%.
     claw_rampage                  = {  94613, 441835, 1 }, -- During Berserk, Mangle, Swipe, and Thrash have a 25% chance to make your next Maul become Ravage.
-    dreadful_wound                = {  94620, 441809, 1 }, -- Ravage also inflicts a Bleed that causes 23,428 damage over 6.0 sec and saps its victims' strength, reducing damage they deal to you by 10%. Dreadful Wound is not affected by Circle of Life and Death. 
+    dreadful_wound                = {  94620, 441809, 1 }, -- Ravage also inflicts a Bleed that causes 23,428 damage over 6.0 sec and saps its victims' strength, reducing damage they deal to you by 10%. Dreadful Wound is not affected by Circle of Life and Death.
     empowered_shapeshifting       = {  94612, 441689, 1 }, -- Frenzied Regeneration can be cast in Cat Form for 40 Energy. Bear Form reduces magic damage you take by 4%. Shred and Swipe damage increased by 6%. Mangle damage increased by 15%.
     fount_of_strength             = {  94618, 441675, 1 }, -- Your maximum Energy and Rage are increased by 20. Frenzied Regeneration also increases your maximum health by 10%.
     killing_strikes               = {  94619, 441824, 1 }, -- Ravage increases your Agility by 8% and the armor granted by Ironfur by 20% for 8 sec. Your first Mangle after entering combat makes your next Maul become Ravage.
@@ -215,7 +215,7 @@ spec:RegisterTalents( {
     strike_for_the_heart          = {  94614, 441845, 1 }, -- Shred, Swipe, and Mangle's critical strike chance and critical strike damage are increased by 15%. Mangle heals you for 1% of maximum health.
     tear_down_the_mighty          = {  94614, 441846, 1 }, -- The cooldown of Pulverize is reduced by 10 sec.
     wildpower_surge               = {  94612, 441691, 1 }, -- Mangle grants Feline Potential. When you have 6 stacks, the next time you transform into Cat Form, gain 5 combo points and your next Ferocious Bite or Rip deals 225% increased damage for its full duration.
-    wildshape_mastery             = {  94610, 441678, 1 }, -- Ironfur and Frenzied Regeneration persist in Cat Form. When transforming from Bear to Cat Form, you retain 80% of your Bear Form armor and health for 6 sec. For 6 sec after entering Bear Form, you heal for 10% of damage taken over 8 sec. 
+    wildshape_mastery             = {  94610, 441678, 1 }, -- Ironfur and Frenzied Regeneration persist in Cat Form. When transforming from Bear to Cat Form, you retain 80% of your Bear Form armor and health for 6 sec. For 6 sec after entering Bear Form, you heal for 10% of damage taken over 8 sec.
 
     -- Elune's Chosen
     arcane_affinity               = {  94586, 429540, 1 }, -- All Arcane damage from your spells and abilities is increased by 3%.
@@ -226,7 +226,7 @@ spec:RegisterTalents( {
     lunar_amplification           = {  94596, 429529, 1 }, -- Each non-Arcane damaging ability you use increases the damage of your next Arcane damaging ability by 3%, stacking up to 3 times.
     lunar_calling                 = {  94590, 429523, 1 }, -- Thrash now deals Arcane damage and its damage is increased by 12%.
     lunar_insight                 = {  94588, 429530, 1 }, -- Moonfire deals 8% additional damage.
-    lunation                      = {  94586, 429539, 1 }, -- Your Arcane abilities reduce the cooldown of Lunar Beam by 3.0 sec. 
+    lunation                      = {  94586, 429539, 1 }, -- Your Arcane abilities reduce the cooldown of Lunar Beam by 3.0 sec.
     moon_guardian                 = {  94598, 429520, 1 }, -- Free automatic Moonfires from Galactic Guardian generate 5 Rage.
     moondust                      = {  94597, 429538, 1 }, -- Enemies affected by Moonfire are slowed by 20%.
     stellar_command               = {  94590, 429668, 1 }, -- Increases the damage of Lunar Beam by 30% and Fury of Elune by 15%.
@@ -904,6 +904,99 @@ spec:RegisterAuras( {
     }
 } )
 
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229310, 229308, 229306, 229307, 229305 },
+        auras = {
+            luck_of_the_draw = {
+                id = 1218553,
+                duration = 8,
+                max_stack = 1
+            },
+            stacked_deck = {
+                id = 1218537,
+                duration = 20,
+                max_stack = 10
+            }
+        }
+    },
+    -- Dragonflight
+    tier31 = {
+        items = { 207252, 207253, 207254, 207255, 207257 },
+        auras = {
+            dream_thorns = {
+                id = 425407,
+                duration = 45,
+                max_stack = 1,
+                copy = "blazing_thorns"
+            }
+        }
+    },
+    tier30 = {
+        items = { 202518, 202516, 202515, 202514, 202513, 217193, 217195, 217191, 217192, 217194 },
+        auras = {
+            furious_regeneration = {
+                id = 408504,
+                duration = 8,
+                max_stack = 1
+            },
+            indomitable_guardian = {
+                id = 408522,
+                duration = 12,
+                max_stack = 5
+            }
+        }
+    },
+    tier29 = {
+        items = { 200351, 200353, 200354, 200355, 200356 },
+        auras = {
+            bloody_healing = {
+                id = 394504,
+                duration = 6,
+                max_stack = 1
+            }
+        }
+    },
+    -- Legacy
+    tier21 = { items = { 152127, 152129, 152125, 152124, 152126, 152128 } },
+    tier20 = { items = { 147136, 147138, 147134, 147133, 147135, 147137 } },
+    tier19 = { items = { 138330, 138336, 138366, 138324, 138327, 138333 } },
+    class = { items = { 139726, 139728, 139723, 139730, 139725, 139729, 139727, 139724 } },
+    ailuro_pouncers = { items = { 137024 } },
+    behemoth_headdress = { items = { 151801 } },
+    chatoyant_signet = { items = { 137040 } },
+    dual_determination = { items = { 137041 } },
+    ekowraith_creator_of_worlds = { items = { 137015 } },
+    elizes_everlasting_encasement = { items = { 137067 } },
+    fiery_red_maimers = { items = { 144354 } },
+    lady_and_the_child = { items = { 144295 } },
+    luffa_wrappings = { items = { 137056 } },
+    oakhearts_puny_quods = {
+        items = { 144432 },
+        auras = {
+            oakhearts_puny_quods = {
+                id = 236479,
+                duration = 3,
+                max_stack = 1
+            }
+        }
+    },
+    skysecs_hold = {
+        items = { 137025 },
+        auras = {
+            skysecs_hold = {
+                id = 208218,
+                duration = 3,
+                max_stack = 1
+            }
+        }
+    },
+    the_wildshapers_clutch = { items = { 137094 } },
+    soul_of_the_archdruid = { items = { 151636 } }
+} )
+
+
 Hekili:EmbedAdaptiveSwarm( spec )
 
 -- Function to remove any form currently active.
@@ -947,96 +1040,6 @@ end )
 spec:RegisterStateExpr( "ironfur_damage_threshold", function ()
     return ( settings.ironfur_damage_threshold or 0 ) / 100 * health.max * ( solo and 0.5 or 1 )
 end )
-
--- The War Within
-spec:RegisterGear( "tww2", 229310, 229308, 229306, 229307, 229305  )
-spec:RegisterAuras( {
-    -- 2-set
-    -- https://www.wowhead.com/ptr-2/spell=1218553/luck-of-the-draw
-    -- Each time you take damage you have a chance to activate Luck of the Draw! causing you to cast Survival Instincts for 4.0 sec. Your damage done is increased by 15% for 8 sec after Luck of the Draw! activates.
-    luck_of_the_draw = {
-    id = 1218553,
-    duration = 8,
-    max_stack = 1,
-    },
-    stacked_deck = {
-    -- https://www.wowhead.com/ptr-2/spell=1218537/stacked-deck
-    --After you gain Luck of the Draw! your next 10 Druid abilities cast another Druid ability at 125% effectiveness.
-    id = 1218537,
-    duration = 20,
-    max_stack = 10,
-    },
-
-    } )
-
--- Tier 29
-spec:RegisterGear( "tier29", 200351, 200353, 200354, 200355, 200356 )
-spec:RegisterAura( "bloody_healing", {
-    id = 394504,
-    duration = 6,
-    max_stack = 1,
-} )
-
--- Tier 30
-spec:RegisterGear( "tier30", 202518, 202516, 202515, 202514, 202513, 217193, 217195, 217191, 217192, 217194 )
--- 2 pieces (Guardian) : When you take damage, Mangle and Thrash damage and Rage generation are increased by 15% for 8 sec and you heal for 6% of damage taken over 8 sec.
-spec:RegisterAura( "furious_regeneration", {
-    id = 408504,
-    duration = 8,
-    max_stack = 1
-} )
--- 4 pieces (Guardian) : Raze Raze Maul damage increased by 20% and casting Ironfur or Raze Raze Maul increases your maximum health by 3% for 12 sec, stacking 5 times.
-spec:RegisterAura( "indomitable_guardian", {
-    id = 408522,
-    duration = 12,
-    max_stack = 5
-} )
-
-spec:RegisterGear( "tier31", 207252, 207253, 207254, 207255, 207257 )
--- (2) Rage you spend during Rage of the Sleeper fuel the growth of Dream Thorns, which wreath you in their protection after Rage of the Sleeper expires, absorbing $425407s2% of damage dealt to you while the thorns remain, up to ${$s2/100*$AP} per $s1 Rage spent.
--- (4) Each $s1 Rage you spend while Rage of the Sleeper is active extends its duration by ${$s4/1000}.1 sec, up to ${$s3/1000}.1. Your Dream Thorns become Blazing Thorns, causing $s2% of damage absorbed to be reflected at the attacker.
-spec:RegisterAuras( {
-    dream_thorns = {
-        id = 425407,
-        duration = 45,
-        max_stack = 1,
-        copy = "blazing_thorns" -- ???
-    },
-
-})
-
--- Gear.
-spec:RegisterGear( "class", 139726, 139728, 139723, 139730, 139725, 139729, 139727, 139724 )
-spec:RegisterGear( "tier19", 138330, 138336, 138366, 138324, 138327, 138333 )
-spec:RegisterGear( "tier20", 147136, 147138, 147134, 147133, 147135, 147137 ) -- Bonuses NYI
-spec:RegisterGear( "tier21", 152127, 152129, 152125, 152124, 152126, 152128 )
-
-spec:RegisterGear( "ailuro_pouncers", 137024 )
-spec:RegisterGear( "behemoth_headdress", 151801 )
-spec:RegisterGear( "chatoyant_signet", 137040 )
-spec:RegisterGear( "dual_determination", 137041 )
-spec:RegisterGear( "ekowraith_creator_of_worlds", 137015 )
-spec:RegisterGear( "elizes_everlasting_encasement", 137067 )
-spec:RegisterGear( "fiery_red_maimers", 144354 )
-spec:RegisterGear( "lady_and_the_child", 144295 )
-spec:RegisterGear( "luffa_wrappings", 137056 )
-spec:RegisterGear( "oakhearts_puny_quods", 144432 )
-    spec:RegisterAura( "oakhearts_puny_quods", {
-        id = 236479,
-        duration = 3,
-        max_stack = 1,
-    } )
-spec:RegisterGear( "skysecs_hold", 137025 )
-    spec:RegisterAura( "skysecs_hold", {
-        id = 208218,
-        duration = 3,
-        max_stack = 1,
-    } )
-
-spec:RegisterGear( "the_wildshapers_clutch", 137094 )
-
-spec:RegisterGear( "soul_of_the_archdruid", 151636 )
-
 
 spec:RegisterStateExpr( "lunar_eclipse", function ()
     return eclipse.wrath_counter
@@ -1621,7 +1624,7 @@ spec:RegisterAbilities( {
         end,
 
         handler = function ()
-            
+
             -- Regular talents
             if talent.fluid_form.enabled and buff.bear_form.down then shift( "bear_form" ) end
             if talent.infected_wounds.enabled then applyDebuff( "target", "infected_wounds" ) end
@@ -1705,7 +1708,7 @@ spec:RegisterAbilities( {
             -- Ravage specific interactions
             if talent.ravage.enabled then spec.abilities.ravage_maul.handler() end
 
-            -- Legacy / PvP         
+            -- Legacy / PvP
             if conduit.savage_combatant.enabled then removeBuff( "savage_combatant" ) end
             if set_bonus.tier30_4pc > 0 then addStack( "indomitable_guardian" ) end
             if pvptalent.sharpened_claws.enabled or essence.conflict_and_strife.major then applyBuff( "sharpened_claws" ) end

--- a/TheWarWithin/DruidRestoration.lua
+++ b/TheWarWithin/DruidRestoration.lua
@@ -462,6 +462,20 @@ spec:RegisterPet( "treants",
 
 spec:RegisterTotem( "treants", 54983 )
 
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229310, 229308, 229306, 229307, 229305 }
+    },
+    -- Dragonflight
+    tier31 = {
+        items = { 207252, 207253, 207254, 207255, 207257, 217193, 217195, 217191, 217192, 217194 }
+    },
+    tier30 = {
+        items = { 202518, 202516, 202515, 202514, 202513 }
+    },
+} )
+
 spec:RegisterStateFunction( "break_stealth", function ()
     removeBuff( "shadowmeld" )
     if buff.prowl.up then
@@ -521,17 +535,6 @@ spec:RegisterHook( "runHandler", function( ability )
     end
 end )
 
--- The War Within
-spec:RegisterGear( "tww2", 229310, 229308, 229306, 229307, 229305  )
-
--- Tier 30
-spec:RegisterGear( "tier30", 202518, 202516, 202515, 202514, 202513 )
--- 2 pieces (Restoration) : Rejuvenation and Lifebloom healing increased by 12%. Regrowth healing over time increased by 50%.
--- 4 pieces (Restoration) : Flourish increases the rate of your heal over time effects by 30% for an additional 16 sec after it ends. Verdant Infusion causes your Swiftmend target to gain 15% increased healing from you for 6 sec.
-
-spec:RegisterGear( "tier31", 207252, 207253, 207254, 207255, 207257, 217193, 217195, 217191, 217192, 217194 )
--- (2) You and your Grove Guardian's Nourishes now heal $s1 additional allies within $423618r yds at $s2% effectiveness.
--- (4) Consuming Clearcasting now causes your Regrowth to also cast Nourish onto a nearby injured ally at $s1% effectiveness, preferring those with your heal over time effects.
 
 local TranquilityTickHandler = setfenv( function()
 

--- a/TheWarWithin/EvokerAugmentation.lua
+++ b/TheWarWithin/EvokerAugmentation.lua
@@ -624,6 +624,38 @@ spec:RegisterAuras( {
     },
 } )
 
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229283, 229281, 229279, 229280, 229278 }
+    },
+    -- Dragonflight
+    tier31 = {
+        items = { 207225, 207226, 207227, 207228, 207230, 217178, 217180, 217176, 217177, 217179 },
+        auras = {
+            t31_2pc_proc = {
+                duration = 3600,
+                max_stack = 1
+            },
+            t31_2pc_stacks = {
+                duration = 3600,
+                max_stack = 3
+            },
+            trembling_earth = {
+                id = 424368,
+                duration = 3600,
+                max_stack = 5
+            }
+        }
+    },
+    tier30 = {
+        items = { 202491, 202489, 202488, 202487, 202486 }
+    },
+    tier29 = {
+        items = { 200381, 200383, 200378, 200380, 200382 }
+    }
+} )
+
 local lastEssenceTick = 0
 
 do
@@ -678,30 +710,6 @@ spec:RegisterHook( "runHandler_startCombat", function( action )
     if talent.onslaught.enabled then addStack( "burnout" ) end
     if talent.unrelenting_siege.enabled then applyBuff( "unrelenting_siege" ) end
 end )
-
--- TheWarWithin
-spec:RegisterGear( "tww2", 229283, 229281, 229279, 229280, 229278 )
-
--- Dragonflight
-spec:RegisterGear( "tier29", 200381, 200383, 200378, 200380, 200382 )
-spec:RegisterGear( "tier30", 202491, 202489, 202488, 202487, 202486 )
-spec:RegisterGear( "tier31", 207225, 207226, 207227, 207228, 207230, 217178, 217180, 217176, 217177, 217179 )
-spec:RegisterAuras( {
-    t31_2pc_proc = {
-        duration = 3600,
-        max_stack = 1
-    },
-    t31_2pc_stacks = {
-        duration = 3600,
-        max_stack = 3
-    },
-    trembling_earth = {
-        id = 424368,
-        duration = 3600,
-        max_stack = 5
-    }
-} )
-
 
 spec:RegisterHook( "reset_precast", function()
     max_empower = talent.font_of_magic.enabled and 4 or 3

--- a/TheWarWithin/EvokerDevastation.lua
+++ b/TheWarWithin/EvokerDevastation.lua
@@ -832,7 +832,7 @@ spec:RegisterGear({
             }
         }
     }
-})
+} )
 
 local EmeraldTranceTick = setfenv( function()
     addStack( "emerald_trance" )

--- a/TheWarWithin/EvokerPreservation.lua
+++ b/TheWarWithin/EvokerPreservation.lua
@@ -396,23 +396,32 @@ do
     end )
 end
 
--- TheWarWithin
-spec:RegisterGear( "tww2", 229283, 229281, 229279, 229280, 229278 )
-
--- Dragonflight
-spec:RegisterGear( "tier30", 202491, 202489, 202488, 202487, 202486 )
-spec:RegisterAura( "spiritbloom", {
-    id = 409895,
-    duration = 8,
-    tick_time = 2,
-    max_stack = 1
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229283, 229281, 229279, 229280, 229278 }
+    },
+    -- Dragonflight
+    tier31 = {
+        items = { 207225, 207226, 207227, 207228, 207230 }
+    },
+    tier30 = {
+        items = { 202491, 202489, 202488, 202487, 202486 },
+        auras = {
+            spiritbloom = {
+                id = 409895,
+                duration = 8,
+                tick_time = 2,
+                max_stack = 1
+            },
+            essence_rush = {
+                id = 409899,
+                duration = 3,
+                max_stack = 1
+            }
+        }
+    }
 } )
-spec:RegisterAura( "essence_rush", {
-    id = 409899,
-    duration = 3,
-    max_stack = 1
-} )
-spec:RegisterGear( "tier31", 207225, 207226, 207227, 207228, 207230 )
 
 spec:RegisterStateExpr( "empowered_spell_count", function()
     return actual_empowered_spell_count


### PR DESCRIPTION
Convert RegisterGear to the new format ahead of the 11.2 branch, making it easy to insert the new tier sets. Also some automatic white space cleaning here and there I guess.