### PR TITLE
11.2 Prep - Convert register gear to new version - Hunter, Mage, Monk

### DIFF
--- a/TheWarWithin/HunterBeastMastery.lua
+++ b/TheWarWithin/HunterBeastMastery.lua
@@ -1228,37 +1228,40 @@ spec:RegisterPets({
     }
 } )
 
---- The War Within
-spec:RegisterGear( "tww1", 212018, 212019, 212020, 212021, 212023 )
-spec:RegisterGear( "tww2", 229271, 229269, 229274, 229272, 229270 )
-spec:RegisterAuras( {
-   -- 2-set
-    jackpot = {
-
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229271, 229269, 229274, 229272, 229270 },
+        auras = {
+            -- 2-set
+            jackpot = {
+                -- TODO: Add ID and aura properties
+            },
+            -- Possible TODO: pet attacks reduce Bestial Wrath CD?
+            potent_mutagen = {
+                id = 1218003,
+                duration = 8,
+                max_stack = 1
+            }
+        }
     },
-    -- Possible TODO: pet attacks reduce bestial wrath cd?
-    potent_mutagen = {
-        id = 1218003,
-        duration = 8,
-        max_stack = 1
+    tww1 = {
+        items = { 212018, 212019, 212020, 212021, 212023 }
     },
-
-} )
-
--- Legacy
---- Shadowlands
-local ExpireNesingwarysTrappingApparatus = setfenv( function()
-    focus.regen = focus.regen * 0.5
-    forecastResources( "focus" )
-end, state )
-
---- Dragonflight
-spec:RegisterGear( "tier31", 207216, 207217, 207218, 207219, 207221, 217183, 217185, 217181, 217182, 217184 )
-spec:RegisterGear( "tier29", 200390, 200392, 200387, 200389, 200391 )
-spec:RegisterAura( "lethal_command", {
-    id = 394298,
-    duration = 15,
-    max_stack = 1
+    -- Dragonflight
+    tier31 = {
+        items = { 207216, 207217, 207218, 207219, 207221, 217183, 217185, 217181, 217182, 217184 }
+    },
+    tier29 = {
+        items = { 200390, 200392, 200387, 200389, 200391 },
+        auras = {
+            lethal_command = {
+                id = 394298,
+                duration = 15,
+                max_stack = 1
+            }
+        }
+    },
 } )
 
 spec:RegisterStateExpr( "barbed_shot_grace_period", function ()

--- a/TheWarWithin/HunterMarksmanship.lua
+++ b/TheWarWithin/HunterMarksmanship.lua
@@ -821,46 +821,52 @@ spec:RegisterStateTable( "tar_trap", setmetatable( {}, {
     end
 } ) )
 
-
-
-spec:RegisterGear( "tww1", 212018, 212019, 212020, 212021, 212023 )
-spec:RegisterGear( "tww2", 229271, 229269, 229274, 229272, 229270 )
-spec:RegisterAuras( {
-    -- 2-set
-    -- https://www.wowhead.com/spell=1218033
-    -- Jackpot! Auto shot damage increased by 200% and the time between auto shots is reduced by 0.5 sec.
-    jackpot = {
-        id = 1218033,
-        duration = 10,
-        max_stack = 1,
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229271, 229269, 229274, 229272, 229270 },
+        auras = {
+            -- 2-set
+            jackpot = {
+                id = 1218033,
+                duration = 10,
+                max_stack = 1
+            }
+        }
     },
-
-} )
-
--- Dragonflight
-spec:RegisterGear( "tier29", 200390, 200392, 200387, 200389, 200391 )
-spec:RegisterAuras( {
-    -- 2pc
-    find_the_mark = {
-        id = 394366,
-        duration = 15,
-        max_stack = 1
+    tww1 = {
+        items = { 212018, 212019, 212020, 212021, 212023 }
     },
-    hit_the_mark = {
-        id = 394371,
-        duration = 6,
-        max_stack = 1
+    -- Dragonflight
+    tier31 = {
+        items = { 207216, 207217, 207218, 207219, 207221, 217183, 217185, 217181, 217182, 217184 }
     },
-    -- 4pc
-    focusing_aim = {
-        id = 394384,
-        duration = 15,
-        max_stack = 1
+    tier30 = {
+        items = { 202482, 202480, 202479, 202478, 202477 }
+    },
+    tier29 = {
+        items = { 200390, 200392, 200387, 200389, 200391 },
+        auras = {
+            -- 2pc
+            find_the_mark = {
+                id = 394366,
+                duration = 15,
+                max_stack = 1
+            },
+            hit_the_mark = {
+                id = 394371,
+                duration = 6,
+                max_stack = 1
+            },
+            -- 4pc
+            focusing_aim = {
+                id = 394384,
+                duration = 15,
+                max_stack = 1
+            }
+        }
     }
 } )
-spec:RegisterGear( "tier30", 202482, 202480, 202479, 202478, 202477 )
-spec:RegisterGear( "tier31", 207216, 207217, 207218, 207219, 207221, 217183, 217185, 217181, 217182, 217184 )
-
 
 local SpottersMarkConsumer = setfenv( function ( max_targets )
 

--- a/TheWarWithin/HunterSurvival.lua
+++ b/TheWarWithin/HunterSurvival.lua
@@ -694,51 +694,60 @@ spec:RegisterPets({
     }
 } )
 
--- The War Within
-spec:RegisterGear( "tww2", 229271, 229269, 229274, 229272, 229270 )
-spec:RegisterAuras( {
-    -- 2-set
-    -- https://www.wowhead.com/spell=1216874
-    -- Winning Streak! Wildfire Bomb damage increased by 6%.
-    winning_streak = {
-        id = 1216874,
-        duration = 30,
-        max_stack = 6,
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229271, 229269, 229274, 229272, 229270 },
+        auras = {
+            -- 2-set
+            winning_streak = {
+                id = 1216874,
+                duration = 30,
+                max_stack = 6
+            },
+            -- 4-set
+            strike_it_rich = {
+                id = 1216879,
+                duration = 10,
+                max_stack = 1
+            }
+        }
     },
-    -- 4-set
-    -- https://www.wowhead.com/spell=1216879
-    strike_it_rich = {
-        id = 1216879,
-        duration = 10,
-        max_stack = 1,
+    -- Dragonflight
+    tier31 = {
+        items = { 207216, 207217, 207218, 207219, 207221 },
+        auras = {
+            fury_strikes = {
+                id = 425830,
+                duration = 12,
+                max_stack = 1
+            },
+            contained_explosion = {
+                id = 426344,
+                duration = 12,
+                max_stack = 1
+            }
+        }
     },
-
-} )
-
--- Dragonflight
-spec:RegisterGear( "tier29", 200390, 200392, 200387, 200389, 200391, 217183, 217185, 217181, 217182, 217184 )
-spec:RegisterAura( "bestial_barrage", {
-    id = 394388,
-    duration = 15,
-    max_stack = 1
-} )
-spec:RegisterGear( "tier30", 202482, 202480, 202479, 202478, 202477 )
-spec:RegisterAura( "shredded_armor", {
-    id = 410167,
-    duration = 8,
-    max_stack = 1
-} )
-spec:RegisterGear( "tier31", 207216, 207217, 207218, 207219, 207221 )
-spec:RegisterAuras( {
-    fury_strikes = {
-        id = 425830,
-        duration = 12,
-        max_stack = 1
+    tier30 = {
+        items = { 202482, 202480, 202479, 202478, 202477 },
+        auras = {
+            shredded_armor = {
+                id = 410167,
+                duration = 8,
+                max_stack = 1
+            }
+        }
     },
-    contained_explosion = {
-        id = 426344,
-        duration = 12,
-        max_stack = 1
+    tier29 = {
+        items = { 200390, 200392, 200387, 200389, 200391, 217183, 217185, 217181, 217182, 217184 },
+        auras = {
+            bestial_barrage = {
+                id = 394388,
+                duration = 15,
+                max_stack = 1
+            }
+        }
     }
 } )
 

--- a/TheWarWithin/MageArcane.lua
+++ b/TheWarWithin/MageArcane.lua
@@ -913,63 +913,60 @@ do
     end
 end
 
-
--- The War Within
-spec:RegisterGear( "tww2", 229346, 229344, 229342, 229343, 229341 )
-spec:RegisterAuras( {
-   -- 2-set
-   clarity = {
-    id = 1216178,
-    duration = 12,
-    max_stack = 1
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229346, 229344, 229342, 229343, 229341 },
+        auras = {
+            clarity = {
+                id = 1216178,
+                duration = 12,
+                max_stack = 1
+            }
+        }
     },
-} )
-
-
--- Dragonflight
-spec:RegisterGear( "tier31", 207288, 207289, 207290, 207291, 207293, 217232, 217234, 217235, 217231, 217233 )
-spec:RegisterAuras( {
-    forethought = {
-        id = 424293,
-        duration = 20,
-        max_stack = 5
+    -- Dragonflight
+    tier31 = {
+        items = { 207288, 207289, 207290, 207291, 207293, 217232, 217234, 217235, 217231, 217233 },
+        auras = {
+            forethought = {
+                id = 424293,
+                duration = 20,
+                max_stack = 5
+            },
+            arcane_battery = {
+                id = 424334,
+                duration = 30,
+                max_stack = 3
+            },
+            arcane_artillery = {
+                id = 424331,
+                duration = 30,
+                max_stack = 1
+            }
+        }
     },
-    arcane_battery = {
-        id = 424334,
-        duration = 30,
-        max_stack = 3
+    tier30 = {
+        items = { 202554, 202552, 202551, 202550, 202549 },
+        auras = {
+            arcane_overload = {
+                id = 409022,
+                duration = 18,
+                max_stack = 25
+            }
+        }
     },
-    arcane_artillery = {
-        id = 424331,
-        duration = 30,
-        max_stack = 1
+    tier29 = {
+        items = { 200318, 200320, 200315, 200317, 200319 },
+        auras = {
+            bursting_energy = {
+                id = 395006,
+                duration = 12,
+                max_stack = 4
+            }
+        }
     }
 } )
-
--- Tier 30
-spec:RegisterGear( "tier30", 202554, 202552, 202551, 202550, 202549 )
-spec:RegisterAura( "arcane_overload", {
-    id = 409022,
-    duration = 18,
-    max_stack = 25
-} )
-
-local TriggerArcaneOverloadT30 = setfenv( function()
-    applyBuff( "arcane_overload" )
-end, state )
-
--- Hero Talents
-local TriggerArcaneSoul = setfenv( function()
-    applyBuff( "arcane_soul" )
-end, state )
-
-spec:RegisterGear( "tier29", 200318, 200320, 200315, 200317, 200319 )
-spec:RegisterAura( "bursting_energy", {
-    id = 395006,
-    duration = 12,
-    max_stack = 4
-} )
-
 
 spec:RegisterHook( "spend", function( amt, resource )
     if resource == "arcane_charges" then

--- a/TheWarWithin/MageFire.lua
+++ b/TheWarWithin/MageFire.lua
@@ -894,53 +894,54 @@ spec:RegisterStateTable( "improved_scorch", setmetatable( {}, {
     end, state )
 } ) )
 
-
--- The War Within
-spec:RegisterGear( "tww2", 229346, 229344, 229342, 229343, 229341 )
-spec:RegisterAuras( {
-   -- 2-set
-rollin_hot = {
-    id = 1219035,
-    duration = 15,
-    max_stack = 1
-},
-   --[[ 4-set
-    jackpot = {
-        -- When you hit Jackpot you gain 7% more dps for 12s. If you gain jackpot from combustion the duration is increased by 100%
-    }, ]]--
-
-} )
-
--- Dragonflight
-spec:RegisterGear( "tier31", 207288, 207289, 207290, 207291, 207293 )
-spec:RegisterAura( "searing_rage", {
-    id = 424285,
-    duration = 12,
-    max_stack = 5
-} )
-
-spec:RegisterGear( "tier30", 202554, 202552, 202551, 202550, 202549, 217232, 217234, 217235, 217231, 217233 )
-spec:RegisterAuras( {
-    charring_embers = {
-        id = 408665,
-        duration = 14,
-        max_stack = 1,
-        copy = 453122
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229346, 229344, 229342, 229343, 229341 },
+        auras = {
+            rollin_hot = {
+                id = 1219035,
+                duration = 15,
+                max_stack = 1
+            }
+        }
     },
-    calefaction = {
-        id = 408673,
-        duration = 60,
-        max_stack = 20
+    -- Dragonflight
+    tier31 = {
+        items = { 207288, 207289, 207290, 207291, 207293 },
+        auras = {
+            searing_rage = {
+                id = 424285,
+                duration = 12,
+                max_stack = 5
+            }
+        }
     },
-    flames_fury = {
-        id = 409964,
-        duration = 30,
-        max_stack = 2
+    tier30 = {
+        items = { 202554, 202552, 202551, 202550, 202549, 217232, 217234, 217235, 217231, 217233 },
+        auras = {
+            charring_embers = {
+                id = 408665,
+                duration = 14,
+                max_stack = 1,
+                copy = 453122
+            },
+            calefaction = {
+                id = 408673,
+                duration = 60,
+                max_stack = 20
+            },
+            flames_fury = {
+                id = 409964,
+                duration = 30,
+                max_stack = 2
+            }
+        }
+    },
+    tier29 = {
+        items = { 200318, 200320, 200315, 200317, 200319 }
     }
 } )
-
-
-spec:RegisterGear( "tier29", 200318, 200320, 200315, 200317, 200319 )
 
 local TriggerHyperthermia = setfenv( function()
 

--- a/TheWarWithin/MageFrost.lua
+++ b/TheWarWithin/MageFrost.lua
@@ -977,37 +977,39 @@ spec:RegisterStateTable( "incanters_flow", {
     end, state ),
 } )
 
-
 spec:RegisterStateExpr( "bf_flurry", function () return false end )
 spec:RegisterStateExpr( "comet_storm_remains", function () return buff.active_comet_storm.remains end )
 
--- The War Within
-spec:RegisterGear( "tww2", 229346, 229344, 229342, 229343, 229341 )
-spec:RegisterAuras( {
-   --[[ 2-set
-    jackpot = {
-        -- spells have a chance to proc a jackpot that generates a frostbolt valley hitting a primary target and spreading to surrounding mobs (until 8). Casting Icy Veins always procs it
-    },--]]
-   -- 4-set
-    extended_bankroll = {
-        id = 1216914,
-        duration = 30,
-        max_stack = 1
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229346, 229344, 229342, 229343, 229341 },
+        auras = {
+            extended_bankroll = {
+                id = 1216914,
+                duration = 30,
+                max_stack = 1
+            }
+        }
     },
-
+    -- Dragonflight
+    tier31 = {
+        items = { 207288, 207289, 207290, 207291, 207293, 217232, 217234, 217235, 217231, 217233 }
+    },
+    tier30 = {
+        items = { 202554, 202552, 202551, 202550, 202549 }
+    },
+    tier29 = {
+        items = { 200318, 200320, 200315, 200317, 200319 },
+        auras = {
+            touch_of_ice = {
+                id = 394994,
+                duration = 6,
+                max_stack = 1
+            }
+        }
+    }
 } )
-
--- Dragonflight
-
-spec:RegisterGear( "tier31", 207288, 207289, 207290, 207291, 207293, 217232, 217234, 217235, 217231, 217233 )
-spec:RegisterGear( "tier30", 202554, 202552, 202551, 202550, 202549 )
-spec:RegisterGear( "tier29", 200318, 200320, 200315, 200317, 200319 )
-spec:RegisterAura( "touch_of_ice", {
-    id = 394994,
-    duration = 6,
-    max_stack = 1
-} )
-
 
 local BrainFreeze = setfenv( function()
     if talent.perpetual_winter.enabled then gainCharges( "flurry", 1 ) else setCooldown( "flurry", 0 ) end

--- a/TheWarWithin/MonkBrewmaster.lua
+++ b/TheWarWithin/MonkBrewmaster.lua
@@ -770,6 +770,68 @@ spec:RegisterAuras( {
     }
 } )
 
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229301, 229299, 229298, 229297, 229296 },
+        auras = {
+            luck_of_the_draw = {
+                id = 1217990,
+                duration = 8,
+                max_stack = 1
+            },
+            opportunistic_strike = {
+                id = 1217999,
+                duration = 20,
+                max_stack = 2
+            }
+        }
+    },
+    -- Dragonflight
+    tier31 = {
+        items = { 207243, 207244, 207245, 207246, 207248, 217188, 217190, 217186, 217187, 217189 }
+    },
+    tier30 = {
+        items = { 202509, 202507, 202506, 202505, 202504 },
+        auras = {
+            leverage = {
+                id = 408503,
+                duration = 30,
+                max_stack = 5
+            }
+        }
+    },
+    tier29 = {
+        items = { 200363, 200365, 200360, 200362, 200364 },
+        auras = {
+            brewmasters_rhythm = {
+                id = 394797,
+                duration = 15,
+                max_stack = 4
+            }
+        }
+    },
+    -- Legacy
+    tier21 = { items = { 152145, 152147, 152143, 152142, 152144, 152146 } },
+    tier20 = { items = { 147154, 147156, 147152, 147151, 147153, 147155 } },
+    tier19 = { items = { 138325, 138328, 138331, 138334, 138337, 138367 } },
+    class =  { items = { 139731, 139732, 139733, 139734, 139735, 139736, 139737, 139738 } },
+    cenedril_reflector_of_hatred = { items = { 137019 } },
+    cinidaria_the_symbiote = { items = { 133976 } },
+    drinking_horn_cover = { items = { 137097 } },
+    firestone_walkers = { items = { 137027 } },
+    fundamental_observation = { items = { 137063 } },
+    gai_plins_soothing_sash = { items = { 137079 } },
+    hidden_masters_forbidden_touch = { items = { 137057 } },
+    jewel_of_the_lost_abbey = { items = { 137044 } },
+    katsuos_eclipse = { items = { 137029 } },
+    march_of_the_legion = { items = { 137220 } },
+    salsalabims_lost_tunic = { items = { 137016 } },
+    soul_of_the_grandmaster = { items = { 151643 } },
+    stormstouts_last_gasp = { items = { 151788 } },
+    the_emperors_capacitor = { items = { 144239 } },
+    the_wind_blows = { items = { 151811 } }
+} )
 
 spec:RegisterHook( "reset_postcast", function( x )
     for k, v in pairs( stagger ) do
@@ -777,63 +839,6 @@ spec:RegisterHook( "reset_postcast", function( x )
     end
     return x
 end )
-
--- The War Within
-spec:RegisterGear( "tww2", 229301, 229299, 229298, 229297, 229296 )
-spec:RegisterAuras( {
-    -- 2-set
-    -- https://www.wowhead.com/ptr-2/spell=1217990/luck-of-the-draw
-    -- Each time you take damage you have a chance to activate Luck of the Draw! causing you to cast Fortifying Brew for 6.0 sec. Your damage done is increased by 15% for 8 sec after Luck of the Draw! activates.
-    luck_of_the_draw = {
-        id = 1217990,
-        duration = 8,
-        max_stack = 1
-    },
-    -- tier_4_set_placeholder =https://www.wowhead.com/ptr-2/spell=1217999/opportunistic-strike
-    --[When you gain Luck of the Draw!, your next 2 casts of Blackout Kick deal 150% increased damage and incur a 2.0 sec reduced cooldown.]
-    opportunistic_strike = {
-        id = 1217999,
-        duration = 20,
-        max_stack = 2
-    },
-} )
-
-
--- Dragonflight
-spec:RegisterGear( "tier31", 207243, 207244, 207245, 207246, 207248, 217188, 217190, 217186, 217187, 217189 )
-spec:RegisterGear( "tier30", 202509, 202507, 202506, 202505, 202504 )
-spec:RegisterAura( "leverage", {
-    id = 408503,
-    duration = 30,
-    max_stack = 5
-} )
-spec:RegisterGear( "tier29", 200363, 200365, 200360, 200362, 200364 )
-spec:RegisterAura( "brewmasters_rhythm", {
-    id = 394797,
-    duration = 15,
-    max_stack = 4
-} )
-
--- Legacy
-spec:RegisterGear( "tier19", 138325, 138328, 138331, 138334, 138337, 138367 )
-spec:RegisterGear( "tier20", 147154, 147156, 147152, 147151, 147153, 147155 )
-spec:RegisterGear( "tier21", 152145, 152147, 152143, 152142, 152144, 152146 )
-spec:RegisterGear( "class", 139731, 139732, 139733, 139734, 139735, 139736, 139737, 139738 )
-spec:RegisterGear( "cenedril_reflector_of_hatred", 137019 )
-spec:RegisterGear( "cinidaria_the_symbiote", 133976 )
-spec:RegisterGear( "drinking_horn_cover", 137097 )
-spec:RegisterGear( "firestone_walkers", 137027 )
-spec:RegisterGear( "fundamental_observation", 137063 )
-spec:RegisterGear( "gai_plins_soothing_sash", 137079 )
-spec:RegisterGear( "hidden_masters_forbidden_touch", 137057 )
-spec:RegisterGear( "jewel_of_the_lost_abbey", 137044 )
-spec:RegisterGear( "katsuos_eclipse", 137029 )
-spec:RegisterGear( "march_of_the_legion", 137220 )
-spec:RegisterGear( "salsalabims_lost_tunic", 137016 )
-spec:RegisterGear( "soul_of_the_grandmaster", 151643 )
-spec:RegisterGear( "stormstouts_last_gasp", 151788 )
-spec:RegisterGear( "the_emperors_capacitor", 144239 )
-spec:RegisterGear( "the_wind_blows", 151811 )
 
 spec:RegisterHook( "spend", function( amount, resource )
     if equipped.the_emperors_capacitor and resource == "chi" then

--- a/TheWarWithin/MonkMistweaver.lua
+++ b/TheWarWithin/MonkMistweaver.lua
@@ -646,29 +646,36 @@ spec:RegisterAuras( {
     },
 } )
 
--- The War Within
-spec:RegisterGear( "tww2", 229301, 229299, 229298, 229297, 229296 )
-
--- Dragonflight
-spec:RegisterGear( "tier31", 207243, 207244, 207245, 207246, 207248, 217188, 217190, 217186, 217187, 217189 )
-spec:RegisterAuras( {
-    chi_harmony = {
-        id = 423439,
-        duration = 8,
-        max_stack = 1
-    }
-} )
-spec:RegisterGear( "tier30", 202509, 202507, 202506, 202505, 202504 )
-spec:RegisterAuras( {
-    soulfang_infusion = {
-        id = 410007,
-        duration = 3,
-        max_stack = 1
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229301, 229299, 229298, 229297, 229296 }
     },
-    soulfang_vitality = {
-        id = 410082,
-        duration = 6,
-        max_stack = 1
+    -- Dragonflight
+    tier31 = {
+        items = { 207243, 207244, 207245, 207246, 207248, 217188, 217190, 217186, 217187, 217189 },
+        auras = {
+            chi_harmony = {
+                id = 423439,
+                duration = 8,
+                max_stack = 1
+            }
+        }
+    },
+    tier30 = {
+        items = { 202509, 202507, 202506, 202505, 202504 },
+        auras = {
+            soulfang_infusion = {
+                id = 410007,
+                duration = 3,
+                max_stack = 1
+            },
+            soulfang_vitality = {
+                id = 410082,
+                duration = 6,
+                max_stack = 1
+            }
+        }
     }
 } )
 

--- a/TheWarWithin/MonkWindwalker.lua
+++ b/TheWarWithin/MonkWindwalker.lua
@@ -787,70 +787,75 @@ spec:RegisterAuras( {
     },
 } )
 
--- The War Within
-spec:RegisterGear( "tww2", 229301, 229299, 229298, 229297, 229296 )
-spec:RegisterAuras( {
-    -- 2-set
-    -- https://www.wowhead.com/ptr-2/spell=1216182/winning-streak // https://www.wowhead.com/ptr-2/spell=1215717/monk-windwalker-11-1-class-set-2pc
-    -- [Your spells and abilities have a chance to activate a Winning Streak! increasing the damage of your Rising Sun Kick and Spinning Crane Kick by 3% stacking up to 10 times. Rising Sun Kick and Spinning Crane Kick have a 15% chance to remove Winning Streak!] = {
-    winning_streak = {
-        id = 1216182,
-        duration = 3600,
-        max_stack = 10
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229301, 229299, 229298, 229297, 229296 },
+        auras = {
+            winning_streak = {
+                id = 1216182,
+                duration = 3600,
+                max_stack = 10
+            },
+            cashout = {
+                id = 1216498,
+                duration = 30,
+                max_stack = 10
+            }
+        }
     },
-    -- https://www.wowhead.com/ptr-2/spell=1216498/cashout // https://www.wowhead.com/ptr-2/spell=1215718/monk-windwalker-11-1-class-set-4pc
-    cashout = {
-        id = 1216498,
-        duration = 30,
-        max_stack = 10
+    -- Dragonflight
+    tier31 = {
+        items = { 207243, 207244, 207245, 207246, 207248 }
     },
-} )
-
--- Dragonflight
-spec:RegisterGear( "tier31", 207243, 207244, 207245, 207246, 207248 )
-spec:RegisterGear( "tier30", 202509, 202507, 202506, 202505, 202504 )
-spec:RegisterAura( "shadowflame_vulnerability", {
-    id = 411376,
-    duration = 15,
-    max_stack = 1
-} )
-spec:RegisterGear( "tier29", 200360, 200362, 200363, 200364, 200365, 217188, 217190, 217186, 217187, 217189 )
-spec:RegisterAuras( {
-    kicks_of_flowing_momentum = {
-        id = 394944,
-        duration = 30,
-        max_stack = 2,
+    tier30 = {
+        items = { 202509, 202507, 202506, 202505, 202504 },
+        auras = {
+            shadowflame_vulnerability = {
+                id = 411376,
+                duration = 15,
+                max_stack = 1
+            }
+        }
     },
-    fists_of_flowing_momentum = {
-        id = 394949,
-        duration = 30,
-        max_stack = 3,
-    }
+    tier29 = {
+        items = { 200360, 200362, 200363, 200364, 200365, 217188, 217190, 217186, 217187, 217189 },
+        auras = {
+            kicks_of_flowing_momentum = {
+                id = 394944,
+                duration = 30,
+                max_stack = 2
+            },
+            fists_of_flowing_momentum = {
+                id = 394949,
+                duration = 30,
+                max_stack = 3
+            }
+        }
+    },
+    -- Legacy
+    tier21 = { items = { 152145, 152147, 152143, 152142, 152144, 152146 } },
+    tier20 = { items = { 147154, 147156, 147152, 147151, 147153, 147155 } },
+    tier19 = { items = { 138325, 138328, 138331, 138334, 138337, 138367 } },
+    class =  { items = { 139731, 139732, 139733, 139734, 139735, 139736, 139737, 139738 } },
+    cenedril_reflector_of_hatred = { items = { 137019 } },
+    cinidaria_the_symbiote = { items = { 133976 } },
+    drinking_horn_cover = { items = { 137097 } },
+    firestone_walkers = { items = { 137027 } },
+    fundamental_observation = { items = { 137063 } },
+    gai_plins_soothing_sash = { items = { 137079 } },
+    hidden_masters_forbidden_touch = { items = { 137057 } },
+    jewel_of_the_lost_abbey = { items = { 137044 } },
+    katsuos_eclipse = { items = { 137029 } },
+    march_of_the_legion = { items = { 137220 } },
+    prydaz_xavarics_magnum_opus = { items = { 132444 } },
+    salsalabims_lost_tunic = { items = { 137016 } },
+    sephuzs_secret = { items = { 132452 } },
+    the_emperors_capacitor = { items = { 144239 } },
+    soul_of_the_grandmaster = { items = { 151643 } },
+    stormstouts_last_gasp = { items = { 151788 } },
+    the_wind_blows = { items = { 151811 } }
 } )
-
--- Legacy
-spec:RegisterGear( "tier19", 138325, 138328, 138331, 138334, 138337, 138367 )
-spec:RegisterGear( "tier20", 147154, 147156, 147152, 147151, 147153, 147155 )
-spec:RegisterGear( "tier21", 152145, 152147, 152143, 152142, 152144, 152146 )
-spec:RegisterGear( "class", 139731, 139732, 139733, 139734, 139735, 139736, 139737, 139738 )
-spec:RegisterGear( "cenedril_reflector_of_hatred", 137019 )
-spec:RegisterGear( "cinidaria_the_symbiote", 133976 )
-spec:RegisterGear( "drinking_horn_cover", 137097 )
-spec:RegisterGear( "firestone_walkers", 137027 )
-spec:RegisterGear( "fundamental_observation", 137063 )
-spec:RegisterGear( "gai_plins_soothing_sash", 137079 )
-spec:RegisterGear( "hidden_masters_forbidden_touch", 137057 )
-spec:RegisterGear( "jewel_of_the_lost_abbey", 137044 )
-spec:RegisterGear( "katsuos_eclipse", 137029 )
-spec:RegisterGear( "march_of_the_legion", 137220 )
-spec:RegisterGear( "prydaz_xavarics_magnum_opus", 132444 )
-spec:RegisterGear( "salsalabims_lost_tunic", 137016 )
-spec:RegisterGear( "sephuzs_secret", 132452 )
-spec:RegisterGear( "the_emperors_capacitor", 144239 )
-spec:RegisterGear( "soul_of_the_grandmaster", 151643 )
-spec:RegisterGear( "stormstouts_last_gasp", 151788 )
-spec:RegisterGear( "the_wind_blows", 151811 )
-
 
 spec:RegisterStateTable( "combos", {
     blackout_kick = true,


### PR DESCRIPTION
Convert RegisterGear to the new format ahead of the 11.2 branch, making it easy to insert the new tier sets.