### PR TITLE
11.2 Prep - Convert register gear to new version - Paladin, Priest, RSham, Warlock, Warrior

### DIFF
--- a/TheWarWithin/PaladinHoly.lua
+++ b/TheWarWithin/PaladinHoly.lua
@@ -596,36 +596,40 @@ spec:RegisterAuras( {
     },
 } )
 
--- Current Expansion
-spec:RegisterGear( "tww2", 229244, 229242, 229243, 229245, 229247 )
-
--- Legacy
-
-spec:RegisterGear( "tier31", 207189, 207190, 207191, 207192, 207194 )
-spec:RegisterAuras( {
-    holy_reverberation = { -- TODO: Is actually multiple applications, not true stacks; check SimC.
-        id = 423377,
-        duration = 8,
-        max_stack = 6,
-        friendly = true,
-        copy = { "holy_reverberation_heal", "holy_reverberation_buff" }
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229244, 229242, 229243, 229245, 229247 }
     },
-    holy_reverberation_dot = {
-        id = 423379,
-        duration = 8,
-        max_stack = 6,
-        copy = { "holy_reverberation_dmg", "holy_reverberation_debuff" }
+    -- Dragonflight
+    tier31 = {
+        items = { 207189, 207190, 207191, 207192, 207194 },
+        auras = {
+            holy_reverberation = {
+                id = 423377,
+                duration = 8,
+                max_stack = 6,
+                friendly = true,
+                copy = { "holy_reverberation_heal", "holy_reverberation_buff" }
+            },
+            holy_reverberation_dot = {
+                id = 423379,
+                duration = 8,
+                max_stack = 6,
+                copy = { "holy_reverberation_dmg", "holy_reverberation_debuff" }
+            },
+            first_light = {
+                id = 427946,
+                duration = 6,
+                max_stack = 1
+            }
+        }
     },
-    first_light = {
-        id = 427946,
-        duration = 6,
-        max_stack = 1
+    tier30 = {
+        items = { 202455, 202453, 202452, 202451, 202450, 217198, 217200, 217196, 217197, 217199 }
     }
-} )
+})
 
-
-spec:RegisterGear( "tier30", 202455, 202453, 202452, 202451, 202450, 217198, 217200, 217196, 217197, 217199 )
--- 2pc is based on crits which aren't guaranteed, so we can't proactively model them.
 
 local HandleAwakening = setfenv( function()
         if buff.awakening.at_max_stacks then

--- a/TheWarWithin/PaladinProtection.lua
+++ b/TheWarWithin/PaladinProtection.lua
@@ -815,77 +815,83 @@ spec:RegisterAuras( {
     },
 } )
 
--- The War Within
-spec:RegisterGear( "tww2", 229244, 229242, 229243, 229245, 229247 )
-spec:RegisterAura( "luck_of_the_draw", {
-    -- https://www.wowhead.com/ptr-2/spell=1218114/luck-of-the-draw
-    -- Each time you take damage you have a chance to activate Luck of the Draw! causing you to cast Guardian of Ancient Kings for 4.0 sec. Your damage done is increased by 15% for 10 sec after Luck of the Draw! activates.
-        id = 1218114,
-        duration = 10,
-        max_stack = 1
-} )
-
--- Legacy
-spec:RegisterGear( "tier31", 207189, 207190, 207191, 207192, 207194 )
-spec:RegisterAuras( {
-    sanctification = { -- TODO: Explore reset of stacks when empowered Consecration expires.
-        id = 424616,
-        duration = 20,
-        max_stack = 5
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229244, 229242, 229243, 229245, 229247 },
+        auras = {
+            luck_of_the_draw = {
+                id = 1218114,
+                duration = 10,
+                max_stack = 1
+            }
+        }
     },
-    sanctification_empower = {
-        id = 424622,
-        duration = 30,
-        max_stack = 1
+    -- Dragonflight
+    tier31 = {
+        items = { 207189, 207190, 207191, 207192, 207194 },
+        auras = {
+            sanctification = {
+                id = 424616,
+                duration = 20,
+                max_stack = 5
+            },
+            sanctification_empower = {
+                id = 424622,
+                duration = 30,
+                max_stack = 1
+            }
+        }
     },
-})
-
--- Tier 30
-spec:RegisterGear( "tier30", 202455, 202453, 202452, 202451, 202450 )
-spec:RegisterAura( "heartfire", {
-    id = 408399,
-    duration = 5,
-    max_stack = 1
-} )
-
-
--- Gear Sets
-spec:RegisterGear( "tier29", 200417, 200419, 200414, 200416, 200418, 217198, 217200, 217196, 217197, 217199 )
-spec:RegisterAuras( {
-    ally_of_the_light = {
-        id = 394714,
-        duration = 8,
-        max_stack = 1
+    tier30 = {
+        items = { 202455, 202453, 202452, 202451, 202450 },
+        auras = {
+            heartfire = {
+                id = 408399,
+                duration = 5,
+                max_stack = 1
+            }
+        }
     },
-    deflecting_light = {
-        id = 394727,
-        duration = 10,
-        max_stack = 1
-    }
+    tier29 = {
+        items = { 200417, 200419, 200414, 200416, 200418, 217198, 217200, 217196, 217197, 217199 },
+        auras = {
+            ally_of_the_light = {
+                id = 394714,
+                duration = 8,
+                max_stack = 1
+            },
+            deflecting_light = {
+                id = 394727,
+                duration = 10,
+                max_stack = 1
+            }
+        }
+    },
+    -- Legacy
+    tier21 = { items = { 152151, 152153, 152149, 152148, 152150, 152152 } },
+    tier20 = {
+        items = { 147160, 147162, 147158, 147157, 147159, 147161 },
+        auras = {
+            sacred_judgment = {
+                id = 246973,
+                duration = 8,
+                max_stack = 1
+            }
+        }
+    },
+    tier19 = { items = { 138350, 138353, 138356, 138359, 138362, 138369 } },
+    class =  { items = { 139690, 139691, 139692, 139693, 139694, 139695, 139696, 139697 } },
+    breastplate_of_the_golden_valkyr = { items = { 137017 } },
+    heathcliffs_immortality = { items = { 137047 } },
+    justice_gaze = { items = { 137065 } },
+    saruans_resolve = { items = { 144275 } },
+    tyelca_ferren_marcuss_stature = { items = { 137070 } },
+    tyrs_hand_of_faith = { items = { 137059 } },
+    uthers_guard = { items = { 137105 } },
+    soul_of_the_highlord = { items = { 151644 } },
+    pillars_of_inmost_light = { items = { 151812 } }
 } )
-
-spec:RegisterGear( "tier19", 138350, 138353, 138356, 138359, 138362, 138369 )
-spec:RegisterGear( "tier20", 147160, 147162, 147158, 147157, 147159, 147161 )
-    spec:RegisterAura( "sacred_judgment", {
-        id = 246973,
-        duration = 8,
-        max_stack = 1,
-    } )
-
-spec:RegisterGear( "tier21", 152151, 152153, 152149, 152148, 152150, 152152 )
-spec:RegisterGear( "class", 139690, 139691, 139692, 139693, 139694, 139695, 139696, 139697 )
-
-spec:RegisterGear( "breastplate_of_the_golden_valkyr", 137017 )
-spec:RegisterGear( "heathcliffs_immortality", 137047 )
-spec:RegisterGear( "justice_gaze", 137065 )
-spec:RegisterGear( "saruans_resolve", 144275 )
-spec:RegisterGear( "tyelca_ferren_marcuss_stature", 137070 )
-spec:RegisterGear( "tyrs_hand_of_faith", 137059 )
-spec:RegisterGear( "uthers_guard", 137105 )
-
-spec:RegisterGear( "soul_of_the_highlord", 151644 )
-spec:RegisterGear( "pillars_of_inmost_light", 151812 )
-
 
 spec:RegisterStateExpr( "last_consecration", function () return action.consecration.lastCast end )
 spec:RegisterStateExpr( "last_blessed_hammer", function () return action.blessed_hammer.lastCast end )

--- a/TheWarWithin/PaladinRetribution.lua
+++ b/TheWarWithin/PaladinRetribution.lua
@@ -931,6 +931,43 @@ spec:RegisterAuras( {
     }
 } )
 
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229244, 229242, 229243, 229245, 229247 },
+        auras = {
+            winning_streak = {
+                id = 1216828,
+                duration = 30,
+                max_stack = 10
+            },
+            all_in = {
+                id = 1216837,
+                duration = 4,
+                max_stack = 1
+            }
+            -- TODO: Incorporate free spends?
+        }
+    },
+    -- Dragonflight
+    tier31 = {
+        items = { 207189, 207190, 207191, 207192, 207194, 217198, 217200, 217196, 217197, 217199 },
+        auras = {
+            echoes_of_wrath = {
+                id = 423590,
+                duration = 12,
+                max_stack = 1
+            }
+        }
+    },
+    tier30 = {
+        items = { 202455, 202453, 202452, 202451, 202450 }
+    },
+    tier29 = {
+        items = { 200417, 200419, 200414, 200416, 200418 }
+    }
+} )
+
 spec:RegisterHook( "prespend", function( amount, resource )
     -- You still need the holy power in order to cast, but it won't be consumed. It does trigger other effects as though it were consumed, though.
     if resource == "holy_power" and buff.all_in.up then
@@ -1042,36 +1079,6 @@ spec:RegisterUnitEvent( "UNIT_POWER_UPDATE", "player", nil, function( event, uni
 end )
 
 spec:RegisterStateExpr( "consecration", function () return buff.consecration end )
-
--- The War Within
-spec:RegisterGear( "tww2", 229244, 229242, 229243, 229245, 229247 )
-spec:RegisterAuras( {
-   -- 2-set
-    winning_streak = {
-        id = 1216828,
-        duration = 30,
-        max_stack = 10
-    },
-    all_in = {
-        id = 1216837,
-        duration = 4,
-        max_stack = 1
-    },
-
-    -- TODO: Incorporate free spends?
-
-} )
-
--- Legacy
-spec:RegisterGear( "tier31", 207189, 207190, 207191, 207192, 207194, 217198, 217200, 217196, 217197, 217199 )
-spec:RegisterAura( "echoes_of_wrath", {
-    id = 423590,
-    duration = 12,
-    max_stack = 1
-} )
-spec:RegisterGear( "tier30", 202455, 202453, 202452, 202451, 202450 )
-spec:RegisterGear( "tier29", 200417, 200419, 200414, 200416, 200418 )
-
 
 local tempDebug = { 387174, 255937, 427453, 429826, 427441 }
 local IsSpellOverlayed = IsSpellOverlayed

--- a/TheWarWithin/PriestDiscipline.lua
+++ b/TheWarWithin/PriestDiscipline.lua
@@ -517,29 +517,39 @@ spec:RegisterAuras( {
     },
 } )
 
--- The War Within
-spec:RegisterGear( "tww1", 212084, 212083, 212081, 212086, 212082 )
-spec:RegisterAuras( {
-    darkness_from_light = {
-        id = 455033,
-        duration = 30,
-        max_stack = 3
+spec:RegisterGear({
+    -- The War Within
+    tww1 = {
+        items = { 212084, 212083, 212081, 212086, 212082 },
+        auras = {
+            darkness_from_light = {
+                id = 455033,
+                duration = 30,
+                max_stack = 3
+            }
+        }
+    },
+    tww2 = {
+        items = { 229334, 229332, 229337, 229335, 229333 }
+    },
+    -- Dragonflight
+    tier29 = {
+        items = { 200327, 200329, 200324, 200326, 200328 }
+    },
+    tier30 = {
+        items = { 202543, 202542, 202541, 202545, 202540 },
+        auras = {
+            radiant_providence = {
+                id = 410638,
+                duration = 3600,
+                max_stack = 2
+            }
+        }
+    },
+    tier31 = {
+        items = { 207279, 207280, 207281, 207282, 207284, 217202, 217204, 217205, 217201, 217203 }
     }
 } )
-spec:RegisterGear( "tww2", 229334, 229332, 229337, 229335, 229333 )
-
--- Dragonflight
-spec:RegisterGear( "tier29", 200327, 200329, 200324, 200326, 200328 )
-spec:RegisterGear( "tier30", 202543, 202542, 202541, 202545, 202540 )
-spec:RegisterAuras( {
-    radiant_providence = {
-        id = 410638,
-        duration = 3600,
-        max_stack = 2
-    }
-} )
-spec:RegisterGear( "tier31", 207279, 207280, 207281, 207282, 207284, 217202, 217204, 217205, 217201, 217203 )
-
 
 spec:RegisterStateTable( "priest", {
     self_power_infusion = true
@@ -549,7 +559,6 @@ local holy_schools = {
     holy = true,
     holyfire = true
 }
-
 
 local entropic_rift_expires = 0
 local er_extensions = 0
@@ -579,7 +588,6 @@ local premonitions = {
     solace = "premonition_of_solace",
     clairvoyance = "premonition_of_clairvoyance"
 }
-
 
 spec:RegisterHook( "reset_precast", function ()
     if talent.premonition.enabled then

--- a/TheWarWithin/PriestHoly.lua
+++ b/TheWarWithin/PriestHoly.lua
@@ -438,25 +438,32 @@ spec:RegisterAuras( {
     },
 } )
 
-
-
--- The War Within
-spec:RegisterGear( "tww2", 229334, 229332, 229337, 229335, 229333 )
-
--- Dragonflight
-spec:RegisterGear( "tier30", 202543, 202542, 202541, 202545, 202540 )
-spec:RegisterAuras( {
-    inspired_word = {
-        id = 409479,
-        duration = 3600,
-        max_stack = 15
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229334, 229332, 229337, 229335, 229333 }
+    },
+    -- Dragonflight
+    tier30 = {
+        items = { 202543, 202542, 202541, 202545, 202540 },
+        auras = {
+            inspired_word = {
+                id = 409479,
+                duration = 3600,
+                max_stack = 15
+            }
+        }
+    },
+    tier31 = {
+        items = { 207279, 207280, 207281, 207282, 207284, 217202, 217204, 217205, 217201, 217203 },
+        auras = {
+            sacred_reverence = {
+                id = 423510,
+                duration = 3600,
+                max_stack = 2
+            }
+        }
     }
-} )
-spec:RegisterGear( "tier31", 207279, 207280, 207281, 207282, 207284, 217202, 217204, 217205, 217201, 217203 )
-spec:RegisterAura( "sacred_reverence", {
-    id = 423510,
-    duration = 3600,
-    max_stack = 2
 } )
 
 local naaruMulti = 1 + ( 0.1 * state.talent.light_of_the_naaru.rank )

--- a/TheWarWithin/PriestShadow.lua
+++ b/TheWarWithin/PriestShadow.lua
@@ -1004,7 +1004,6 @@ spec:RegisterGear( {
     }
 } )
 
-
 -- Don't need to actually snapshot this, the APL only cares about the power of the cast.
 spec:RegisterStateExpr( "pmultiplier", function ()
     if this_action ~= "devouring_plague" then return 1 end
@@ -1024,7 +1023,7 @@ spec:RegisterHook( "reset_precast", function ()
     end
 
     if not unfurlingDarknessInitialized then
-        -- Copy actual scraped debuff to buff table.        
+        -- Copy actual scraped debuff to buff table.
         auras.player.buff.unfurling_darkness_cd = auras.player.debuff.unfurling_darkness_cd
         -- Make debuff.unfurling_darkness_cd reference buff.unfurling_darkness_cd (incl. buff metatable).
         rawset( debuff, "unfurling_darkness_cd", buff.unfurling_darkness_cd )

--- a/TheWarWithin/ShamanRestoration.lua
+++ b/TheWarWithin/ShamanRestoration.lua
@@ -24,7 +24,7 @@ spec:RegisterTalents( {
     astral_bulwark              = { 103611, 377933, 1 }, -- Astral Shift reduces damage taken by an additional 20%.
     astral_shift                = { 103616, 108271, 1 }, -- Shift partially into the elemental planes, taking 60% less damage for 12 sec.
     awakening_storms            = {  94867, 455129, 1 }, -- Lightning Bolt and Chain Lightning have a chance to strike your target for 137,966 Nature damage. Every 3 times this occurs, your next Lightning Bolt is replaced by Tempest.
-    brimming_with_life          = { 103582, 381689, 1 }, -- Maximum health increased by 10%, and while you are at full health, Reincarnation cools down 75% faster. 
+    brimming_with_life          = { 103582, 381689, 1 }, -- Maximum health increased by 10%, and while you are at full health, Reincarnation cools down 75% faster.
     call_of_the_elements        = { 103592, 383011, 1 }, -- Reduces the cooldown of Totemic Recall by 60 sec.
     capacitor_totem             = { 103579, 192058, 1 }, -- Summons a totem at the target location that gathers electrical energy from the surrounding air and explodes after 2 sec, stunning all enemies within 10 yards for 3 sec.
     chain_heal                  = { 103588,   1064, 1 }, -- Heals the friendly target for 260,213, then jumps up to 30 yards to heal the 4 most injured nearby allies. Healing is reduced by 30% with each jump.
@@ -62,7 +62,7 @@ spec:RegisterTalents( {
     poison_cleansing_totem      = { 103609, 383013, 1 }, -- Summons a totem at your feet that removes all Poison effects from a nearby party or raid member within 39 yards every 1.5 sec for 9 sec.
     primordial_bond             = { 103612, 381764, 1 }, -- While you have an elemental active, your damage taken is reduced by 5%.
     purge                       = { 103624,    370, 1 }, -- Purges the enemy target, removing 1 beneficial Magic effect.
-    refreshing_waters           = { 103594, 378211, 1 }, -- Your Healing Surge is 25% more effective on yourself. 
+    refreshing_waters           = { 103594, 378211, 1 }, -- Your Healing Surge is 25% more effective on yourself.
     rolling_thunder             = {  94889, 454026, 1 }, -- Tempest summons a Nature Feral Spirit for 15 sec.
     seasoned_winds              = { 103628, 355630, 1 }, -- Interrupting a spell with Wind Shear decreases your damage taken from that spell school by 15% for 18 sec. Stacks up to 2 times.
     spirit_walk                 = { 103591,  58875, 1 }, -- Removes all movement impairing effects and increases your movement speed by 60% for 8 sec.
@@ -71,11 +71,11 @@ spec:RegisterTalents( {
     spiritwalkers_grace         = { 103584,  79206, 1 }, -- Calls upon the guidance of the spirits for 15 sec, permitting movement while casting Shaman spells. Castable while casting. Increases movement speed by 20%.
     static_charge               = { 103618, 265046, 1 }, -- Reduces the cooldown of Capacitor Totem by 5 sec for each enemy it stuns, up to a maximum reduction of 20 sec.
     stone_bulwark_totem         = { 103629, 108270, 1 }, -- Summons a totem at your feet that grants you an absorb shield preventing 2.4 million damage for 15 sec, and an additional 248,338 every 5 sec for 30 sec.
-    storm_swell                 = {  94873, 455088, 1 }, -- Tempest grants 15% Mastery for 6 sec. 
+    storm_swell                 = {  94873, 455088, 1 }, -- Tempest grants 15% Mastery for 6 sec.
     stormcaller                 = {  94893, 454021, 1 }, -- Increases the critical strike chance of your Nature damage spells by 5% and the critical strike damage of your Nature spells by 5%.
     supercharge                 = {  94873, 455110, 1 }, -- Lightning Bolt, Tempest, and Chain Lightning have a 35% chance to refund 2 Maelstrom Weapon stacks.
     surging_currents            = {  94880, 454372, 1 }, -- When you cast Tempest you gain Surging Currents, increasing the effectiveness of your next Chain Heal or Healing Surge by 20%, up to 100%.
-    tempest                     = {  94892, 454009, 1 }, -- Every 40 Maelstrom Weapon stacks spent replaces your next Lightning Bolt with Tempest. 
+    tempest                     = {  94892, 454009, 1 }, -- Every 40 Maelstrom Weapon stacks spent replaces your next Lightning Bolt with Tempest.
     thunderous_paws             = { 103581, 378075, 1 }, -- Ghost Wolf removes snares and increases your movement speed by an additional 25% for the first 3 sec. May only occur once every 20 sec.
     thundershock                = { 103621, 378779, 1 }, -- Thunderstorm knocks enemies up instead of away and its cooldown is reduced by 5 sec.
     thunderstorm                = { 103603,  51490, 1 }, -- Calls down a bolt of lightning, dealing 10,451 Nature damage to all enemies within 10 yards, reducing their movement speed by 40% for 5 sec, and knocking them away from the Shaman. Usable while stunned.
@@ -110,7 +110,7 @@ spec:RegisterTalents( {
     earthliving_weapon          = {  81049, 382021, 1 }, -- Imbue your weapon with the element of Earth for 1 |4hour:hrs;. Your Riptide, Healing Wave, Healing Surge, and Chain Heal healing a 20% chance to trigger Earthliving on the target, healing for 132,837 over 9 sec.
     echo_of_the_elements        = {  81044, 333919, 1 }, -- Riptide and Lava Burst have an additional charge.
     first_ascendant             = { 103433, 462440, 1 }, -- The cooldown of Ascendance is reduced by 60 sec.
-    flow_of_the_tides           = {  81031, 382039, 1 }, -- Chain Heal bounces an additional time and casting Chain Heal on a target affected by Riptide consumes Riptide, increasing the healing of your Chain Heal by 30%. 
+    flow_of_the_tides           = {  81031, 382039, 1 }, -- Chain Heal bounces an additional time and casting Chain Heal on a target affected by Riptide consumes Riptide, increasing the healing of your Chain Heal by 30%.
     healing_rain                = {  81040,  73920, 1 }, -- Blanket the target area in healing rains, restoring 243,096 health to up to 5 allies over 10 sec.
     healing_stream_totem_2      = {  81022,   5394, 1 }, -- Summons a totem at your feet for 18 sec that heals an injured party or raid member within 52 yards for 63,140 every 1.9 sec. If you already know Healing Stream Totem, instead gain 1 additional charge of Healing Stream Totem.
     healing_tide_totem          = {  81032, 108280, 1 }, -- Summons a totem at your feet for 10 sec, which pulses every 1.9 sec, healing all party or raid members within 52 yards for 123587.3. Healing reduced beyond 5 targets.
@@ -127,11 +127,11 @@ spec:RegisterTalents( {
     riptide                     = {  81027,  61295, 1 }, -- Restorative waters wash over a friendly target, healing them for 250,372 and an additional 183,851 over 21 sec.
     spirit_link_totem           = {  81033,  98008, 1 }, -- Summons a totem at the target location for 6 sec, which reduces damage taken by all party and raid members within 13 yards by 15%. Immediately and every 1 sec, the health of all affected players is redistributed evenly.
     spiritwalkers_tidal_totem   = {  81045, 404522, 1 }, -- After using Healing Tide Totem, the cast time of your next 3 Healing Surges within 30 sec is reduced by 100% and their mana cost is reduced by 50%.
-    spouting_spirits            = { 103432, 462383, 1 }, -- Spirit Link Totem reduces damage taken by an additional 5%, and it restores 564,970 health to all nearby allies 1 second after it is dropped. Healing reduced beyond 5 targets. 
+    spouting_spirits            = { 103432, 462383, 1 }, -- Spirit Link Totem reduces damage taken by an additional 5%, and it restores 564,970 health to all nearby allies 1 second after it is dropped. Healing reduced beyond 5 targets.
     therazanes_resilience       = { 103435, 1217622, 1 }, -- Earth Shield and Water Shield no longer lose charges and are 115% effective.
     tidal_waves                 = {  81021,  51564, 1 }, -- Casting Riptide grants 2 stacks of Tidal Waves. Tidal Waves reduces the cast time of your next Healing Wave or Chain Heal by 20%, or increases the critical effect chance of your next Healing Surge by 30%.
     tide_turner                 = {  92675, 404019, 1 }, -- The lowest health target of Healing Tide Totem is healed for 30% more and receives 15% increased healing from you for 4 sec.
-    tidebringer                 = {  81041, 236501, 1 }, -- Every 10 sec, the cast time of your next Chain Heal is reduced by 50%, and jump distance increased by 100%. Maximum of 2 charges. 
+    tidebringer                 = {  81041, 236501, 1 }, -- Every 10 sec, the cast time of your next Chain Heal is reduced by 50%, and jump distance increased by 100%. Maximum of 2 charges.
     tidewaters                  = { 103434, 462424, 1 }, -- When you cast Surging Totem, each ally with your Riptide on them is healed for 260,755.
     torrent                     = {  81047, 200072, 1 }, -- Riptide's initial heal is increased 20% and has a 10% increased critical strike chance.
     undercurrent                = {  81052, 382194, 2 }, -- For each Riptide active on an ally, your heals are 0.5% more effective.
@@ -146,13 +146,13 @@ spec:RegisterTalents( {
     -- Totemic
     amplification_core          = {  94874, 445029, 1 }, -- While Surging Totem is active, your damage and healing done is increased by 3%.
     earthsurge                  = {  94881, 455590, 1 }, -- Allies affected by your Earthen Wall Totem, Ancestral Protection Totem, and Earthliving effect receive 15% increased healing from you.
-    imbuement_mastery           = {  94871, 445028, 1 }, -- Increases the duration of your Earthliving effect by 3 sec. 
+    imbuement_mastery           = {  94871, 445028, 1 }, -- Increases the duration of your Earthliving effect by 3 sec.
     lively_totems               = {  94882, 445034, 1 }, -- When you summon a Healing Tide Totem, Healing Stream Totem, Cloudburst Totem, Mana Tide Totem, or Spirit Link Totem you cast a free instant Chain Heal at 100% effectiveness.
     oversized_totems            = {  94859, 445026, 1 }, -- Increases the size and radius of your totems by 15%, and the health of your totems by 30%.
     oversurge                   = {  94874, 445030, 1 }, -- Surging Totem heals for 150% more during Ascendance.
     pulse_capacitor             = {  94866, 445032, 1 }, -- Increases the healing done by Surging Totem by 25%.
     reactivity                  = {  94872, 445035, 1 }, -- Your Healing Stream Totems now also heals a second ally at 50% effectiveness. Cloudburst Totem stores 25% additional healing.
-    supportive_imbuements       = {  94866, 445033, 1 }, -- Learn a new weapon imbue, Tidecaller's Guard.  Tidecaller's Guard Imbue your shield with the element of Water for 1 |4hour:hrs;. Your healing done is increased by 2.4% and the duration of your Healing Stream Totem and Cloudburst Totem is increased by 3.6 sec. 
+    supportive_imbuements       = {  94866, 445033, 1 }, -- Learn a new weapon imbue, Tidecaller's Guard.  Tidecaller's Guard Imbue your shield with the element of Water for 1 |4hour:hrs;. Your healing done is increased by 2.4% and the duration of your Healing Stream Totem and Cloudburst Totem is increased by 3.6 sec.
     surging_totem               = {  94877, 444995, 1, "totemic" }, -- Summons a totem at the target location that maintains Healing Rain for 24 sec. Heals for 30% more than a normal Healing Rain. Replaces Healing Rain.
     swift_recall                = {  94859, 445027, 1 }, -- Successfully removing a harmful effect with Tremor Totem or Poison Cleansing Totem, or controlling an enemy with Capacitor Totem or Earthgrab Totem reduces the cooldown of the totem used by 5 sec. Cannot occur more than once every 20 sec per totem.
     totemic_coordination        = {  94881, 445036, 1 }, -- Chain Heals from Lively Totem and Totemic Rebound are 25% more effective.
@@ -178,16 +178,16 @@ spec:RegisterTalents( {
 } )
 
 -- PvP Talents
-spec:RegisterPvpTalents( { 
+spec:RegisterPvpTalents( {
     burrow              = 5576, -- (409293) Burrow beneath the ground, becoming unattackable, removing movement impairing effects, and increasing your movement speed by 50% for 5 sec. When the effect ends, enemies within 6 yards are knocked in the air and take 455,287 Physical damage.
-    counterstrike_totem =  708, -- (204331) Summons a totem at your feet for 15 sec. Whenever enemies within 26 yards of the totem deal direct damage, the totem will deal 100% of the damage dealt back to attacker. 
+    counterstrike_totem =  708, -- (204331) Summons a totem at your feet for 15 sec. Whenever enemies within 26 yards of the totem deal direct damage, the totem will deal 100% of the damage dealt back to attacker.
     electrocute         =  714, -- (206642) When you successfully Purge a beneficial effect, the enemy suffers 165,559 Nature damage over 3 sec.
     grounding_totem     =  715, -- (204336) Summons a totem at your feet that will redirect all harmful spells cast within 39 yards on a nearby party or raid member to itself. Will not redirect area of effect spells. Lasts 3 sec.
-    living_tide         = 5388, -- (353115) 
-    rain_dance          = 3755, -- (290250) 
+    living_tide         = 5388, -- (353115)
+    rain_dance          = 3755, -- (290250)
     static_field_totem  = 5567, -- (355580) Summons a totem with 5% of your health at the target location for 6 sec that forms a circuit of electricity that enemies cannot pass through.
     storm_conduit       = 5704, -- (1217092) Casting Lightning Bolt or Chain Lightning reduces the cooldown of Astral Shift, Gust of Wind, Wind Shear, and Nature Totems by 3.0 sec. Interrupt duration reduced by 50% on Lightning Bolt and Chain Lightning casts.
-    totem_of_wrath      = 5705, -- (460697) Nature's Swiftness summons a totem at your feet for 15 sec that increases the critical effect of damage and healing spells of all nearby allies within 53 yards by 15% for 15 sec. 
+    totem_of_wrath      = 5705, -- (460697) Nature's Swiftness summons a totem at your feet for 15 sec that increases the critical effect of damage and healing spells of all nearby allies within 53 yards by 15% for 15 sec.
     unleash_shield      = 5437, -- (356736) Unleash your Elemental Shield's energy on an enemy target: Lightning Shield: Knocks them away. Earth Shield: Roots them in place for 2 sec. Water Shield: Summons a whirlpool for 6 sec, reducing damage and healing by 50% while they stand within it.
 } )
 
@@ -301,25 +301,34 @@ spec:RegisterAuras( {
     },
 } )
 
--- The War Within
-spec:RegisterGear( "tww2", 229260, 229261, 229262, 229263, 229265 )
-
--- Dragonflight
-spec:RegisterGear( "tier29", 200399, 200401, 200396, 200398, 200400, 217238, 217240, 217236, 217237, 217239 )
-spec:RegisterGear( "tier30", 202473, 202471, 202470, 202469, 202468 )
-spec:RegisterAuras( {
-    rainstorm = {
-        id = 409386,
-        duration = 6,
-        max_stack = 40
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229260, 229261, 229262, 229263, 229265 }
     },
-    swelling_rain = {
-        id = 409391,
-        duration = 15,
-        max_stack = 40
+    -- Dragonflight
+    tier29 = {
+        items = { 200399, 200401, 200396, 200398, 200400, 217238, 217240, 217236, 217237, 217239 }
+    },
+    tier30 = {
+        items = { 202473, 202471, 202470, 202469, 202468 },
+        auras = {
+            rainstorm = {
+                id = 409386,
+                duration = 6,
+                max_stack = 40
+            },
+            swelling_rain = {
+                id = 409391,
+                duration = 15,
+                max_stack = 40
+            }
+        }
+    },
+    tier31 = {
+        items = { 207207, 207208, 207209, 207210, 207212 }
     }
 } )
-spec:RegisterGear( "tier31", 207207, 207208, 207209, 207210, 207212 )
 
 local recall_totems = {
     capacitor_totem = 1,
@@ -698,10 +707,10 @@ spec:RegisterAbilities( {
         notalent = "surging_totem",
 
         handler = function ()
-            
+
             applyBuff( "healing_rain" )
 
-            if talent.downpour.enabled then 
+            if talent.downpour.enabled then
                 applyBuff( "downpour" )
                 setCooldown( "downpour", 0 )
             end
@@ -722,7 +731,7 @@ spec:RegisterAbilities( {
             if talent.healing_stream_totem.rank + talent.healing_stream_totem_2.rank > 1 then return 2 end
         end,
         cooldown = function () return 30 - ( talent.totemic_surge.enabled and 6 or 0 ) end,
-        recharge = function() 
+        recharge = function()
             if talent.healing_stream_totem.rank + talent.healing_stream_totem_2.rank > 1 then return ( 30 - (talent.totemic_surge.enabled and 6 or 0 ))
             else return nil end
         end,
@@ -988,7 +997,7 @@ spec:RegisterAbilities( {
 
         handler = function ()
             summonTotem( "surging_totem" )
-            
+
             if talent.downpour.enabled then
                 setCooldown( "downpour", 0 )
                 applyBuff( "downpour" )
@@ -1013,7 +1022,7 @@ spec:RegisterAbilities( {
             applyBuff( "tidecallers_guard" )
         end,
     },
-	
+
 	-- Talent: Resets the cooldown of your most recently used totem with a base cooldown shorter than 3 minutes.
     totemic_recall = {
         id = 108285,
@@ -1032,7 +1041,7 @@ spec:RegisterAbilities( {
             if talent.creation_core.enabled and recall_totem_2 then setCooldown( recall_totem_2, 0 ) end
         end,
     },
-	
+
     -- Unleash elemental forces of Life, healing a friendly target for 12,592 and increasing the effect of your next healing spell. Riptide, Healing Wave, or Healing Surge: 35% increased healing. Chain Heal: 15% increased healing and bounces to 1 additional target. Healing Rain or Downpour: 2 additional allies healed. Wellspring: 25% of overhealing done is converted to an absorb effect.
     unleash_life = {
         id = 73685,

--- a/TheWarWithin/WarlockAffliction.lua
+++ b/TheWarWithin/WarlockAffliction.lua
@@ -896,77 +896,84 @@ spec:RegisterHook( "combatExit", function()
     wipe( corruptionTargets )
 end )
 
--- The War Within
-spec:RegisterGear( "tww2", 229325, 229323, 229328, 229326, 229324 )
-spec:RegisterAuras( {
--- 2-set
--- https://www.wowhead.com/spell=1219034/jackpot
--- Your spells and abilities have a chance to hit a Jackpot! that increases your haste by 12% for 12 sec. Casting Summon Darkglare always hits a Jackpot!
-    jackpot = {
-        id = 1219034,
-        duration = 12,
-        max_stack = 1
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229325, 229323, 229328, 229326, 229324 },
+        auras = {
+            jackpot = {
+                id = 1219034,
+                duration = 12,
+                max_stack = 1
+            }
+        }
     },
-
-} )
-
--- Dragonflight
-spec:RegisterGear( "tier31", 207270, 207271, 207272, 207273, 207275, 217212, 217214, 217215, 217211, 217213 )
--- (4) Soul Rot grants 3 Umbrafire Kindling which increase the damage of your next Malefic Rapture to deal 50% or your next Seed of Corruption by 60%. Additionally, Umbrafire Kindling causes Malefic Rapture to extend the duration of your damage over time effects and Haunt by 2 sec.
-spec:RegisterAura( "umbrafire_kindling", {
-    id = 423765,
-    duration = 20,
-    max_stack = 3
-} )
-spec:RegisterGear( "tier30", 202534, 202533, 202532, 202536, 202531 )
-spec:RegisterAura( "infirmity", {
-    id = 409765,
-    duration = 16, -- spelldata says 2 sec, but applies for 16 seconds from PS and 10 seconds from VT.
-    max_stack = 1
-} )
--- Tier 29
-spec:RegisterGear( "tier29", 200336, 200338, 200333, 200335, 200337 )
-spec:RegisterAuras( {
-    cruel_inspiration = {
-        id = 394215,
-        duration = 6,
-        max_stack = 1
+    -- Dragonflight
+    tier31 = {
+        items = { 207270, 207271, 207272, 207273, 207275, 217212, 217214, 217215, 217211, 217213 },
+        auras = {
+            umbrafire_kindling = {
+                id = 423765,
+                duration = 20,
+                max_stack = 3
+            }
+        }
     },
-    cruel_epiphany = {
-        id = 394253,
-        duration = 40,
-        max_stack = 5
-    }
+    tier30 = {
+        items = { 202534, 202533, 202532, 202536, 202531 },
+        auras = {
+            infirmity = {
+                id = 409765,
+                duration = 16,
+                max_stack = 1
+            }
+        }
+    },
+    tier29 = {
+        items = { 200336, 200338, 200333, 200335, 200337 },
+        auras = {
+            cruel_inspiration = {
+                id = 394215,
+                duration = 6,
+                max_stack = 1
+            },
+            cruel_epiphany = {
+                id = 394253,
+                duration = 40,
+                max_stack = 5
+            }
+        }
+    },
+    tier28 = {
+        items = { 188884, 188887, 188888, 188889, 188890 },
+        bonuses = {
+            tier28_2pc = 364437,
+            tier28_4pc = 363953
+        },
+        auras = {
+            calamitous_crescendo = {
+                id = 364322,
+                duration = 10,
+                max_stack = 1
+            }
+        }
+    },
+    -- Legacy
+    tier21 = { items = { 152174, 152177, 152172, 152176, 152173, 152175 } },
+    tier20 = { items = { 147183, 147186, 147181, 147185, 147182, 147184 } },
+    tier19 = { items = { 138314, 138323, 138373, 138320, 138311, 138317 } },
+    class =  { items = { 139765, 139768, 139767, 139770, 139764, 139769, 139766, 139763 } },
+    amanthuls_vision = { items = { 154172 } },
+    hood_of_eternal_disdain = { items = { 132394 } },
+    norgannons_foresight = { items = { 132455 } },
+    pillars_of_the_dark_portal = { items = { 132357 } },
+    power_cord_of_lethtendris = { items = { 132457 } },
+    reap_and_sow = { items = { 144364 } },
+    sacrolashs_dark_strike = { items = { 132378 } },
+    soul_of_the_netherlord = { items = { 151649 } },
+    stretens_sleepless_shackles = { items = { 132381 } },
+    the_master_harvester = { items = { 151821 } }
 } )
--- Tier 28
-spec:RegisterGear( "tier28", 188884, 188887, 188888, 188889, 188890 )
-spec:RegisterSetBonuses( "tier28_2pc", 364437, "tier28_4pc", 363953 )
--- 2-Set - Deliberate Malice - Malefic Rapture's damage is increased by 15% and each cast extends the duration of Corruption, Agony, and Unstable Affliction by 2 sec.
--- 4-Set - Calamitous Crescendo - While Agony, Corruption, and Unstable Affliction are active, your Drain Soul has a 10% chance / Shadow Bolt has a 20% chance to make your next Malefic Rapture cost no Soul Shards and cast instantly.
-spec:RegisterAura( "calamitous_crescendo", {
-    id = 364322,
-    duration = 10,
-    max_stack = 1,
-} )
-
--- Legacy
-
-spec:RegisterGear( "tier21", 152174, 152177, 152172, 152176, 152173, 152175 )
-spec:RegisterGear( "tier20", 147183, 147186, 147181, 147185, 147182, 147184 )
-spec:RegisterGear( "tier19", 138314, 138323, 138373, 138320, 138311, 138317 )
-spec:RegisterGear( "class", 139765, 139768, 139767, 139770, 139764, 139769, 139766, 139763 )
-
-spec:RegisterGear( "amanthuls_vision", 154172 )
-spec:RegisterGear( "hood_of_eternal_disdain", 132394 )
-spec:RegisterGear( "norgannons_foresight", 132455 )
-spec:RegisterGear( "pillars_of_the_dark_portal", 132357 )
-spec:RegisterGear( "power_cord_of_lethtendris", 132457 )
-spec:RegisterGear( "reap_and_sow", 144364 )
-spec:RegisterGear( "sacrolashs_dark_strike", 132378 )
-spec:RegisterGear( "soul_of_the_netherlord", 151649 )
-spec:RegisterGear( "stretens_sleepless_shackles", 132381 )
-spec:RegisterGear( "the_master_harvester", 151821 )
-
 
 --[[ spec:RegisterStateFunction( "applyUnstableAffliction", function( duration )
     for i = 1, 5 do
@@ -979,13 +986,11 @@ spec:RegisterGear( "the_master_harvester", 151821 )
     end
 end ) ]]
 
-
 spec:RegisterHook( "reset_preauras", function ()
     if class.abilities.summon_darkglare.realCast and state.now - class.abilities.summon_darkglare.realCast < 20 then
         target.updated = true
     end
 end )
-
 
 local SUMMON_DEMON_TEXT
 
@@ -1056,14 +1061,12 @@ spec:RegisterHook( "reset_precast", function ()
     class.abilities.summon_pet = class.abilities[ settings.default_pet or "summon_sayaad" ]
 end )
 
-
 spec:RegisterHook( "spend", function( amt, resource )
     if resource == "soul_shards" and amt > 0 and talent.summon_darkglare.enabled then
         if talent.grand_warlocks_design.enabled then reduceCooldown( "summon_darkglare", amt * 2 ) end
         if legendary.wilfreds_sigil_of_superior_summoning.enabled then reduceCooldown( "summon_darkglare", amt * 2 ) end
     end
 end )
-
 
 spec:RegisterStateExpr( "target_uas", function ()
     return active_dot.unstable_affliction
@@ -1078,7 +1081,6 @@ spec:RegisterStateExpr( "can_seed", function ()
     if active_dot.seed_of_corruption < seed_targets - ( state:IsInFlight( "seed_of_corruption" ) and 1 or 0 ) then return true end
     return false
 end )
-
 
 local Glyphed = IsSpellKnownOrOverridesKnown
 

--- a/TheWarWithin/WarlockDemonology.lua
+++ b/TheWarWithin/WarlockDemonology.lua
@@ -220,9 +220,6 @@ local function UpdateShardsForGuldan()
     shards_for_guldan = UnitPower( "player", Enum.PowerType.SoulShards )
 end
 
-
-
-
 local dreadstalkers_travel_time = 1
 
 spec:RegisterCombatLogEvent( function( _, subtype, _, source, _, _, _, destGUID, _, _, _, spellID, spellName )
@@ -357,7 +354,6 @@ spec:RegisterCombatLogEvent( function( _, subtype, _, source, _, _, _, destGUID,
     end
 end )
 
-
 local ExpireDreadstalkers = setfenv( function()
     addStack( "demonic_core", nil, 2 )
     if talent.shadows_bite.enabled then applyBuff( "shadows_bite" ) end
@@ -377,32 +373,6 @@ spec:RegisterStateFunction( "SoulStrikeIfNotCapped", function()
         if Hekili.ActiveDebug then Hekili:Debug( "*** Soul Strike not cast at %.2f due to capped shards; requeuing in cast by pet at %.2f.", query_time, gcd.remains > 0 and gcd.expires or ( query_time + gcd.max ) ) end
     end
 end )
-
--- The War Within
-spec:RegisterGear( "tww2", 229325, 229323, 229328, 229326, 229324 )
-
--- Dragonflight
-
-spec:RegisterGear( "tier29", 200336, 200338, 200333, 200335, 200337 )
-spec:RegisterAura( "blazing_meteor", {
-    id = 394215,
-    duration = 6,
-    max_stack = 1
-} )
-spec:RegisterGear( "tier30", 202534, 202533, 202532, 202536, 202531 )
-spec:RegisterAura( "rite_of_ruvaraad", {
-    id = 409725,
-    duration = 17,
-    max_stack = 1
-} )
-spec:RegisterGear( "tier31", 207270, 207271, 207272, 207273, 207275, 217212, 217214, 217215, 217211, 217213 )
-spec:RegisterAuras( {
-    doom_brand = {
-        id = 423583,
-        duration = 20,
-        max_stack = 1
-    }
-} )
 
 local wipe = table.wipe
 
@@ -576,7 +546,6 @@ spec:RegisterHook( "reset_precast", function()
     if Hekili.ActiveDebug then Hekili:Debug( "Should have seen demons." ) end
 end )
 
-
 spec:RegisterHook( "advance_end", function ()
     -- For virtual imps, assume they'll take 0.5s to start casting and then chain cast.
     local longevity = 0.5 + ( state.level > 55 and 7 or 6 ) * 2 * state.haste
@@ -591,7 +560,6 @@ spec:RegisterHook( "advance_end", function ()
         end
     end
 end )
-
 
 -- Provide a way to confirm if all Hand of Gul'dan imps have landed.
 spec:RegisterStateExpr( "spawn_remains", function ()
@@ -635,7 +603,6 @@ spec:RegisterVariable( "imp_despawn", function ()
 
     return val
 end )
-
 
 spec:RegisterHook( "spend", function( amt, resource )
     if resource == "soul_shards" then
@@ -697,7 +664,6 @@ spec:RegisterHook( "spend", function( amt, resource )
     end
 end )
 
-
 spec:RegisterHook( "advance_end", function( time )
     if buff.ritual_overlord.expires > query_time - time and buff.ritual_overlord.down then
         applyBuff( "art_overlord" )
@@ -711,7 +677,6 @@ spec:RegisterHook( "advance_end", function( time )
         applyBuff( "art_pit_lord" )
     end
 end )
-
 
 spec:RegisterStateFunction( "summon_demon", function( name, duration, count )
     local db = other_demon_v
@@ -735,7 +700,6 @@ spec:RegisterStateFunction( "summon_demon", function( name, duration, count )
     end
 end )
 
-
 spec:RegisterStateFunction( "extend_demons", function( duration )
     duration = duration or 15
 
@@ -753,7 +717,6 @@ spec:RegisterStateFunction( "extend_demons", function( duration )
         if n == 0 then break end
     end
 end )
-
 
 spec:RegisterStateFunction( "consume_demons", function( name, count )
     local db = other_demon_v
@@ -810,7 +773,6 @@ spec:RegisterStateFunction( "consume_demons", function( name, count )
     end
 end )
 
-
 spec:RegisterStateExpr( "soul_shard", function () return soul_shards.current end )
 spec:RegisterStateExpr( "soul_shard_deficit", function () return soul_shards.max - soul_shards.current end )
 
@@ -833,11 +795,9 @@ spec:RegisterStateExpr( "time_to_hog", function ()
     return cast_time
 end )
 
-
 spec:RegisterStateExpr( "major_demons_active", function ()
     return ( buff.grimoire_felguard.up and 1 or 0 ) + ( buff.vilefiend.up and 1 or 0 ) + ( buff.dreadstalkers.up and 1 or 0 )
 end )
-
 
 -- When the next major demon (anything but Wild Imps) expires.
 spec:RegisterStateExpr( "major_demon_remains", function ()
@@ -851,7 +811,6 @@ spec:RegisterStateExpr( "major_demon_remains", function ()
     return expire
 end )
 
-
 -- New imp forecasting expressions for Demo.
 spec:RegisterStateExpr( "incoming_imps", function ()
     local n = 0
@@ -864,7 +823,6 @@ spec:RegisterStateExpr( "incoming_imps", function ()
 
     return n
 end )
-
 
 local time_to_n = 0
 
@@ -895,7 +853,6 @@ spec:RegisterStateTable( "query_imp_spawn", setmetatable( {}, {
         return remains
     end,
 } ) )
-
 
 local valid_demons = {
     grimoire_felguard = "grimoire_felguard",
@@ -936,7 +893,7 @@ spec:RegisterStateExpr( "there_would_really_be_no_point_to_generate_shards", fun
     local hog_cast = action.hand_of_guldan.cast_time
     local padding = gcd.max * 2
 
-    
+
     local shortest = 999
 
     for k in pairs( valid_demons ) do
@@ -959,7 +916,6 @@ spec:RegisterStateTable( "time_to_imps", setmetatable( {}, {
         return query_imp_spawn.remains
     end
 } ) )
-
 
 spec:RegisterStateTable( "imps_spawned_during", setmetatable( {}, {
     __index = function( t, k )
@@ -987,6 +943,43 @@ spec:RegisterStateTable( "imps_spawned_during", setmetatable( {}, {
     end,
 } ) )
 
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229325, 229323, 229328, 229326, 229324 }
+    },
+    -- Dragonflight
+    tier31 = {
+        items = { 207270, 207271, 207272, 207273, 207275, 217212, 217214, 217215, 217211, 217213 },
+        auras = {
+            doom_brand = {
+                id = 423583,
+                duration = 20,
+                max_stack = 1
+            }
+        }
+    },
+    tier30 = {
+        items = { 202534, 202533, 202532, 202536, 202531 },
+        auras = {
+            rite_of_ruvaraad = {
+                id = 409725,
+                duration = 17,
+                max_stack = 1
+            }
+        }
+    },
+    tier29 = {
+        items = { 200336, 200338, 200333, 200335, 200337 },
+        auras = {
+            blazing_meteor = {
+                id = 394215,
+                duration = 6,
+                max_stack = 1
+            }
+        }
+    }
+} )
 
 -- Auras
 spec:RegisterAuras( {

--- a/TheWarWithin/WarlockDestruction.lua
+++ b/TheWarWithin/WarlockDestruction.lua
@@ -1120,13 +1120,56 @@ spec:RegisterAuras( {
     },
 } )
 
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229325, 229323, 229328, 229326, 229324 },
+        auras = {
+            jackpot = {
+                id = 1217798,
+                duration = 10,
+                max_stack = 1
+            }
+        }
+    },
+    -- Dragonflight
+    tier31 = {
+        items = { 207270, 207271, 207272, 207273, 207275 },
+        auras = {
+            searing_bolt = {
+                id = 423886,
+                duration = 10,
+                max_stack = 1
+            }
+        }
+    },
+    tier30 = {
+        items = { 202534, 202533, 202532, 202536, 202531 },
+        auras = {
+            umbrafire_embers = {
+                id = 409652,
+                duration = 13,
+                max_stack = 8
+            }
+        }
+    },
+    tier29 = {
+        items = { 200336, 200338, 200333, 200335, 200337, 217212, 217214, 217215, 217211, 217213 },
+        auras = {
+            chaos_maelstrom = {
+                id = 394679,
+                duration = 10,
+                max_stack = 1
+            }
+        }
+    }
+} )
 
 spec:RegisterHook( "runHandler", function( a )
     if talent.rolling_havoc.enabled and havoc_active and not debuff.havoc.up and action[ a ].startsCombat then
         addStack( "rolling_havoc" )
     end
 end )
-
 
 spec:RegisterHook( "spend", function( amt, resource )
     if resource == "soul_shards" then
@@ -1175,7 +1218,6 @@ spec:RegisterHook( "spend", function( amt, resource )
     end
 end )
 
-
 spec:RegisterHook( "advance_end", function( time )
     if buff.art_mother.expires > query_time - time and buff.art_mother.down then
         summon_demon( "mother_of_chaos", 6 )
@@ -1183,7 +1225,6 @@ spec:RegisterHook( "advance_end", function( time )
         if talent.secrets_of_the_coven.enabled then applyBuff( "infernal_bolt" ) end
     end
 end )
-
 
 local lastTarget
 local lastMayhem = 0
@@ -1197,7 +1238,6 @@ spec:RegisterHook( "COMBAT_LOG_EVENT_UNFILTERED", function( _, subtype, _, sourc
         end
     end
 end, false )
-
 
 spec:RegisterStateExpr( "last_havoc", function ()
     if talent.mayhem.enabled then return lastMayhem end
@@ -1220,8 +1260,6 @@ spec:RegisterStateExpr( "diabolic_ritual", function ()
     return buff.ritual_overlord.up or buff.ritual_mother.up or buff.ritual_pit_lord.up
 end )
 
-
-
 spec:RegisterHook( "TimeToReady", function( wait, action )
     local ability = action and class.abilities[ action ]
 
@@ -1233,41 +1271,6 @@ spec:RegisterHook( "TimeToReady", function( wait, action )
 end )
 
 spec:RegisterStateExpr( "soul_shard", function () return soul_shards.current end )
-
-
--- The War Within
-spec:RegisterGear( "tww2", 229325, 229323, 229328, 229326, 229324 )
-spec:RegisterAuras( {
--- 2-set
--- https://www.wowhead.com/ptr-2/spell=1217798/jackpot
--- Hitting a Jackpot! increases your Mastery by 3% and your spells gain maximum benefit from Mastery: Chaotic Energies for 10 sec.
-    jackpot = {
-        id = 1217798,
-        duration = 10,
-        max_stack = 1,
-    },
-} )
-
--- Dragonflight
--- Tier 29
-spec:RegisterGear( "tier29", 200336, 200338, 200333, 200335, 200337, 217212, 217214, 217215, 217211, 217213 )
-spec:RegisterAura( "chaos_maelstrom", {
-    id = 394679,
-    duration = 10,
-    max_stack = 1
-} )
-spec:RegisterGear( "tier30", 202534, 202533, 202532, 202536, 202531 )
-spec:RegisterAura( "umbrafire_embers", {
-    id = 409652,
-    duration = 13,
-    max_stack = 8
-} )
-spec:RegisterGear( "tier31", 207270, 207271, 207272, 207273, 207275 )
-spec:RegisterAura( "searing_bolt", {
-    id = 423886,
-    duration = 10,
-    max_stack = 1
-} )
 
 local SUMMON_DEMON_TEXT
 
@@ -1302,7 +1305,6 @@ spec:RegisterHook( "reset_precast", function ()
         applyBuff( "infernal_bolt" )
     end
 end )
-
 
 spec:RegisterCycle( function ()
     if active_enemies == 1 then return end

--- a/TheWarWithin/WarriorArms.lua
+++ b/TheWarWithin/WarriorArms.lua
@@ -554,6 +554,76 @@ spec:RegisterAuras( {
     },
 } )
 
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229235, 229233, 229238, 229236, 229234 },
+        auras = {
+            winning_streak = {
+                id = 1216552,
+                duration = 30,
+                max_stack = 10,
+                copy = "winning_streak_arms"
+            },
+            hedged_bets = {
+                id = 1216556,
+                duration = 12,
+                max_stack = 1
+            }
+        }
+    },
+    -- Dragonflight
+    tier31 = {
+        items = { 207180, 207181, 207182, 207183, 207185 },
+        setBonuses = {
+            tier31_2pc = 422923,
+            tier31_4pc = 422924
+        },
+        auras = {
+            finishing_wound = {
+                id = 426284,
+                duration = 5,
+                max_stack = 1
+            }
+        }
+    },
+    tier30 = {
+        items = { 202446, 202444, 202443, 202442, 202441 },
+        setBonuses = {
+            tier30_2pc = 405577,
+            tier30_4pc = 405578
+        },
+        auras = {
+            crushing_advance = {
+                id = 410138,
+                duration = 30,
+                max_stack = 3
+            }
+        }
+    },
+    tier29 = {
+        items = { 200426, 200428, 200423, 200425, 200427, 217218, 217220, 217216, 217217, 217219 },
+        setBonuses = {
+            tier29_2pc = 393705,
+            tier29_4pc = 393706
+        },
+        auras = {
+            strike_vulnerabilities = {
+                id = 394173,
+                duration = 6,
+                max_stack = 1
+            }
+        }
+    },
+    auras = {
+        lethal_blows = {
+            id = 455485,
+            duration = 12,
+            max_stack = 1
+        }
+    }
+} )
+
 local rageSpent = 0
 local gloryRage = 0
 
@@ -607,7 +677,6 @@ spec:RegisterCombatLogEvent( function( _, subtype, _,  sourceGUID, sourceName, _
     end
 end )
 
-
 local RAGE = Enum.PowerType.Rage
 local lastRage = -1
 
@@ -629,7 +698,6 @@ spec:RegisterUnitEvent( "UNIT_POWER_FREQUENT", "player", nil, function( event, u
     end
 end )
 
-
 spec:RegisterHook( "TimeToReady", function( wait, action )
     local id = class.abilities[ action ].id
     if buff.bladestorm.up and ( id < -99 or id > 0 ) then
@@ -647,7 +715,6 @@ end, state )
 local TriggerTestOfMight = setfenv( function()
     addStack( "test_of_might" )
 end, state )
-
 
 spec:RegisterHook( "reset_precast", function ()
     rage_spent = nil
@@ -690,64 +757,7 @@ spec:RegisterStateExpr( "cycle_for_execute", function ()
     return Hekili:GetNumTargetsBelowHealthPct( talent.massacre.enabled and 35 or 20, false, max( settings.cycle_min, offset + delay ) ) > 0
 end )
 
--- The War Within
-spec:RegisterGear( "tww2", 229235, 229233, 229238, 229236, 229234 )
-spec:RegisterAuras( {
-    -- 2-set
-    -- https://www.wowhead.com/ptr-2/spell=1216552/winning-streak
-    -- Mortal Strike and Cleave damage increased by 2%. = {
-    winning_streak = {
-        id = 1216552,
-        duration = 30,
-        max_stack = 10,
-        copy = "winning_streak_arms"
-    },
-    -- https://www.wowhead.com/ptr-2/spell=1216556/hedged-bets
-    -- Overpower damage increased by 20%and recharge rate increased by 75%.
-    hedged_bets = {
-        id = 1216556,
-        duration = 12,
-        max_stack = 1
-    },
-} )
 
-spec:RegisterGear( "tier29", 200426, 200428, 200423, 200425, 200427, 217218, 217220, 217216, 217217, 217219 )
-spec:RegisterSetBonuses( "tier29_2pc", 393705, "tier29_4pc", 393706 )
---(2) Set Bonus: Mortal Strike and Cleave damage and chance to critically strike increased by 10%.
---(4) Set Bonus: Mortal Strike, Cleave, & Execute critical strikes increase your damage and critical strike chance by 5% for 6 seconds.
-spec:RegisterAura( "strike_vulnerabilities", {
-    id = 394173,
-    duration = 6,
-    max_stack = 1
-} )
-
-spec:RegisterGear( "tier30", 202446, 202444, 202443, 202442, 202441 )
-spec:RegisterSetBonuses( "tier30_2pc", 405577, "tier30_4pc", 405578 )
---(2) Set Bonus: Deep Wounds increases your chance to critically strike and critical strike damage dealt to afflicted targets by 5%.
---(4) Deep Wounds critical strikes have a chance to increase the damage of your next Mortal Strike by 10% and cause it to deal
---    [(19.32% of Attack power) * 2] Physical damage to enemies in front of you, stacking up to 3 times. Damage reduced above 5 targets. (2s cooldown)
-spec:RegisterAura( "crushing_advance", {
-    id = 410138,
-    duration = 30,
-    max_stack = 3
-} )
-
-spec:RegisterGear( "tier31", 207180, 207181, 207182, 207183, 207185 )
-spec:RegisterSetBonuses( "tier31_2pc", 422923, "tier31_4pc", 422924 )
--- (4) Sudden Death also makes your next Execute powerfully slam the ground, causing a Thunder Clap that deals 100% increased damage. In addition, the Execute target bleeds for 50% of Execute's damage over 5 sec. If this bleed is reapplied, remaining damage is added to the new bleed.
-spec:RegisterAura( "finishing_wound", {
-    id = 426284,
-    duration = 5,
-    max_stack = 1
-} )
-
-spec:RegisterAuras( {
-    lethal_blows = {
-        id = 455485,
-        duration = 12,
-        max_stack = 1
-    }
-} )
 
 -- Abilities
 spec:RegisterAbilities( {

--- a/TheWarWithin/WarriorFury.lua
+++ b/TheWarWithin/WarriorFury.lua
@@ -113,14 +113,14 @@ spec:RegisterTalents( {
     berserker_shout              = {  90348, 384100, 1 }, -- Go berserk, removing and granting immunity to Fear, Sap, and Incapacitate effects for 6 sec. Also remove fear effects from group members within 12 yds.
     berserker_stance             = {  90325, 386196, 1 }, -- An aggressive combat state that increases the damage of your auto-attacks by 15% and reduces the duration of Fear, Sap and Incapacitate effects on you by 10%. Lasts until canceled.
     berserkers_torment           = {  90362, 390123, 1 }, -- Activating Avatar or Recklessness grants 8 sec of the other.
-    bitter_immunity              = {  90356, 383762, 1 }, -- Restores 20% health instantly and removes all diseases, poisons and curses affecting you. 
+    bitter_immunity              = {  90356, 383762, 1 }, -- Restores 20% health instantly and removes all diseases, poisons and curses affecting you.
     bounding_stride              = {  90355, 202163, 1 }, -- Reduces the cooldown of Heroic Leap by 15 sec, and Heroic Leap now also increases your movement speed by 70% for 3 sec.
     cacophonous_roar             = {  90383, 382954, 1 }, -- Intimidating Shout can withstand 200% more damage before breaking.
     champions_might              = {  90323, 386284, 1 }, -- The duration of Champion's Spear is increased by 2 sec. You deal 25% increased critical strike damage to targets chained to your Spear.
     champions_spear              = {  90380, 376079, 1 }, -- Throw a spear at the target location, dealing 43,399 Physical damage instantly and an additional 48,350 damage over 4 sec. Deals reduced damage beyond 5 targets. Enemies hit are chained to the spear's location for the duration. Generates 10 Rage.
     concussive_blows             = {  90354, 383115, 1 }, -- Cooldown of Pummel reduced by 1.0 sec. Successfully interrupting an enemy increases the damage you deal to them by 5% for 10 sec.
     crackling_thunder            = {  95959, 203201, 1 }, -- Thunder Clap's radius is increased by 50%, and it reduces movement speed by an additional 20%.
-    cruel_strikes                = {  90381, 392777, 2 }, -- Critical strike chance increased by 1% and critical strike damage of Execute increased by 5%. 
+    cruel_strikes                = {  90381, 392777, 2 }, -- Critical strike chance increased by 1% and critical strike damage of Execute increased by 5%.
     crushing_force               = {  90347, 382764, 2 }, -- Bloodthirst deals an additional 5% damage and deals 5% increased critical strike damage.
     defensive_stance             = {  92538, 386208, 1 }, -- A defensive combat state that reduces all damage you take by 15%, and all damage you deal by 10%. Lasts until canceled.
     double_time                  = {  90382, 103827, 1 }, -- Increases the maximum number of charges on Charge by 1, and reduces its cooldown by 3 sec.
@@ -183,7 +183,7 @@ spec:RegisterTalents( {
     invigorating_fury            = {  90393, 383468, 1 }, -- Enraged Regeneration lasts 3 sec longer and instantly heals for 10% of your maximum health.
     massacre                     = {  90410, 206315, 1 }, -- Execute is now usable on targets below 35% health, and its cooldown is reduced by 1.5 sec.
     meat_cleaver                 = {  90391, 280392, 1 }, -- Whirlwind and Thunder Clap deal 25% more damage and now affect your next 4 single-target melee attacks, instead of the next 2 attacks.
-    odyns_fury                   = {  90418, 385059, 1 }, -- Unleashes your power, dealing 81,570 Physical damage and an additional 39,272 Physical damage over 4 sec to all enemies within 12 yards. Deals reduced damage beyond 5 targets. Generates 15 Rage. 
+    odyns_fury                   = {  90418, 385059, 1 }, -- Unleashes your power, dealing 81,570 Physical damage and an additional 39,272 Physical damage over 4 sec to all enemies within 12 yards. Deals reduced damage beyond 5 targets. Generates 15 Rage.
     onslaught                    = {  90424, 315720, 1 }, -- Brutally attack an enemy for 75,074 Physical damage. Generates 30 Rage.
     powerful_enrage              = {  90398, 440277, 1 }, -- Enrage increases the damage your abilities deal by an additional 15% and Enrage's duration is increased by 1 sec.
     raging_blow                  = {  90396,  85288, 1 }, -- A mighty blow with both weapons that deals a total of 56,918 Physical damage. Raging Blow has a 25% chance to instantly reset its own cooldown. Generates 12 Rage.
@@ -197,12 +197,12 @@ spec:RegisterTalents( {
     sudden_death                 = {  90429, 280721, 1 }, -- Your attacks have a chance to reset the cooldown of Execute and make it usable on any target, regardless of their health.
     swift_strikes                = {  90416, 383459, 2 }, -- Haste increased by 1% and Raging Blow and Bloodthirst generate an additional 1 Rage.
     tenderize                    = {  90423, 388933, 1 }, -- Onslaught Enrages you, and if you have Slaughtering Strikes grants you 3 stacks of Slaughtering Strikes.
-    titanic_rage                 = {  90417, 394329, 1 }, -- Odyn's Fury's Enrages you, deals 10% increased damage and grants you 4 stacks of Whirlwind. 
+    titanic_rage                 = {  90417, 394329, 1 }, -- Odyn's Fury's Enrages you, deals 10% increased damage and grants you 4 stacks of Whirlwind.
     unbridled_ferocity           = {  90414, 389603, 1 }, -- Rampage has a 6% chance to grant Recklessness for 4 sec.
-    unhinged                     = {  90389, 386628, 1 }, -- Every other time Bladestorm or Ravager deal damage, you automatically cast a Bloodthirst at your target or random nearby enemy. 
+    unhinged                     = {  90389, 386628, 1 }, -- Every other time Bladestorm or Ravager deal damage, you automatically cast a Bloodthirst at your target or random nearby enemy.
     vicious_contempt             = {  90404, 383885, 2 }, -- Bloodthirst deals 25% increased damage to enemies who are below 35% health.
     warpaint                     = {  90394, 208154, 1 }, -- You take 10% reduced damage while Enrage is active.
-    wrath_and_fury               = {  90387, 392936, 1 }, -- Raging Blow deals 15% increased damage and while Enraged, Raging Blow has a 10% increased chance to instantly reset its own cooldown. 
+    wrath_and_fury               = {  90387, 392936, 1 }, -- Raging Blow deals 15% increased damage and while Enraged, Raging Blow has a 10% increased chance to instantly reset its own cooldown.
 
     -- Mountain Thane
     avatar_of_the_storm          = {  94805, 437134, 1 }, -- Casting Avatar grants you 2 charges of Thunder Blast and resets the cooldown of Thunder Clap. While Avatar is not active, Lightning Strikes have a 10% chance to grant you Avatar for 4 secs. Thunder Blast Your next Thunder Clap becomes a Thunder Blast that deals Stormstrike damage.
@@ -229,8 +229,8 @@ spec:RegisterTalents( {
     imminent_demise              = {  94788, 444769, 1 }, -- Every 3 Slayer's Strikes you gain Sudden Death. Using Sudden Death accelerates your next Bladestorm, striking 1 additional time (max 3). Bladestorm's total duration is unchanged.
     opportunist                  = {  94787, 444774, 1 }, -- When Raging Blow resets its own cooldown, your next Raging Blow deals 20% additional damage and 20% additional critical damage.
     overwhelming_blades          = {  94810, 444772, 1 }, -- Each strike of Bladestorm applies Overwhelmed to all enemies affected, increasing damage you deal to them by 1% for 20 sec, max 10 stacks.
-    reap_the_storm               = {  94809, 444775, 1 }, -- Bloodthirst has a 20% chance to cause you to unleash a flurry of steel, striking all nearby enemies for 51,783 damage and applying Overwhelmed. Deals reduced damage beyond 8 targets. 
-    relentless_pursuit           = {  94795, 444776, 1 }, -- Charge grants you 70% movement speed for 3 sec. Charge removes all movement impairing effects, this effect cannot occur more than once every 30 sec. 
+    reap_the_storm               = {  94809, 444775, 1 }, -- Bloodthirst has a 20% chance to cause you to unleash a flurry of steel, striking all nearby enemies for 51,783 damage and applying Overwhelmed. Deals reduced damage beyond 8 targets.
+    relentless_pursuit           = {  94795, 444776, 1 }, -- Charge grants you 70% movement speed for 3 sec. Charge removes all movement impairing effects, this effect cannot occur more than once every 30 sec.
     show_no_mercy                = {  94784, 444771, 1 }, -- Marked for Execution increases the critical strike chance and critical strike damage of your next Execute on the target by 15%.
     slayers_dominance            = {  94814, 444767, 1, "slayer" }, -- Your attacks against your primary target have a high chance to overwhelm their defenses and trigger a Slayer's Strike, dealing 60,496 damage and applying Marked for Execution, increasing the damage they take from your next Execute by 15%. Stacks 3 times.
     slayers_malice               = {  94801, 444779, 1 }, -- Raging Blow damage increased by 30%.
@@ -240,7 +240,7 @@ spec:RegisterTalents( {
 
 
 -- PvP Talents
-spec:RegisterPvpTalents( { 
+spec:RegisterPvpTalents( {
     battlefield_commander = 5629, -- (424742) Your Shout abilities have additional effects.  Battle Shout: Increases Stamina by 3%.  Piercing Howl: Radius increased by 50%  Berserker Shout: Range increased by 8 yds.  Intimidating Shout: Cooldown reduced by 15 sec.  Rallying Cry: Removes movement impairing effects and grants 30% movement speed to allies.  Thunderous Roar: Targets receive 5% more damage from all sources while bleeding.
     bodyguard             =  168, -- (213871) Protect an ally, causing 40% of all Physical damage they take to be transfered to you. When the target takes Physical damage, your Shield Slam cooldown has a 30% chance to be reset. Bodyguard is cancelled if the target is further than 20 yards from you. Lasts 1 min. Only one target can be Bodyguarded at a time.
     demolition            = 5374, -- (329033) Reduces the cooldown of your Shattering Throw or Wrecking Throw by 50% and increases its damage to absorb shields by an additional 250%.
@@ -535,100 +535,131 @@ spec:RegisterAuras( {
     },
 } )
 
--- The War Within
-spec:RegisterGear( "tww2", 229235, 229233, 229238, 229236, 229234 )
-spec:RegisterAuras( {
-    -- 2-set
-    -- https://www.wowhead.com/ptr-2/spell=1216561/winning-streak
-    -- Rampage damage increased by 2%.
-    winning_streak = {
-        id = 1216561,
-        duration = 30,
-        max_stack = 10,
-        copy = "winning_streak_fury"
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229235, 229233, 229238, 229236, 229234 },
+        auras = {
+            winning_streak = {
+                id = 1216561,
+                duration = 30,
+                max_stack = 10,
+                copy = "winning_streak_fury"
+            },
+            double_down_bt = {
+                id = 1216565,
+                duration = 12,
+                max_stack = 1
+            },
+            double_down_rb = {
+                id = 1216569,
+                duration = 12,
+                max_stack = 1
+            }
+        }
     },
-    -- https://www.wowhead.com/ptr-2/spell=1216565/double-down
-    -- Bloodthirst damage increased by 15% and critical strike chance increased by 25%.
-    double_down_bt = {
-        id = 1216565,
-        duration = 12,
-        max_stack = 1
+    -- Dragonflight
+    tier31 = {
+        items = { 207180, 207181, 207182, 207183, 207185 },
+        setBonuses = {
+            tier31_2pc = 422925,
+            tier31_4pc = 422926
+        },
+        auras = {
+            furious_bloodthirst = {
+                id = 423211,
+                duration = 20,
+                max_stack = 3
+            }
+        }
     },
-    --https://www.wowhead.com/ptr-2/spell=1216569/double-down
-    --Raging Blow damage increased by 15% and Rage generated increased by (w2 / 10).
-    double_down_rb = {
-        id = 1216569,
-        duration = 12,
-        max_stack = 1
+    tier30 = {
+        items = { 202446, 202444, 202443, 202442, 202441, 217218, 217220, 217216, 217217, 217219 },
+        setBonuses = {
+            tier30_2pc = 405579,
+            tier30_4pc = 405580
+        },
+        auras = {
+            merciless_assault = {
+                id = 409983,
+                duration = 14,
+                max_stack = 10
+            }
+        }
     },
+    tier29 = {
+        items = { 200426, 200428, 200423, 200425, 200427 },
+        setBonuses = {
+            tier29_2pc = 393708,
+            tier29_4pc = 393709
+        }
+    },
+    -- Legacy
+    tier21 = {
+        items = { 152178, 152179, 152180, 152181, 152182, 152183 },
+        auras = {
+            slaughter = {
+                id = 253384,
+                duration = 4
+            },
+            outrage = {
+                id = 253385,
+                duration = 8
+            }
+        }
+    },
+    tier20 = {
+        items = { 147187, 147188, 147189, 147190, 147191, 147192 },
+        auras = {
+            raging_thirst = {
+                id = 242300,
+                duration = 8
+            },
+            bloody_rage = {
+                id = 242952,
+                duration = 10,
+                max_stack = 10
+            }
+        }
+    },
+    ceannar_charger = { items = { 137088 } },
+    timeless_stratagem = { items = { 143728 } },
+    kazzalax_fujiedas_fury = {
+        items = { 137053 },
+        auras = {
+            fujiedas_fury = {
+                id = 207776,
+                duration = 10,
+                max_stack = 4
+            }
+        }
+    },
+    mannoroths_bloodletting_manacles = { items = { 137107 } },
+    najentuss_vertebrae = { items = { 137087 } },
+    valarjar_berserkers = { items = { 151824 } },
+    ayalas_stone_heart = {
+        items = { 137052 },
+        auras = {
+            stone_heart = {
+                id = 225947,
+                duration = 10
+            }
+        }
+    },
+    the_great_storms_eye = {
+        items = { 151823 },
+        auras = {
+            tornados_eye = {
+                id = 248142,
+                duration = 6,
+                max_stack = 6
+            }
+        }
+    },
+    archavons_heavy_hand = { items = { 137060 } },
+    weight_of_the_earth = { items = { 137077 } },
+    soul_of_the_battlelord = { items = { 151650 } }
 } )
-
--- Dragonflight
-spec:RegisterGear( "tier29", 200426, 200428, 200423, 200425, 200427 )
-spec:RegisterSetBonuses( "tier29_2pc", 393708, "tier29_4pc", 393709 )
-
-spec:RegisterGear( "tier30", 202446, 202444, 202443, 202442, 202441, 217218, 217220, 217216, 217217, 217219 )
-spec:RegisterSetBonuses( "tier30_2pc", 405579, "tier30_4pc", 405580 )
-spec:RegisterAura( "merciless_assault", {
-    id = 409983,
-    duration = 14,
-    max_stack = 10
-} )
-
-spec:RegisterGear( "tier31", 207180, 207181, 207182, 207183, 207185 )
-spec:RegisterSetBonuses( "tier31_2pc", 422925, "tier31_4pc", 422926 )
-spec:RegisterAura( "furious_bloodthirst", {
-    id = 423211,
-    duration = 20,
-    max_stack = 3
-} )
--- Legacy
-spec:RegisterGear( 'tier20', 147187, 147188, 147189, 147190, 147191, 147192 )
-    spec:RegisterAura( "raging_thirst", {
-        id = 242300,
-        duration = 8
-        } ) -- fury 2pc.
-    spec:RegisterAura( "bloody_rage", {
-        id = 242952,
-        duration = 10,
-        max_stack = 10
-        } ) -- fury 4pc.
-
-spec:RegisterGear( 'tier21', 152178, 152179, 152180, 152181, 152182, 152183 )
-    spec:RegisterAura( "slaughter", {
-        id = 253384,
-        duration = 4
-    } ) -- fury 2pc dot.
-    spec:RegisterAura( "outrage", {
-        id = 253385,
-        duration = 8
-    } ) -- fury 4pc.
-
-spec:RegisterGear( "ceannar_charger", 137088 )
-spec:RegisterGear( "timeless_stratagem", 143728 )
-spec:RegisterGear( "kazzalax_fujiedas_fury", 137053 )
-    spec:RegisterAura( "fujiedas_fury", {
-        id = 207776,
-        duration = 10,
-        max_stack = 4
-    } )
-spec:RegisterGear( "mannoroths_bloodletting_manacles", 137107 ) -- NYI.
-spec:RegisterGear( "najentuss_vertebrae", 137087 )
-spec:RegisterGear( "valarjar_berserkers", 151824 )
-spec:RegisterGear( "ayalas_stone_heart", 137052 )
-    spec:RegisterAura( "stone_heart", { id = 225947,
-        duration = 10
-    } )
-spec:RegisterGear( "the_great_storms_eye", 151823 )
-    spec:RegisterAura( "tornados_eye", {
-        id = 248142,
-        duration = 6,
-        max_stack = 6
-    } )
-spec:RegisterGear( "archavons_heavy_hand", 137060 )
-spec:RegisterGear( "weight_of_the_earth", 137077 ) -- NYI.
-
-spec:RegisterGear( "soul_of_the_battlelord", 151650 )
 
 state.IsActiveSpell = IsActiveSpell
 
@@ -706,7 +737,7 @@ spec:RegisterUnitEvent( "UNIT_POWER_FREQUENT", "player", nil, function( event, u
             end
             if state.legendary.glory.enabled and FindPlayerAuraByID( 324143 ) then
                 gloryRage = ( gloryRage + lastRage - current ) % 25
-            end 
+            end
         end
         lastRage = current
     end
@@ -1123,7 +1154,7 @@ spec:RegisterAbilities( {
         },
     },
 
-    
+
     champions_spear = {
         id = function() return talent.champions_spear.enabled and 376079 or 307865 end,
         cast = 0,
@@ -1748,8 +1779,8 @@ spec:RegisterAbilities( {
 
         -- Add usable check for Unrelenting Onslaught talent
         usable = function()
-            if buff.bladestorm.up and not talent.unrelenting_onslaught.enabled then 
-                return false, "can't use during bladestorm without unrelenting onslaught" 
+            if buff.bladestorm.up and not talent.unrelenting_onslaught.enabled then
+                return false, "can't use during bladestorm without unrelenting onslaught"
             end
             return true
         end,

--- a/TheWarWithin/WarriorProtection.lua
+++ b/TheWarWithin/WarriorProtection.lua
@@ -570,47 +570,66 @@ spec:RegisterAuras( {
     }
 } )
 
--- The War
-spec:RegisterGear( "tww2", 229235, 229233, 229238, 229236, 229234 )
-spec:RegisterAuras( {
--- 2-set
--- https://www.wowhead.com/ptr-2/spell=1218163/luck-of-the-draw
--- Each time you take damage you have a chance to cast Shield Wall for 4.0 sec and gain Luck of the Draw!, which increases your damage dealt by 15% for 10 sec.
-    luck_of_the_draw = {
-        id = 1218163,
-        duration = 10,
-        max_stack = 1,
+spec:RegisterGear({
+    -- The War Within
+    tww2 = {
+        items = { 229235, 229233, 229238, 229236, 229234 },
+        auras = {
+            luck_of_the_draw = {
+                id = 1218163,
+                duration = 10,
+                max_stack = 1
+            }
+        }
     },
-} )
-
--- Dragonflight
-spec:RegisterGear( "tier29", 200426, 200428, 200423, 200425, 200427 )
-spec:RegisterSetBonuses( "tier29_2pc", 393710, "tier29_4pc", 393711 ) -- Dragonflight Season 1
-spec:RegisterAura( "vanguards_determination", {
-    id = 394056,
-    duration = 5,
-    max_stack = 1,
-} )
-spec:RegisterGear( "tier30", 202446, 202444, 202443, 202442, 202441 )
-spec:RegisterSetBonuses( "tier30_2pc", 405581, "tier30_4pc", 405582 )
-spec:RegisterAura( "earthen_tenacity", {
-    id = 410218,
-    duration = 5,
-    max_stack = 1
-} )
-spec:RegisterGear( "tier31", 207180, 207181, 207182, 207183, 207185, 217218, 217220, 217216, 217217, 217219 )
-spec:RegisterSetBonuses( "tier31_2pc", 422927, "tier31_4pc", 422928 )
-spec:RegisterAuras( {
-    fervid = {
-        id = 425517,
-        duration = 10,
-        max_stack = 1
+    -- Dragonflight
+    tier31 = {
+        items = { 207180, 207181, 207182, 207183, 207185, 217218, 217220, 217216, 217217, 217219 },
+        setBonuses = {
+            tier31_2pc = 422927,
+            tier31_4pc = 422928
+        },
+        auras = {
+            fervid = {
+                id = 425517,
+                duration = 10,
+                max_stack = 1
+            },
+            fervid_opposition = {
+                id = 427413,
+                duration = 5,
+                max_stack = 1
+            }
+        }
     },
-    fervid_opposition = {
-        id = 427413,
-        duration = 5,
-        max_stack = 1
+    tier30 = {
+        items = { 202446, 202444, 202443, 202442, 202441 },
+        setBonuses = {
+            tier30_2pc = 405581,
+            tier30_4pc = 405582
+        },
+        auras = {
+            earthen_tenacity = {
+                id = 410218,
+                duration = 5,
+                max_stack = 1
+            }
+        }
     },
+    tier29 = {
+        items = { 200426, 200428, 200423, 200425, 200427 },
+        setBonuses = {
+            tier29_2pc = 393710,
+            tier29_4pc = 393711
+        },
+        auras = {
+            vanguards_determination = {
+                id = 394056,
+                duration = 5,
+                max_stack = 1
+            }
+        }
+    }
 } )
 
 local rageSpent_10 = 0


### PR DESCRIPTION
Convert RegisterGear to the new format ahead of the 11.2 branch, making it easy to insert the new tier sets.

Some specs were already done previously, so omitted here.