### PR TITLE
Wrong Discord Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If something isn’t working:
 ### ❓ Other Support
 
 - Review the [**Wiki**](https://github.com/Hekili/hekili/wiki)
-- Ask questions in the [**Hekili Discord**](https://discord.gg/3vRJx5g)
+- Ask questions in the [**Hekili Discord**](https://discord.gg/3cCTFxM)
 
 ---
 


### PR DESCRIPTION
Changed to be the permalink from discord read-first channel