### PR TITLE
11.2 - Hunter: Marksmanship

### DIFF
--- a/TheWarWithin/HunterMarksmanship.lua
+++ b/TheWarWithin/HunterMarksmanship.lua
@@ -39,167 +39,142 @@ spec:RegisterResource( Enum.PowerType.Focus, {
 
 -- Talents
 spec:RegisterTalents( {
+
     -- Hunter
-    better_together         = {  94962, 472357, 1 }, -- Howl of the Pack Leader's cooldown is reduced to 25 sec. Your pets gain an extra 5% of your attack power.
-    binding_shackles        = { 102388, 321468, 1 }, -- Targets stunned by Binding Shot, knocked back by High Explosive Trap, knocked up by Implosive Trap, incapacitated by Scatter Shot, or stunned by Intimidation deal 10% less damage to you for 8 sec after the effect ends.
-    binding_shot            = { 102386, 109248, 1 }, -- Fires a magical projectile, tethering the enemy and any other enemies within 5 yds for 10 sec, stunning them for 4 sec if they move more than 5 yds from the arrow. Targets stunned by Binding Shot deal 10% less damage to you for 8 sec after the effect ends.
-    blackrock_munitions     = { 102392, 462036, 1 }, -- The damage of Explosive Shot is increased by 8%.
-    born_to_be_wild         = { 102416, 266921, 1 }, -- Reduces the cooldowns of Aspect of the Cheetah, and Aspect of the Turtle by 30 sec.
-    bursting_shot           = { 102421, 186387, 1 }, -- Fires an explosion of bolts at all enemies in front of you, knocking them back, snaring them by 50% for 6 sec, and dealing 5,522 Physical damage.
-    camouflage              = { 102414, 199483, 1 }, -- You and your pet blend into the surroundings and gain stealth for 1 min. While camouflaged, you will heal for 2% of maximum health every 1 sec.
-    concussive_shot         = { 102407,   5116, 1 }, -- Dazes the target, slowing movement speed by 50% for 6 sec. Steady Shot will increase the duration of Concussive Shot on the target by 3.0 sec.
-    counter_shot            = { 102402, 147362, 1 }, -- Interrupts spellcasting, preventing any spell in that school from being cast for 3 sec.
-    deathblow               = { 102410, 343248, 1 }, -- Aimed Shot has a 10% chance to grant Deathblow.  Deathblow The cooldown of Kill Shot is reset. Your next Kill Shot can be used on any target, regardless of their current health.
-    devilsaur_tranquilizer  = { 102415, 459991, 1 }, -- If Tranquilizing Shot removes only an Enrage effect, its cooldown is reduced by 5 sec.
-    dire_summons            = {  94992, 472352, 1 }, -- Kill Command reduces the cooldown of Howl of the Pack Leader by 1.0 sec. Cobra Shot reduces the cooldown of Howl of the Pack Leader by 1.0 sec.
-    disruptive_rounds       = { 102395, 343244, 1 }, -- When Tranquilizing Shot successfully dispels an effect or Counter Shot interrupts a cast, gain 10 Focus.
-    emergency_salve         = { 102389, 459517, 1 }, -- Feign Death and Aspect of the Turtle removes poison and disease effects from you.
-    entrapment              = { 102403, 393344, 1 }, -- When Tar Trap is activated, all enemies in its area are rooted for 4 sec. Damage taken may break this root.
-    envenomed_fangs         = {  94972, 472524, 1 }, -- Initial damage from your Bear will consume Serpent Sting from up to 8 nearby targets, dealing 100% of its remaining damage instantly.
-    explosive_shot          = { 102420, 212431, 1 }, -- Fires an explosive shot at your target. After 3 sec, the shot will explode, dealing 329,144 Fire damage to all enemies within 8 yds. Deals reduced damage beyond 5 targets.
-    fury_of_the_wyvern      = {  94984, 472550, 1 }, -- Your pet's attacks increase your Wyvern's damage bonus by 1%, up to 10%. Casting Wildfire Bomb extends the duration of your Wyvern by 2.0 sec, up to 10 additional sec.
-    ghillie_suit            = { 102385, 459466, 1 }, -- You take 20% reduced damage while Camouflage is active. This effect persists for 3 sec after you leave Camouflage.
-    high_explosive_trap     = { 102739, 236776, 1 }, -- Hurls a fire trap to the target location that explodes when an enemy approaches, causing 44,960 Fire damage and knocking all enemies away. Limit 1. Trap will exist for 1 min. Targets knocked back by High Explosive Trap deal 10% less damage to you for 8 sec after being knocked back.
-    hogstrider              = {  94988, 472639, 1 }, -- Each time your Boar deals damage, you have a 25% chance to gain a stack of Mongoose Fury and Cobra Shot strikes 1 additional target. Stacks up to 4 times.
-    horsehair_tether        = {  94979, 472729, 1 }, -- When an enemy is stunned by Binding Shot, it is dragged to Binding Shot's center.
-    howl_of_the_pack_leader = {  94991, 471876, 1 }, -- While in combat, every 30 sec your next Kill Command summons the aid of a Beast.  Wyvern A Wyvern descends from the skies, letting out a battle cry that increases the damage of you and your pets by 10% for 15 sec.  Boar A Boar charges through your target 3 times, dealing 313,698 physical damage to the primary target and 125,479 damage to up to 8 nearby enemies.  Bear A Bear leaps into the fray, rending the flesh of your enemies, dealing 601,164 damage over 10 sec to up to 8 nearby enemies.
-    hunters_avoidance       = { 102423, 384799, 1 }, -- Damage taken from area of effect attacks reduced by 5%.
-    implosive_trap          = { 102739, 462031, 1 }, -- Hurls a fire trap to the target location that explodes when an enemy approaches, causing 44,960 Fire damage and knocking all enemies up. Limit 1. Trap will exist for 1 min. Targets knocked up by Implosive Trap deal 10% less damage to you for 8 sec after being knocked up.
-    improved_traps          = { 102418, 343247, 1 }, -- The cooldown of Tar Trap, High Explosive Trap, Implosive Trap, and Freezing Trap is reduced by 5.0 sec.
-    intimidation            = { 103990, 474421, 1 }, -- Your Spotting Eagle descends from the skies, stunning your target for 5 sec. Targets stunned by Intimidation deal 10% less damage to you for 8 sec after the effect ends. This ability does not require line of sight when used against players.
-    keen_eyesight           = { 102409, 378004, 2 }, -- Critical strike chance increased by 2%.
-    kill_shot               = { 102399,  53351, 1 }, -- You attempt to finish off a wounded target, dealing 358,594 Physical damage. Only usable on enemies with less than 20% health.
-    kindling_flare          = { 102425, 459506, 1 }, -- Flare's radius is increased by 50%.
-    kodo_tranquilizer       = { 102415, 459983, 1 }, -- Tranquilizing Shot removes up to 1 additional Magic effect from up to 2 nearby targets.
-    lead_from_the_front     = {  94966, 472741, 1 }, -- Casting Coordinated Assault grants Howl of the Pack Leader and increases the damage dealt by your Beasts by 25% and your pet by 0% for 12 sec.
-    lone_survivor           = { 102391, 388039, 1 }, -- Reduce the cooldown of Survival of the Fittest by 30 sec, and increase its duration by 2.0 sec. Reduce the cooldown of Counter Shot and Muzzle by 2 sec.
-    misdirection            = { 102419,  34477, 1 }, -- Misdirects all threat you cause to the targeted party or raid member, beginning with your next attack within 30 sec and lasting for 8 sec.
-    moment_of_opportunity   = { 102426, 459488, 1 }, -- When a trap triggers, you gain 30% movement speed for 3 sec. Can only occur every 1 min.
-    natural_mending         = { 102401, 270581, 1 }, -- Every 10 Focus you spend reduces the remaining cooldown on Exhilaration by 1.0 sec.
-    no_hard_feelings        = { 102412, 459546, 1 }, -- When Misdirection targets your pet, it reduces the damage they take by 50% for 5 sec. The cooldown of Misdirection is reduced by 5 sec.
-    no_mercy                = {  94969, 472660, 1 }, -- Damage from your Kill Shot sends your pets into a rage, causing all active pets within 20 yds and your Bear to pounce to the target and Smack, Claw, or Bite it. Your pets will not leap if their target is already in melee range.
-    pack_mentality          = {  94985, 472358, 1 }, -- Howl of the Pack Leader causes your Kill Command to generate an additional stack of Tip of the Spear. Summoning a Beast reduces the cooldown of Wildfire Bomb by 10.0 sec.
-    padded_armor            = { 102406, 459450, 1 }, -- Survival of the Fittest gains an additional charge.
-    pathfinding             = { 102404, 378002, 1 }, -- Movement speed increased by 4%.
-    posthaste               = { 102411, 109215, 1 }, -- Disengage also frees you from all movement impairing effects and increases your movement speed by 50% for 4 sec.
-    quick_load              = { 102413, 378771, 1 }, -- When you fall below 40% health, Bursting Shot and Scatter Shot have their cooldown immediately reset. This can only occur once every 25 sec.
-    rejuvenating_wind       = { 102381, 385539, 1 }, -- Maximum health increased by 8%, and Exhilaration now also heals you for an additional 12.0% of your maximum health over 8 sec.
-    roar_of_sacrifice       = { 102405,  53480, 1 }, -- Instructs your pet to protect a friendly target from critical strikes, making attacks against that target unable to be critical strikes. Lasts 12 sec. While Roar of Sacrifice is active, your Spotting Eagle cannot apply Spotter's Mark.
-    scare_beast             = { 102382,   1513, 1 }, -- Scares a beast, causing it to run in fear for up to 20 sec. Damage caused may interrupt the effect. Only one beast can be feared at a time.
-    scatter_shot            = { 102421, 213691, 1 }, -- A short-range shot that deals 4,672 damage, removes all harmful damage over time effects, and incapacitates the target for 4 sec. Any damage caused will remove the effect. Turns off your attack when used. Targets incapacitated by Scatter Shot deal 10% less damage to you for 8 sec after the effect ends.
-    scouts_instincts        = { 102424, 459455, 1 }, -- You cannot be slowed below 80% of your normal movement speed while Aspect of the Cheetah is active.
-    scrappy                 = { 102408, 459533, 1 }, -- Casting Aimed Shot reduces the cooldown of Intimidation and Binding Shot by 0.5 sec.
-    serrated_tips           = { 102384, 459502, 1 }, -- You gain 5% more critical strike from critical strike sources.
-    shell_cover             = {  94967, 472707, 1 }, -- When dropping below 60% health, summon the aid of a Turtle, reducing the damage you take by 10% for 6 sec. This effect can only occur once every 1.5 min.
-    slicked_shoes           = {  94979, 472719, 1 }, -- When Disengage removes a movement impairing effect, its cooldown is reduced by 4 sec.
-    specialized_arsenal     = { 102390, 459542, 1 }, -- Aimed Shot deals 10% increased damage.
-    survival_of_the_fittest = { 102422, 264735, 1 }, -- Reduces all damage you and your pet take by 30% for 8 sec.
-    tar_trap                = { 102393, 187698, 1 }, -- Hurls a tar trap to the target location that creates a 8 yd radius pool of tar around itself for 30 sec when the first enemy approaches. All enemies have 50% reduced movement speed while in the area of effect. Limit 1. Trap will exist for 1 min.
-    tarcoated_bindings      = { 102417, 459460, 1 }, -- Binding Shot's stun duration is increased by 1 sec.
-    territorial_instincts   = { 102394, 459507, 1 }, -- The cooldown of Intimidation is reduced by 10 sec.
-    trailblazer             = { 102400, 199921, 1 }, -- Your movement speed is increased by 30% anytime you have not attacked for 3 sec.
-    tranquilizing_shot      = { 102380,  19801, 1 }, -- Removes 1 Enrage and 1 Magic effect from an enemy target. Successfully dispelling an effect generates 10 Focus.
-    trigger_finger          = { 102396, 459534, 2 }, -- You and your pet have 5.0% increased attack speed. This effect is increased by 100% if you do not have an active pet.
-    unnatural_causes        = { 102387, 459527, 1 }, -- Your damage over time effects deal 10% increased damage. This effect is increased by 50% on targets below 20% health.
-    ursine_fury             = {  94972, 472476, 1 }, -- Your Bear's periodic damage has a 10% chance to reduce the cooldown of Butchery or Flanking Strike by 2.0 sec.
-    wilderness_medicine     = { 102383, 343242, 1 }, -- Natural Mending now reduces the cooldown of Exhilaration by an additional 0.5 sec Mend Pet heals for an additional 25% of your pet's health over its duration, and has a 25% chance to dispel a magic effect each time it heals your pet.
+    binding_shackles               = { 102388,  321468, 1 }, -- Targets stunned by Binding Shot, knocked back by High Explosive Trap, knocked up by Implosive Trap, incapacitated by Scatter Shot, or stunned by Intimidation deal $s1% less damage to you for $s2 sec after the effect ends
+    binding_shot                   = { 102386,  109248, 1 }, -- Fires a magical projectile, tethering the enemy and any other enemies within $s1 yds for $s2 sec, stunning them for $s3 sec if they move more than $s4 yds from the arrow
+    blackrock_munitions            = { 102392,  462036, 1 }, -- The damage of Explosive Shot is increased by $s2%$s$s3 Pet damage bonus of Harmonize increased by $s4%
+    born_to_be_wild                = { 102416,  266921, 1 }, -- The cooldown of Aspect of the Cheetah, and Aspect of the Turtle are reduced by $s1 sec
+    bursting_shot                  = { 102421,  186387, 1 }, -- Fires an explosion of bolts at all enemies in front of you, knocking them back, snaring them by $s2% for $s3 sec, and dealing $s$s4 Physical damage
+    camouflage                     = { 102414,  199483, 1 }, -- You and your pet blend into the surroundings and gain stealth for $s1 min. While camouflaged, you will heal for $s2% of maximum health every $s3 sec
+    concussive_shot                = { 102407,    5116, 1 }, -- Dazes the target, slowing movement speed by $s1% for $s2 sec. Steady Shot will increase the duration of Concussive Shot on the target by $s3 sec
+    counter_shot                   = { 102402,  147362, 1 }, -- Interrupts spellcasting, preventing any spell in that school from being cast for $s1 sec
+    deathblow                      = { 102410,  343248, 1 }, -- Aimed Shot has a $s1% chance to grant Deathblow.  Deathblow The cooldown of Black Arrow is reset. Your next Black Arrow can be used on any target, regardless of their current health
+    devilsaur_tranquilizer         = { 102415,  459991, 1 }, -- If Tranquilizing Shot removes only an Enrage effect, its cooldown is reduced by $s1 sec
+    disruptive_rounds              = { 102395,  343244, 1 }, -- When Tranquilizing Shot successfully dispels an effect or Counter Shot interrupts a cast, gain $s1 Focus
+    emergency_salve                = { 102389,  459517, 1 }, -- Feign Death and Aspect of the Turtle removes poison and disease effects from you
+    entrapment                     = { 102403,  393344, 1 }, -- When Tar Trap is activated, all enemies in its area are rooted for $s1 sec. Damage taken may break this root
+    explosive_shot                 = { 102420,  212431, 1 }, -- Fires an explosive shot at your target. After $s2 sec, the shot will explode, dealing $s$s3 Fire damage to all enemies within $s4 yds. Deals reduced damage beyond $s5 targets
+    ghillie_suit                   = { 102385,  459466, 1 }, -- You take $s1% reduced damage while Camouflage is active. This effect persists for $s2 sec after you leave Camouflage
+    harmonize                      = { 102420, 1245926, 1 }, -- All pet damage dealt increased by $s1%
+    high_explosive_trap            = { 102739,  236776, 1 }, -- Hurls a fire trap to the target location that explodes when an enemy approaches, causing $s$s2 Fire damage and knocking all enemies away. Limit $s3. Trap will exist for $s4 min
+    hunters_avoidance              = { 102423,  384799, 1 }, -- Damage taken from area of effect attacks reduced by $s1%
+    implosive_trap                 = { 102739,  462031, 1 }, -- Hurls a fire trap to the target location that explodes when an enemy approaches, causing $s$s2 Fire damage and knocking all enemies up. Limit $s3. Trap will exist for $s4 min
+    improved_traps                 = { 102418,  343247, 1 }, -- The cooldown of Tar Trap, High Explosive Trap, Implosive Trap, and Freezing Trap is reduced by $s1 sec
+    intimidation                   = { 103990,  474421, 1 }, -- Your Spotting Eagle descends from the skies, stunning your target for $s1 sec. This ability does not require line of sight when used against players
+    keen_eyesight                  = { 102409,  378004, 2 }, -- Critical strike chance increased by $s1%
+    kill_shot                      = { 102399,   53351, 1 }, -- You attempt to finish off a wounded target, dealing $s$s2 Physical damage. Only usable on enemies with less than $s3% health
+    kindling_flare                 = { 102425,  459506, 1 }, -- Flare's radius is increased by $s1%
+    kodo_tranquilizer              = { 102415,  459983, 1 }, -- Tranquilizing Shot removes up to $s1 additional Magic effect from up to $s2 nearby targets
+    lone_survivor                  = { 102391,  388039, 1 }, -- The cooldown of Survival of the Fittest is reduced by $s1 sec, and its duration is increased by $s2 sec. The cooldown of Counter Shot is reduced by $s3 sec
+    misdirection                   = { 102419,   34477, 1 }, -- Misdirects all threat you cause to the targeted party or raid member, beginning with your next attack within $s1 sec and lasting for $s2 sec
+    moment_of_opportunity          = { 102426,  459488, 1 }, -- When a trap triggers, you gain $s1% movement speed for $s2 sec
+    natural_mending                = { 102401,  270581, 1 }, -- Every $s1 Focus you spend reduces the remaining cooldown on Exhilaration by $s2 sec
+    no_hard_feelings               = { 102412,  459546, 1 }, -- When Misdirection targets your pet, it reduces the damage they take by $s1% for $s2 sec. The cooldown of Misdirection is reduced by $s3 sec
+    padded_armor                   = { 102406,  459450, 1 }, -- Survival of the Fittest gains an additional charge
+    pathfinding                    = { 102404,  378002, 1 }, -- Movement speed increased by $s1%
+    posthaste                      = { 102411,  109215, 1 }, -- Disengage also frees you from all movement impairing effects and increases your movement speed by $s1% for $s2 sec
+    quick_load                     = { 102413,  378771, 1 }, -- When you fall below $s1% health, Bursting Shot and Scatter Shot have their cooldown immediately reset. This can only occur once every $s2 sec
+    rejuvenating_wind              = { 102381,  385539, 1 }, -- Maximum health increased by $s1%, and Exhilaration now also heals you for an additional $s2% of your maximum health over $s3 sec
+    roar_of_sacrifice              = { 102405,   53480, 1 }, -- Instructs your pet to protect a friendly target from critical strikes, making attacks against that target unable to be critical strikes. Lasts $s1 sec. While Roar of Sacrifice is active, your Spotting Eagle cannot apply Spotter's Mark
+    scare_beast                    = { 102382,    1513, 1 }, -- Scares a beast, causing it to run in fear for up to $s1 sec. Damage caused may interrupt the effect. Only one beast can be feared at a time
+    scatter_shot                   = { 102421,  213691, 1 }, -- A short-range shot that deals $s2 damage, removes all harmful damage over time effects, and incapacitates the target for $s3 sec$s$s4 Any damage caused will remove the effect. Turns off your attack when used
+    scouts_instincts               = { 102424,  459455, 1 }, -- You cannot be slowed below $s1% of your normal movement speed while Aspect of the Cheetah is active
+    scrappy                        = { 102408,  459533, 1 }, -- Casting Aimed Shot reduces the cooldown of Intimidation and Binding Shot by $s1 sec
+    serrated_tips                  = { 102384,  459502, 1 }, -- You gain $s1% more critical strike from critical strike sources
+    specialized_arsenal            = { 102390,  459542, 1 }, -- Aimed Shot deals $s1% increased damage
+    survival_of_the_fittest        = { 102422,  264735, 1 }, -- Reduces all damage you and your pet take by $s1% for $s2 sec
+    tar_trap                       = { 102393,  187698, 1 }, -- Hurls a tar trap to the target location that creates a $s1 yd radius pool of tar around itself for $s2 sec when the first enemy approaches. All enemies have $s3% reduced movement speed while in the area of effect. Limit $s4. Trap will exist for $s5 min
+    tarcoated_bindings             = { 102417,  459460, 1 }, -- Binding Shot's stun duration is increased by $s1 sec
+    territorial_instincts          = { 102394,  459507, 1 }, -- The cooldown of Intimidation is reduced by $s1 sec
+    trailblazer                    = { 102400,  199921, 1 }, -- Your movement speed is increased by $s1% anytime you have not attacked for $s2 sec
+    tranquilizing_shot             = { 102380,   19801, 1 }, -- Removes $s1 Enrage and $s2 Magic effect from an enemy target. Successfully dispelling an effect generates $s3 Focus
+    trigger_finger                 = { 102396,  459534, 2 }, -- You and your pet have $s1% increased attack speed. This effect is increased by $s2% if you do not have an active pet
+    unnatural_causes               = { 102387,  459527, 1 }, -- Your damage over time effects deal $s1% increased damage. This effect is increased by $s2% on targets below $s3% health
+    wilderness_medicine            = { 102383,  343242, 1 }, -- Natural Mending now reduces the cooldown of Exhilaration by an additional $s1 sec Mend Pet heals for an additional $s2% of your pet's health over its duration, and has a $s3% chance to dispel a magic effect each time it heals your pet
 
     -- Marksmanship
-    aimed_shot              = { 103982,  19434, 1 }, -- A powerful aimed shot that deals 553,260 Physical damage.
-    ammo_conservation       = { 103975, 459794, 1 }, -- Rapid Fire shoots 3 additional shots. Aimed Shot cooldown reduced by 1.0 sec.
-    aspect_of_the_hydra     = { 103957, 470945, 1 }, -- Aimed Shot, Rapid Fire, and Arcane Shot now hit a second nearby target for 40% of their damage.
-    bullet_hell             = { 104095, 473378, 1 }, -- Damage from Multi-Shot and Volley reduces the cooldown of Rapid Fire by 0.25 sec. Damage from Aimed Shot reduces the cooldown of Volley by 0.25 sec.
-    bulletstorm             = { 103962, 389019, 1 }, -- Damage from Rapid Fire increases the damage of Aimed Shot by 2% for 15 sec, stacking up to 15 times. New stacks do not refresh duration and are removed upon casting Rapid Fire.
-    bullseye                = { 103950, 204089, 2 }, -- When your abilities damage a target below 20% health, you gain 1% increased critical strike chance for 6 sec, stacking up to 15 times.
-    calling_the_shots       = { 103958, 260404, 1 }, -- Consuming Spotter's Mark reduces the cooldown of Trueshot by 3.0 sec.
-    cunning                 = { 103986, 474440, 1 }, -- Your Spotting Eagle gains the Cunning specialization, granting you Master's Call and Pathfinding.  Master's Call Your pet removes all root and movement impairing effects from itself and a friendly target, and grants immunity to all such effects for 4 sec.  Pathfinding Your movement speed is increased by 8%.
-    deadeye                 = { 103972, 321460, 1 }, -- Kill Shot now has 2 charges and has its cooldown reduced by 2.0 sec.
-    double_tap              = { 103953, 473370, 1 }, -- Casting Trueshot or Volley grants Double Tap, causing your next Aimed Shot to fire again at 80% power, or your next Rapid Fire to fire 80% additional shots during its channel.
-    eagles_accuracy         = { 103973, 473369, 2 }, -- Aimed Shot and Rapid Fire's damage is increased by 5.0%.
-    feathered_frenzy        = { 103984, 470943, 1 }, -- Trueshot sends your Spotting Eagle into a frenzy, instantly applying Spotter's Mark to your target. During Trueshot, your chance to apply Spotter's Mark is increased by 100%.
-    focused_aim             = { 103987, 378767, 1 }, -- Consuming Precise Shots reduces the cooldown of Aimed Shot by 0.75 sec.
-    headshot                = { 103972, 471363, 1 }, -- Kill Shot can now benefit from Precise Shots at 25% effectiveness. Kill Shot consumes Precise Shots.
-    improved_deathblow      = { 103969, 378769, 1 }, -- Aimed Shot now has a 15% chance and Rapid Fire now has a 25% chance to grant Deathblow. Kill Shot critical strike damage is increased by 25%.  Deathblow The cooldown of Kill Shot is reset. Your next Kill Shot can be used on any target, regardless of their current health.
-    improved_spotters_mark  = { 104127, 466867, 1 }, -- The damage bonus of Spotter's Mark is increased by 20%.  Spotter's Mark Damaging an enemy with abilities empowered by Precise Shots has a 30% chance to apply Spotter's Mark to the primary target, causing your next Aimed Shot to deal 30% increased damage to the target.
-    improved_streamline     = { 103987, 471427, 1 }, -- Streamline's cast time reduction effect is increased to 30%.
-    in_the_rhythm           = { 103948, 407404, 1 }, -- When Rapid Fire finishes channeling, the time between your Auto Shots is reduced by 1.0 sec for 12 sec.
-    incendiary_ammunition   = { 103985, 471428, 1 }, -- Bulletstorm now increases your critical strike damage by 2%. Additionally, Bulletstorm now stacks 5 more times.
-    kill_zone               = { 103960, 459921, 1 }, -- Your spells and attacks deal 8% increased damage and ignore line of sight against any target in your Volley.
-    killer_mark             = { 104096, 1215032, 1 }, -- Spotter's Mark now additionally increases the critical strike chance of Aimed Shot by 15%.
-    lock_and_load           = { 103988, 194595, 1 }, -- Your ranged auto attacks have a 8% chance to trigger Lock and Load, causing your next Aimed Shot to cost no Focus and be instant.
-    magnetic_gunpowder      = { 103981, 473522, 1 }, -- Consuming Precise Shots reduces the cooldown of Explosive Shot by 2.0 sec. Consuming Lock and Load reduces the cooldown of Explosive Shot by 8.0 sec.
-    master_marksman         = { 103974, 260309, 1 }, -- Your ranged ability critical strikes cause the target to bleed for an additional 15% of the damage dealt over 6 sec.
-    moving_target           = { 103980, 474296, 1 }, -- Consuming Precise Shots increases the damage of your next Aimed Shot by 20% and grants Streamline.  Streamline Your next Aimed Shot has its Focus cost and cast time reduced by 20%. Stacks up to 2 times.
-    no_scope                = { 103955, 473385, 1 }, -- Rapid Fire grants Precise Shots.
-    obsidian_arrowhead      = { 103959, 471350, 1 }, -- The damage of Auto Shot is increased by 25% and its critical strike chance is increased by 15%.
-    ohnahran_winds          = { 103979, 1215021, 1 }, -- When your Eagle applies Spotter's Mark, it has a 25% chance to apply a Spotter's Mark to up to 3 additional nearby enemies.
-    on_target               = { 103959, 471348, 1 }, -- Consuming Spotter's Mark grants 4% increased Haste for 10 sec, stacking up to 4 times. Multiple instances of this effect can overlap.
-    penetrating_shots       = { 104130, 459783, 1 }, -- Gain critical strike damage equal to 40% of your critical strike chance.
-    precise_shots           = { 103977, 260240, 1 }, -- Aimed Shot causes your next Arcane Shot or Multi-Shot to deal 80% more damage and cost 70% less Focus. Your Auto Shot damage is increased by 100% but the time between your Auto Shots is increased by 2.0 sec.
-    precision_detonation    = { 103949, 471369, 1 }, -- Casting Explosive Shot grants Streamline. When Aimed Shot damages a target affected by your Explosive Shot, Explosive Shot instantly explodes, dealing 25% increased damage.  Streamline Your next Aimed Shot has its Focus cost and cast time reduced by 20%. Stacks up to 2 times.
-    quickdraw               = { 103963, 473380, 1 }, -- Lock and Load now increases the damage of Aimed Shot by 15%.
-    rapid_fire              = { 103961, 257044, 1 }, -- Shoot a stream of 10 shots at your target over 1.7 sec, dealing a total of 803,344 Physical damage. Usable while moving. Rapid Fire causes your next Aimed Shot to cast 20% faster. Each shot generates 2 Focus.
-    razor_fragments         = { 103965, 384790, 1 }, -- After gaining Deathblow, your next Kill Shot will deal 75% increased damage, and shred up to 5 targets near your Kill Shot target for 35% of the damage dealt by Kill Shot over 6 sec.
-    salvo                   = { 103960, 400456, 1 }, -- Volley now also applies Explosive Shot to up to 2 targets hit.
-    shrapnel_shot           = { 104126, 473520, 1 }, -- Damaging an enemy with Explosive Shot increases the damage they receive from your next Arcane Shot or Multi-Shot by 30%.
-    small_game_hunter       = { 103978, 459802, 1 }, -- Multi-Shot deals 75% increased damage and Explosive Shot deals 15% increased damage.
-    streamline              = { 103983, 260367, 1 }, -- Rapid Fire's damage is increased by 15%. Casting Rapid Fire grants Streamline.  Streamline Your next Aimed Shot has its Focus cost and cast time reduced by 20%. Stacks up to 2 times.
-    surging_shots           = { 103964, 391559, 1 }, -- Rapid Fire deals 35% additional damage, and Aimed Shot has a 15% chance to reset the cooldown of Rapid Fire.
-    target_acquisition      = { 103968, 473379, 1 }, -- Consuming Spotter's Mark reduces the cooldown of Aimed Shot by 2.0 sec.
-    tenacious               = { 103986, 474456, 1 }, -- Your Spotting Eagle gains the Tenacity specialization, granting you Endurance Training and Air Superiority.  Endurance Training You gain 5% increased maximum health.  Air Superiority Your Spotting Eagle alerts you to oncoming danger, reducing all damage you take by 3%
-    tensile_bowstring       = { 103966, 471366, 1 }, -- While Trueshot is active, consuming Precise Shots extends Trueshot's duration by 1.0 sec, up to 5.0 sec. Additionally, Trueshot now increases the effectiveness of Streamline by 50%.
-    trick_shots             = { 103957, 257621, 1 }, -- When Multi-Shot hits 3 or more targets, your next Aimed Shot or Rapid Fire will ricochet and hit up to 5 additional targets for 75% of normal damage.
-    trueshot                = { 103947, 288613, 1 }, -- Increases your critical strike chance by 20% and critical strike damage by 30% for 15 sec. Reduces the cooldown of your Aimed Shot and Rapid Fire by 60%. Consuming Spotter's Mark reduces the cooldown of Trueshot by 3.0 sec
-    unbreakable_bond        = { 104127, 1223323, 1 }, -- Regain access to Call Pet. While outdoors, your pet deals 15% increased damage and takes 15% reduced damage.
-    unerring_vision         = { 103953, 474738, 1 }, -- Trueshot now increases your critical strike chance by an additional 10% and increases your critical strike damage by an additional 20%. Additionally, Calling the Shots reduces Trueshot's cooldown by an additional 1.0 sec.
-    volley                  = { 103956, 260243, 1 }, -- Rain a volley of arrows down over 6 sec, dealing up to 754,054 Physical damage to any enemy in the area, and gain the effects of Trick Shots for as long as Volley is active.
-    windrunner_quiver       = { 103952, 473523, 1 }, -- Precise Shots can now stack up to 2 times, but its damage bonus is reduced to 80%. Casting Aimed Shot has a 50% chance to grant an additional stack of Precise Shots.
+    aimed_shot                     = { 103982,   19434, 1 }, -- A powerful aimed shot that deals $s$s2 Physical damage
+    ammo_conservation              = { 103975,  459794, 1 }, -- Rapid Fire shoots $s1 additional shots. Aimed Shot cooldown reduced by $s2 sec
+    aspect_of_the_hydra            = { 103957,  470945, 1 }, -- Aimed Shot, Rapid Fire, and Arcane Shot now hit $s1 additional target for $s2% of their damage
+    avian_specialization           = { 104127,  466867, 1 }, -- The damage bonus of Spotter's Mark is increased by $s1%. Additionally, your Eagle learns how to Fetch.  Spotter's Mark Damaging an enemy with abilities empowered by Precise Shots has a $s4% chance to apply Spotter's Mark to the primary target, causing your next Aimed Shot to deal $s5% increased damage to the target
+    bullet_hell                    = { 104095,  473378, 1 }, -- Damage from Multi-Shot and Volley reduces the cooldown of Rapid Fire by $s1 sec. Damage from Aimed Shot reduces the cooldown of Volley by $s2 sec
+    bulletstorm                    = { 103962,  389019, 1 }, -- Damage from Rapid Fire increases the damage of Aimed Shot by $s1% for $s2 sec, stacking up to $s3 times. New stacks do not refresh duration and are removed upon casting Rapid Fire
+    bullseye                       = { 103985,  204089, 1 }, -- When your abilities damage a target below $s1% health, you gain $s2% increased critical strike chance for $s3 sec, stacking up to $s4 times
+    calling_the_shots              = { 103958,  260404, 1 }, -- Trueshot's cooldown is reduced by $s1 sec
+    cunning                        = { 103986,  474440, 1 }, -- Your Spotting Eagle gains the Cunning specialization, granting you Master's Call and Pathfinding.  Master's Call Your pet removes all root and movement impairing effects from itself and a friendly target, and grants immunity to all such effects for $s3 sec.  Pathfinding Your movement speed is increased by $s6%
+    deadeye                        = { 103972,  321460, 1 }, -- Black Arrow now has $s1 charges and has its cooldown reduced by $s2 sec
+    double_tap                     = { 103953,  473370, 1 }, -- Casting Trueshot or Volley grants Double Tap, causing your next Aimed Shot to fire again at $s1% power, or your next Rapid Fire to fire $s2% additional shots during its channel
+    eagles_accuracy                = { 103973,  473369, 2 }, -- Aimed Shot and Rapid Fire's damage is increased by $s1%
+    feathered_frenzy               = { 103984,  470943, 1 }, -- Trueshot sends your Spotting Eagle into a frenzy, instantly applying Spotter's Mark to your target. During Trueshot, your chance to apply Spotter's Mark is increased by $s1%
+    focused_aim                    = { 103987,  378767, 1 }, -- Consuming Precise Shots reduces the cooldown of Aimed Shot by $s1 sec
+    headshot                       = { 103972,  471363, 1 }, -- Black Arrow can now benefit from Precise Shots at $s1% effectiveness. Black Arrow consumes Precise Shots
+    improved_deathblow             = { 103969,  378769, 1 }, -- Aimed Shot now has a $s1% chance and Rapid Fire now has a $s2% chance to grant Deathblow. Black Arrow critical strike damage is increased by $s3%.  Deathblow The cooldown of Black Arrow is reset. Your next Black Arrow can be used on any target, regardless of their current health
+    improved_streamline            = { 103987,  471427, 1 }, -- Streamline's cast time reduction effect is increased to $s1%
+    in_the_rhythm                  = { 103948,  407404, 1 }, -- When Rapid Fire finishes channeling, the time between your Auto Shots is reduced by $s1 sec for $s2 sec
+    incendiary_ammunition          = { 107290,  471428, 1 }, -- Bulletstorm now increases your critical strike damage by $s1%. Additionally, Bulletstorm now stacks $s2 more times
+    kill_zone                      = { 103960,  459921, 1 }, -- Your spells and attacks deal $s1% increased damage and ignore line of sight against any target in your Volley
+    light_ammo                     = { 107288,  378913, 1 }, -- Trick Shots now causes Aimed Shot and Rapid Fire to ricochet to $s1 additional targets. Aspect of the Hydra's damage bonus is increased by $s2%
+    lock_and_load                  = { 107289,  194595, 1 }, -- Your ranged auto attacks have a $s1% chance to trigger Lock and Load, causing your next Aimed Shot to cost no Focus and be instant
+    magnetic_gunpowder             = { 103981,  473522, 1 }, -- Consuming Precise Shots reduces the cooldown of Explosive Shot by $s1 sec. Consuming Lock and Load reduces the cooldown of Explosive Shot by $s2 sec
+    master_marksman                = { 103974,  260309, 1 }, -- Your ranged ability critical strikes cause the target to bleed for an additional $s1% of the damage dealt over $s2 sec
+    moving_target                  = { 103980,  474296, 1 }, -- Consuming Precise Shots increases the damage of your next Aimed Shot by $s1% and grants Streamline.  Streamline Your next Aimed Shot has its Focus cost and cast time reduced by $s4%. Stacks up to $s5 times
+    no_scope                       = { 103955,  473385, 1 }, -- Rapid Fire grants Precise Shots
+    obsidian_arrowhead             = { 103959,  471350, 1 }, -- The damage of Auto Shot is increased by $s1% and its critical strike chance is increased by $s2%
+    ohnahran_winds                 = { 103979, 1215021, 1 }, -- When your Eagle applies Spotter's Mark, it has a $s1% chance to apply a Spotter's Mark to up to $s2 additional nearby enemy at $s3% effectiveness
+    on_target                      = { 103959,  471348, 1 }, -- Consuming Spotter's Mark grants $s1% increased Haste for $s2 sec, stacking up to $s3 times. Multiple instances of this effect can overlap
+    penetrating_shots              = { 104130,  459783, 1 }, -- Gain critical strike damage equal to $s1% of your critical strike chance
+    precise_shots                  = { 103977,  260240, 1 }, -- Aimed Shot causes your next Arcane Shot or Multi-Shot to deal $s1% more damage, cost $s2% less Focus, and have its global cooldown reduced by $s3%. Your Auto Shot damage is increased by $s4% but the time between your Auto Shots is increased by $s5 sec
+    precision_detonation           = { 103949,  471369, 1 }, -- When Aimed Shot damages a target affected by your Explosive Shot, Explosive Shot instantly explodes, dealing $s1% increased damage
+    rapid_fire                     = { 103961,  257044, 1 }, -- Shoot a stream of $s1 shots at your target over $s2 sec, dealing a total of $s3 million Physical damage. Usable while moving. Rapid Fire causes your next Aimed Shot to cast $s4% faster. Each shot generates $s5 Focus
+    razor_fragments                = { 103965,  384790, 1 }, -- After gaining Deathblow, your next Black Arrow will deal $s1% increased damage, and shred up to $s2 targets near your Black Arrow target for $s3% of the damage dealt by Black Arrow over $s4 sec
+    salvo                          = { 103960,  400456, 1 }, -- Volley now also applies Explosive Shot to up to $s1 targets hit
+    shrapnel_shot                  = { 104126,  473520, 1 }, -- Casting Explosive Shot has a $s1% chance to grant Lock and Load
+    small_game_hunter              = { 103978,  459802, 1 }, -- Multi-Shot deals $s1% increased damage and Explosive Shot deals $s2% increased damage
+    streamline                     = { 103983,  260367, 1 }, -- Rapid Fire's damage is increased by $s1%. Casting Rapid Fire grants Streamline.  Streamline Your next Aimed Shot has its Focus cost and cast time reduced by $s4%. Stacks up to $s5 times
+    surging_shots                  = { 103964,  391559, 1 }, -- Rapid Fire deals $s1% additional damage, and Aimed Shot has a $s2% chance to reset the cooldown of Rapid Fire
+    target_acquisition             = { 103968,  473379, 1 }, -- Consuming Spotter's Mark reduces the cooldown of Aimed Shot by $s1 sec
+    tenacious                      = { 103986,  474456, 1 }, -- Your Spotting Eagle gains the Tenacity specialization, granting you Endurance Training and Air Superiority.  Endurance Training You gain $s3% increased maximum health.  Air Superiority Your Spotting Eagle alerts you to oncoming danger, reducing all damage you take by $s6%
+    tensile_bowstring              = { 103966,  471366, 1 }, -- While Trueshot is active, consuming Precise Shots extends Trueshot's duration by $s1 sec, up to $s2 sec. Additionally, Trueshot now increases the effectiveness of Streamline by $s3%
+    trick_shots                    = { 103957,  257621, 1 }, -- When Multi-Shot hits $s1 or more targets, your next Aimed Shot or Rapid Fire will ricochet and hit up to $s2 additional targets for $s3% of normal damage
+    trueshot                       = { 103947,  288613, 1 }, -- Increases your critical strike chance by $s1% and critical strike damage by $s2% for $s3 sec. Reduces the cooldown of your Aimed Shot and Rapid Fire by $s4%
+    unbreakable_bond               = { 104127, 1223323, 1 }, -- Regain access to Call Pet. While outdoors, your pet deals $s1% increased damage and takes $s2% reduced damage
+    unerring_vision                = { 103958,  474738, 1 }, -- Trueshot now increases your critical strike chance by an additional $s1% and increases your critical strike damage by an additional $s2%
+    unmatched_precision            = { 103950, 1232955, 2 }, -- The damage bonus of Precise Shots is increased by an additional $s1%
+    volley                         = { 103956,  260243, 1 }, -- Rain a volley of arrows down over $s1 sec, dealing up to $s2 million Physical damage to any enemy in the area, and gain the effects of Trick Shots for as long as Volley is active
+    windrunner_quiver              = { 103952,  473523, 1 }, -- Precise Shots can now stack up to $s1 times, but its damage bonus is reduced to $s2%. Casting Aimed Shot has a $s3% chance to grant an additional stack of Precise Shots
 
     -- Dark Ranger
-    banshees_mark           = {  94957, 467902, 1 }, -- Murder of Crows now deals Shadow damage. Black Arrow's initial damage has a 25% chance to summon a Murder of Crows on your target.  A Murder of Crows
-    black_arrow             = {  94987, 466932, 1, "dark_ranger" }, -- Your Kill Shot is replaced with Black Arrow.  Black Arrow You attempt to finish off a wounded target, dealing 358,172 Shadow damage and 35,873 Shadow damage over 10 sec. Only usable on enemies above 80% health or below 20% health.
-    bleak_arrows            = {  94961, 467749, 1 }, -- Your auto shot now deals Shadow damage, allowing it to bypass armor. Your auto shot has a 8% chance to grant Deathblow.  Deathblow The cooldown of Kill Shot is reset. Your next Kill Shot can be used on any target, regardless of their current health.
-    bleak_powder            = {  94974, 467911, 1 }, -- Casting Black Arrow while Trick Shots is active causes Black Arrow to explode upon hitting its target, dealing 323,501 Shadow damage to other nearby enemies.
-    dark_chains             = {  94960, 430712, 1 }, -- While in combat, Disengage will chain the closest target to the ground, causing them to move 40% slower until they move 8 yards away.
-    ebon_bowstring          = {  94986, 467897, 1 }, -- Casting Black Arrow has a 15% chance to grant Deathblow.  Deathblow The cooldown of Kill Shot is reset. Your next Kill Shot can be used on any target, regardless of their current health.
-    embrace_the_shadows     = {  94959, 430704, 1 }, -- You heal for 15% of all Shadow damage dealt by you or your pets.
-    phantom_pain            = {  94986, 467941, 1 }, -- When Aimed Shot deals damage, 8% of the damage dealt is replicated to each other unit affected by Black Arrow.
-    shadow_dagger           = {  94960, 467741, 1 }, -- While in combat, Disengage releases a fan of shadow daggers, dealing 392 Shadow damage per second and reducing affected target's movement speed by 30% for 6 sec.
-    shadow_hounds           = {  94983, 430707, 1 }, -- Each time Black Arrow deals damage, you have a small chance to manifest a Dark Hound to charge to your target and deal Shadow damage to nearby targets for 8 sec.
-    shadow_surge            = {  94982, 467936, 1 }, -- Periodic damage from Black Arrow has a small chance to erupt in a burst of darkness, dealing 117,821 Shadow damage to all enemies near the target. Damage reduced beyond 8 targets.
-    smoke_screen            = {  94959, 430709, 1 }, -- Exhilaration grants you 3 sec of Survival of the Fittest. Survival of the Fittest activates Exhilaration at 50% effectiveness.
-    soul_drinker            = {  94983, 469638, 1 }, -- When an enemy affected by Black Arrow dies, you have a 10% chance to gain Deathblow.  Deathblow The cooldown of Kill Shot is reset. Your next Kill Shot can be used on any target, regardless of their current health.
-    the_bell_tolls          = {  94968, 467644, 1 }, -- Black Arrow is now usable on enemies with greater than 80% health or less than 20% health.
-    withering_fire          = {  94993, 466990, 1 }, -- While Trueshot is active, you surrender to darkness, granting you Deathblow. Casting Black Arrow while under the effects of Withering Fire causes you to additionally fire a barrage of 2 additional Black Arrows at nearby targets at 50% effectiveness.
+    banshees_mark                  = {  94957,  467902, 1 }, -- Black Arrow's initial damage has a $s2% chance to summon a flock of crows to attack your target, dealing $s$s3 Shadow damage over $s4 sec
+    black_arrow                    = {  94987,  466932, 1 }, -- Your Kill Shot is replaced with Black Arrow.  Black Arrow You attempt to finish off a wounded target, dealing $s$s5 Shadow damage and $s$s6 Shadow damage over $s7 sec. Only usable on enemies above $s8% health or below $s9% health
+    bleak_arrows                   = {  94961,  467749, 1 }, -- Your auto shot now deals Shadow damage, allowing it to bypass armor. Your auto shot has a $s1% chance to grant Deathblow.  Deathblow The cooldown of Black Arrow is reset. Your next Black Arrow can be used on any target, regardless of their current health
+    bleak_powder                   = {  94974,  467911, 1 }, -- Black Arrow now explodes in a cloud of shadow and sulfur on impact, dealing $s$s2 Shadow damage to all enemies within an $s3 yd cone behind the target. Damage reduced beyond $s4 targets
+    dark_chains                    = {  94960,  430712, 1 }, -- While in combat, Disengage will chain the closest target to the ground, causing them to move $s1% slower until they move $s2 yards away
+    ebon_bowstring                 = {  94986,  467897, 1 }, -- Casting Black Arrow has a $s1% chance to grant Deathblow.  Deathblow The cooldown of Black Arrow is reset. Your next Black Arrow can be used on any target, regardless of their current health
+    phantom_pain                   = {  94986,  467941, 1 }, -- When Aimed Shot deals damage, $s1% of the damage dealt is replicated to up to $s2 other units affected by Black Arrow's periodic damage
+    shadow_dagger                  = {  94960,  467741, 1 }, -- While in combat, Disengage releases a fan of shadow daggers, dealing $s$s2 Shadow damage per second and reducing affected target's movement speed by $s3% for $s4 sec
+    shadow_hounds                  = {  94983,  430707, 1 }, -- Each time Black Arrow deals damage, you have a small chance to manifest a Dark Hound that charges to your target and attacks nearby enemies for $s1 sec
+    smoke_screen                   = {  94959,  430709, 1 }, -- Exhilaration grants you $s1 sec of Survival of the Fittest. Survival of the Fittest activates Exhilaration at $s2% effectiveness
+    soul_drinker                   = {  94983,  469638, 1 }, -- Black Arrow damage increased by $s1%. Bleak Powder damage increased by $s2%
+    the_bell_tolls                 = {  94968,  467644, 1 }, -- Firing a Black Arrow increases all damage dealt by $s1% for $s2 sec. Multiple instances of this effect may overlap
+    umbral_reach                   = {  94982, 1235397, 1 }, -- Black Arrow periodic damage increased by $s1% and Bleak Powder now applies Black Arrow's periodic effect to all enemies it damages. If Bleak Powder damages $s2 or more enemies, gain Trick Shots if talented
+    withering_fire                 = {  94993,  466990, 1 }, -- While Trueshot is active, you surrender to darkness, granting you Withering Fire and Deathblow.  Withering Fire Casting Black Arrow fires a barrage of $s3 additional Black Arrows at nearby targets at $s4% effectiveness, prioritizing enemies that aren't affected by Black Arrow's damage over time effect
 
     -- Sentinel
-    catch_out               = {  94990, 451516, 1 }, -- When a target affected by Sentinel deals damage to you, they are rooted for 3 sec. May only occur every 1 min per target.
-    crescent_steel          = {  94980, 451530, 1 }, -- Targets you damage below 20% health gain a stack of Sentinel every 3 sec.
-    dont_look_back          = {  94989, 450373, 1 }, -- Each time Sentinel deals damage to an enemy you gain an absorb shield equal to 1.0% of your maximum health, up to 10%.
-    extrapolated_shots      = {  94973, 450374, 1 }, -- When you apply Sentinel to a target not affected by Sentinel, you apply 1 additional stack.
-    eyes_closed             = {  94970, 450381, 1 }, -- For 8 sec after activating Trueshot, all abilities are guaranteed to apply Sentinel.
-    invigorating_pulse      = {  94971, 450379, 1 }, -- Each time Sentinel deals damage to an enemy it has an up to 15% chance to generate 5 Focus. Chances decrease with each additional Sentinel currently imploding applied to enemies.
-    lunar_storm             = {  94978, 450385, 1 }, -- Every 30 sec your next Rapid Fire launches a celestial arrow that conjures a 12 yd radius Lunar Storm at the target's location dealing 104,729 Arcane damage. For the next 12 sec, a random enemy affected by Sentinel within your Lunar Storm gets struck for 98,184 Arcane damage every 0.4 sec. Any target struck by this effect takes 10% increased damage from you and your pet for 8 sec.
-    overwatch               = {  94980, 450384, 1 }, -- All Sentinel debuffs implode when a target affected by more than 3 stacks of your Sentinel falls below 20% health. This effect can only occur once every 15 sec per target.
-    release_and_reload      = {  94958, 450376, 1 }, -- When you apply Sentinel on a target, you have a 15% chance to apply a second stack.
-    sentinel                = {  94976, 450369, 1, "sentinel" }, -- Your attacks have a chance to apply Sentinel on the target, stacking up to 10 times. While Sentinel stacks are higher than 3, applying Sentinel has a chance to trigger an implosion, causing a stack to be consumed on the target every sec to deal 84,588 Arcane damage.
-    sentinel_precision      = {  94981, 450375, 1 }, -- Aimed Shot and Rapid Fire deal 5% increased damage.
-    sentinel_watch          = {  94970, 451546, 1 }, -- Whenever a Sentinel deals damage, the cooldown of Trueshot is reduced by 1 sec, up to 15 sec.
-    sideline                = {  94990, 450378, 1 }, -- When Sentinel starts dealing damage, the target is snared by 40% for 3 sec.
-    symphonic_arsenal       = {  94965, 450383, 1 }, -- Multi-Shot discharges arcane energy from all targets affected by your Sentinel, dealing 30,350 Arcane damage to up to 5 targets within 8 yds of your Sentinel targets.
-} )
-
--- PvP Talents
-spec:RegisterPvpTalents( {
-    aspect_of_the_fox      = 5700, -- (1219162)
-    chimaeral_sting        =  653, -- (356719) Stings the target, dealing 117,636 Nature damage and initiating a series of venoms. Each lasts 3 sec and applies the next effect after the previous one ends.  Scorpid Venom: 90% reduced movement speed.  Spider Venom: Silenced.  Viper Venom: 20% reduced damage and healing.
-    consecutive_concussion = 5440, -- (357018)
-    diamond_ice            = 5533, -- (203340)
-    explosive_powder       = 5688, -- (1218150)
-    hunting_pack           = 3729, -- (203235)
-    rangers_finesse        =  659, -- (248443)
-    snipers_advantage      =  660, -- (1217102) Trueshot and Volley increase the range of all shots by 30% for their duration.
-    survival_tactics       =  651, -- (202746)
+    catch_out                      = {  94990,  451516, 1 }, -- When a target affected by Sentinel deals damage to you, they are rooted for $s1 sec. May only occur every $s2 min per target
+    crescent_steel                 = {  94980,  451530, 1 }, -- Targets you damage below $s1% health gain a stack of Sentinel every $s2 sec
+    dont_look_back                 = {  94989,  450373, 1 }, -- Each time Sentinel deals damage to an enemy you gain an absorb shield equal to $s1% of your maximum health, up to $s2%
+    extrapolated_shots             = {  94973,  450374, 1 }, -- When you apply Sentinel to a target not affected by Sentinel, you apply $s1 additional stack
+    eyes_closed                    = {  94970,  450381, 1 }, -- For $s1 sec after activating Trueshot, all abilities are guaranteed to apply Sentinel
+    invigorating_pulse             = {  94971,  450379, 1 }, -- Each time Sentinel deals damage to an enemy it has an up to $s1% chance to generate $s2 Focus. Chances decrease with each additional Sentinel currently imploding applied to enemies
+    lunar_storm                    = {  94978,  450385, 1 }, -- Every $s3 sec, the cooldown of Rapid Fire is reset and your next cast of Rapid Fire also fires a celestial arrow that conjures a $s4 yd radius Lunar Storm at the target's location, dealing $s$s5 Arcane damage. For the next $s6 sec, a random enemy affected by Sentinel within your Lunar Storm gets struck for $s$s7 Arcane damage every $s8 sec. Any target struck by this effect takes $s9% increased damage from you for $s10 sec
+    overwatch                      = {  94980,  450384, 1 }, -- All Sentinel debuffs implode when a target affected by more than $s1 stacks of your Sentinel falls below $s2% health. This effect can only occur once every $s3 sec per target
+    release_and_reload             = {  94958,  450376, 1 }, -- When you apply Sentinel on a target, you have a $s1% chance to apply a second stack
+    sentinel                       = {  94976,  450369, 1 }, -- Your attacks have a chance to apply Sentinel on the target, stacking up to $s2 times. While Sentinel stacks are higher than $s3, applying Sentinel has a chance to trigger an implosion, causing a stack to be consumed on the target every sec to deal $s$s4 Arcane damage
+    sentinel_precision             = {  94981,  450375, 1 }, -- Aimed Shot and Rapid Fire deal $s1% increased damage
+    sentinel_watch                 = {  94970,  451546, 1 }, -- Whenever a Sentinel deals damage, the cooldown of Trueshot is reduced by $s1 sec, up to $s2 sec
+    sideline                       = {  94990,  450378, 1 }, -- When Sentinel starts dealing damage, the target is snared by $s1% for $s2 sec
+    symphonic_arsenal              = {  94965,  450383, 1 }, -- Multi-Shot discharges arcane energy from all targets affected by your Sentinel, dealing $s$s2 Arcane damage to up to $s3 targets within $s4 yds of your Sentinel targets
 } )
 
 -- Auras
@@ -294,7 +269,7 @@ spec:RegisterAuras( {
     bullseye = {
         id = 204090,
         duration = 6,
-        max_stack = function() return 15 * talent.bullseye.rank end,
+        max_stack = 30
     },
     -- Talent: Movement speed reduced by $s4%.
     -- https://wowhead.com/beta/spell=186387
@@ -648,12 +623,6 @@ spec:RegisterAuras( {
         tick_time = 3,
         max_stack = 1,
     },
-    -- https://www.wowhead.com/spell=474310
-    shrapnel_shot = {
-        id = 474310,
-        duration = 12,
-        max_stack = 1,
-    },
     -- Movement slowed by $w1%.
     sideline = {
         id = 450845,
@@ -790,7 +759,13 @@ spec:RegisterAuras( {
 
 
 spec:RegisterStateExpr( "trick_shots", function ()
-    return buff.trick_shots.up or buff.volley.up or false
+    -- Internal Expression to return target count for spells that interact with Trick Shots
+    if buff.trick_shots.up or buff.volley.up then
+        return min( 6 + ( 2 * talent.light_ammo.rank ), active_enemies )
+    elseif talent.aspect_of_the_hydra.enabled then
+        min ( 2, active_enemies )
+    else return 1 end
+
 end )
 
 
@@ -821,12 +796,38 @@ spec:RegisterStateTable( "tar_trap", setmetatable( {}, {
     end
 } ) )
 
-spec:RegisterGear({
+
+
+spec:RegisterGear( {
     -- The War Within
+    tww3 = {
+        items = { 237644, 237645, 237646, 237647, 237649 },
+        auras = {
+            -- Dark Ranger
+            blighted_quiver = {
+                id = 1236975,
+                duration = 3600,
+                max_stack = 10
+            },
+            -- Sentinel
+            boon_of_elune_consumable = {
+                id = 1236644,
+                duration = 20,
+                max_stack = 2
+            },
+            boon_of_elune_storm = {
+                id = 1249464,
+                duration = 12,
+                max_stack = 1
+            },
+        }
+    },
     tww2 = {
         items = { 229271, 229269, 229274, 229272, 229270 },
         auras = {
             -- 2-set
+            -- https://www.wowhead.com/spell=1218033
+            -- Jackpot! Auto shot damage increased by 200% and the time between auto shots is reduced by 0.5 sec.
             jackpot = {
                 id = 1218033,
                 duration = 10,
@@ -888,6 +889,7 @@ local SpottersMarkConsumer = setfenv( function ( max_targets )
     if talent.calling_the_shots.enabled then reduceCooldown( "trueshot", trueshotCDR * markConsumptions ) end
     if talent.target_acquisition.enabled then reduceCooldown( "aimed_shot", 2 * markConsumptions ) end
     if talent.on_target.enabled then addStack( "on_target", nil, markConsumptions ) end
+    setCooldown( "global_cooldown", ( cooldown.global_cooldown.remains / 2 ) )
 
 end, state )
 
@@ -921,7 +923,17 @@ local PreciseShotsConsumer = setfenv( function ()
     removeBuff( "precise_shots" )
 end, state )
 
+local LunarStormCycle = setfenv( function()
+    applyBuff( "lunar_storm_ready" )
+    setCooldown( "rapid_fire", 0 )
+end, state )
+
 spec:RegisterHook( "reset_precast", function ()
+
+    if buff.lunar_storm_cooldown.up then
+        state:QueueAuraEvent( "lunar_storm_cooldown", LunarStormCycle, buff.lunar_storm_cooldown.expires, "AURA_EXPIRATION" )
+    end
+
     if debuff.tar_trap.up then
         debuff.tar_trap.expires = debuff.tar_trap.applied + 30
     end
@@ -955,12 +967,13 @@ spec:RegisterAbilities( {
         cooldown = function () return haste * 12 * ( buff.trueshot.up and 0.4 or 1 ) - ( 1 * talent.ammo_conservation.rank ) end,
         recharge = function () return haste * 12 * ( buff.trueshot.up and 0.4 or 1 ) - ( 1 * talent.ammo_conservation.rank ) end,
         gcd = "spell",
-        school = "physical",
+        school = function() if set_bonus.tww3>=2 and buff.boon_of_elune_consumable.up or set_bonus.tww3>=4 and buff.boon_of_elune_storm.up then return "arcane"
+        else return "physical" end end,
 
         cycle_to = true,
         cycle = "spotters_mark",
 
-        max_targets = function() return ( trick_shots and min( 6, active_enemies ) ) or ( talent.aspect_of_the_hydra.enabled and min ( 2, active_enemies ) ) or 1 end,
+        max_targets = trick_shots,
 
         spend = function ()
             if buff.lock_and_load.up or buff.secrets_of_the_unblinking_vigil.up then return 0 end
@@ -982,13 +995,14 @@ spec:RegisterAbilities( {
             -- Simple buffs
             removeDebuff( "target", "spotters_mark" )
             removeBuff ( "moving_target" )
+            if set_bonus.tww2 >= 2 then removeStack( "boon_of_elune_consumable" ) end
             if talent.precise_shots.enabled then addStack( "precise_shots", nil, 1 + talent.windrunner_quiver.rank ) end
             if debuff.spotters_mark.up then SpottersMarkConsumer( action.aimed_shot.max_targets ) end
 
             if buff.lock_and_load.up then
-                removeBuff( "lock_and_load" )
                 if talent.magnetic_gunpowder.enabled then reduceCooldown( "explosive_shot", 8 ) end
                 if set_bonus.tww2 >= 4 then spec.abilities.explosive_shot.handler() end
+                removeBuff( "lock_and_load" ) -- prevent infinite buffs by removing this after
             else
                 removeBuff( "streamline" )
             end
@@ -1027,7 +1041,8 @@ spec:RegisterAbilities( {
         cooldown = 0,
         gcd = "spell",
         school = "arcane",
-        max_targets = function() return ( trick_shots and min( 6, active_enemies ) ) or ( talent.aspect_of_the_hydra.enabled and min ( 2, active_enemies ) ) or 1 end,
+        max_targets = function() if talent.aspect_of_the_hydra.enabled then return min ( 2, active_enemies )
+        else return 1 end end,
 
         spend = function () return  40  * ( buff.precise_shots.up and 0.6 or 1 ) * ( buff.trueshot.up and legendary.eagletalons_true_focus.enabled and 0.75 or 1 ) end,
         spendType = "focus",
@@ -1281,6 +1296,7 @@ spec:RegisterAbilities( {
             -- It does technically trigger the explosion, but we just need to model the debuff presence
             applyDebuff( "target", "explosive_shot", debuff.explosive_shot.remains + spec.auras.explosive_shot.duration )
             if talent.precision_detonation.enabled then addStack( "streamline" ) end
+            if talent.shrapnel_shot.enabled then applyBuff( "lock_and_load" ) end
         end,
     },
 
@@ -1431,7 +1447,7 @@ spec:RegisterAbilities( {
         gcd = "spell",
         school = "physical",
 
-        max_targets = function() return ( trick_shots and min( 6, active_enemies ) ) or ( talent.aspect_of_the_hydra.enabled and min ( 2, active_enemies ) ) or 1 end,
+        max_targets = trick_shots,
         shots = function() return ( 7 + 3 * talent.ammo_conservation.rank ) * ( buff.double_tap.up and 1.8 or 1 ) end,
 
         talent = "rapid_fire",
@@ -1449,7 +1465,7 @@ spec:RegisterAbilities( {
         end,
 
         start = function ()
-            if talent.bulletstorm.enabled and trick_shots then
+            if talent.bulletstorm.enabled then
                 addStack( "bulletstorm", nil, action.rapid_fire.max_targets * action.rapid_fire.shots )
             end
             if talent.lunar_storm.enabled and buff.lunar_storm_ready.up then
@@ -1515,7 +1531,7 @@ spec:RegisterAbilities( {
     trueshot = {
         id = 288613,
         cast = 0,
-        cooldown = 120,
+        cooldown = function() return 120 - ( talent.calling_the_shots.enabled and 30 or 0 ) - ( set_bonus.tww3 >=2 and hero_tree.dark_ranger and 30 or 0 ) end,
         gcd = "off",
         school = "physical",
 
@@ -1545,11 +1561,11 @@ spec:RegisterAbilities( {
 
         end,
 
-        meta = {
+        --[[meta = {
             duration_guess = function( t )
                 return ( t.duration - ( 15 * talent.sentinel_watch.rank) - ( 15 * talent.calling_the_shots.rank ) )
             end,
-        }
+        }--]]
     },
 
     -- Talent: Rain a volley of arrows down over $d, dealing up to ${$260247s1*12} Physical damage to any enemy in the area, and gain the effects of Trick Shots for as long as Volley is active.
@@ -1576,6 +1592,9 @@ spec:RegisterAbilities( {
                     if active_enemies > 1 then active_dot.explosive_shot = min( true_active_enemies, active_dot.explosive_shot + 1 ) end
                 else
                    active_dot.explosive_shot = min( true_active_enemies, active_dot.explosive_shot + 2 )
+                end
+                if talent.shrapnel_shot.enabled then
+                    applyBuff( "lock_and_load" )
                 end
             end
 

--- a/TheWarWithin/HunterMarksmanship.lua
+++ b/TheWarWithin/HunterMarksmanship.lua
@@ -1556,6 +1556,9 @@ spec:RegisterAbilities( {
                 applyBuff ( "withering_fire" )
                 applyBuff( "deathblow" )
                 gainCharges( "black_arrow", 1 )
+                if set_bonus.tww2 >= 4 then
+                    removeBuff( "blighted_quiver" )
+                end
             end
             if talent.feathered_frenzy.enabled then applyDebuff( "target", "spotters_mark" ) end
 


### PR DESCRIPTION
# Notes
### List of Blizz 11.2 Patch Notes in Chronological Order
- [x] [June 19](https://www.wowhead.com/news/patch-11-2-ghosts-of-karesh-ptr-development-notes-377345)
- [x] [June 24](https://www.wowhead.com/news/patch-11-2-ptr-development-notes-for-june-24th-new-and-reworked-tier-bonuses-377461)
- [x] [July 3](https://www.wowhead.com/news/patch-11-2-ptr-development-notes-and-class-tuning-unholy-dk-bursting-sores-hard-377622)
- [x] [July 8](https://www.wowhead.com/news/patch-11-2-development-notes-for-july-8th-class-and-tier-set-tuning-377687)
- [x] [July 10](https://www.wowhead.com/news/additional-patch-11-2-ptr-development-notes-rogue-and-warlock-buffs-377719)
- [x] [July 14](https://www.wowhead.com/news/patch-11-2-ptr-development-notes-more-class-tuning-377757)
# Hunter 11.2 Changes
- [x] **New Talent: Harmonize**  
  - Pet damage increased by 4% (choice node with Explosive Shot).  
  _Dev note: Explosive Shot hasn’t found a great home in Beast Mastery’s kit, so we’re offering an opportunity to trade it for some pet damage._
- [x] **Blackrock Munitions**  
  - Now also increases the pet-damage bonus of Harmonize by 2%.
- [x] **Moment of Opportunity**  
  - Remove internal cooldown.
## Hero Talent Specific Changes
### Dark Ranger
- [x] **Bleak Powder**  
  - Now deals reduced damage beyond 8 targets.
- [x] Reposition several talents.
- [x] **New Talent: Umbral Reach**  
  - Black Arrow periodic damage ↑ 100%.  
  - Bleak Powder now applies Black Arrow’s periodic effect to each enemy it damages.  
  - If Bleak Powder damages ≥ 2 enemies, gain Beast Cleave/Trick Shots (if talented).  
  _Dev note: Making Black Arrow’s periodic damage effect easier to apply should make Phantom Pain substantially easier to use._
- [x] **The Bell Tolls**  
  - Now baseline on Black Arrow: casting Black Arrow increases all you & pet damage by 3% for 12 s (can overlap).
- [x] **Soul Drinker**  
  - Black Arrow damage ↑ 15%; Bleak Powder damage ↑ 20%.
- [x] **Withering Fire**  
  - Now prioritizes targets **without** Black Arrow’s periodic effect.
- [x] Black Arrow’s periodic damage is now a rolling periodic.
- [x] Dark Hounds no longer have a chance to summon alongside Dire Beasts.
- [x] Black Arrow damage ↑ 20% for **Beast Mastery** only.
- [x] Phantom Pain share ↑ 20% for Beast Mastery; ↑ 30% for Marksmanship.
- [x] **Removed Talents**:  
  - Embrace the Shadows  
  - Shadow Surge
- [x] **Manaforge Omega 2-Set (Hunter Dark Ranger 11.2 Class Set 2pc)**  
  - Beast Mastery: Black Arrow arrow damage ↑ 10% and Bleak Powder damage ↑ 20%; Call of the Wild cooldown ↓ 60 s.  
  - Marksmanship & Survival: Black Arrow arrow damage ↑ 10% and Bleak Powder damage ↑ 20%; Trueshot cooldown ↓ 30 s.
- [x] **Manaforge Omega 4-Set (Hunter Dark Ranger 11.2 Class Set 4pc)**  
  - Withering Fire’s Black Arrow damage ↑ 50% (was 25%).  
  - Consuming Deathblow has a 50% chance (all specs) to cause all Black Arrow barrages during your next Withering Fire to fire 1 additional Black Arrow.
### Sentinel
- [x] **Lunar Storm**  
  - Reset cooldowns of Rapid Fire and Wildfire Bomb immediately when Lunar Storm becomes available.  
  _Dev note: Reduces cognitive load and adds excitement._
- [x] **Manaforge Omega 2-Set (Hunter Sentinel 11.2 Class Set 2pc)**  
  - Marksmanship: Rapid Fire damage ↑ 25%; when Lunar Storm fades, gain Boon of Elune—next 2 Aimed Shots deal Arcane damage and +20%.  
  - Beast Mastery & Survival: Wildfire Bomb damage ↑ 10%; when Lunar Storm fades, gain Boon of Elune—next 2 Wildfire Bombs deal Arcane damage and initial damage ↑ 150%.
- [x] **Manaforge Omega 4-Set (Hunter Sentinel 11.2 Class Set 4pc)**  
  - Sentinel’s damage ↑ 25%.  
  - Boon of Elune now remains active for the duration of Lunar Storm at 100% effectiveness (no extra-stack activation).
## Marksmanship
### General
- [x] New Talent Skeleton
- [x] Season 3 Tier Set
  - [x] Item IDs
  - [x] 2-set Auras and Interactions if applicable
  - [x] 4-set Auras and Interactions if applicable
### Spec Changes
- [x] Reposition many talents.
- [x] **New Talent: Unmatched Precision**  
  - Precise Shots damage bonus ↑ 20% / 40%.
- [x] **Shrapnel Shot** (redesigned): Explosive Shot has a 100% chance to grant Lock and Load.  
  _Dev note: Aiming for Liberation of Undermine–style gameplay._
- [x] **Avian Specialization** (formerly Improved Spotter’s Mark)  
  - Now also teaches your Eagle to Fetch loot.
- [x] **Precise Shots**  
  - Now also reduces global cooldown of affected spells by 50%.  
  _Dev note: Makes Precise Shots feel snappier._
- [x] **Kill Zone**  
  - Line-of-sight bypass lingers 3 s after removal.
- [x] **Light Ammo** (returned)  
  - Now also increases Aspect of the Hydra damage bonus by 15%.
- [x] **Calling the Shots**  
  - Trueshot cooldown ↓ 30 s.  
  _Dev note: Simplifies and improves consistency._
- [x] **Ohn’ahran Winds**  
  - Eagle’s Spotter’s Mark now 100% to one additional nearby enemy at full effectiveness.  
  _Dev note: Increases consistency._
- [x] **Moving Target**  
  - Aimed Shot bonus ↓ 8%.  
  _Dev note: Shifts some power into baseline Aimed Shot._
- [x] Aimed Shot damage ↑ 10%.
- [x] Lock and Load trigger chance ↑ 10% (was 8%); now has bad-luck protection.
- [x] Precision Detonation bonus ↑ 40% (was 25%).
- [x] Unerring Vision no longer affects Calling the Shots.
- [x] Combine Calling the Shots & Unerring Vision into a choice node.
- [x] Bullseye is no longer a 2-point node.
- [x] Fix targeting issues with Ohn’ahran Winds.
- [x] **Removed Talents**:  
  - Killer Mark  
  - Quickdraw