### PR TITLE
Update APL locations

### DIFF
--- a/TheWarWithin/Priorities/DeathKnightBlood.simc
+++ b/TheWarWithin/Priorities/DeathKnightBlood.simc
@@ -1,3 +1,4 @@
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/deathknight_blood.simc
 ## 152154b
 ## 2025-04-29
 

--- a/TheWarWithin/Priorities/DeathKnightFrost.simc
+++ b/TheWarWithin/Priorities/DeathKnightFrost.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/commits/thewarwithin/ActionPriorityLists/deathknight_frost.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/deathknight_frost.simc
 ## Up to date with SimC: March 5 2025 - 04347cf
 
 ## Evaluates a trinkets cooldown, divided by pillar of frost, empower rune weapon, or breath of sindragosa's cooldown. If it's value has no remainder return 1, else return 0.5.

--- a/TheWarWithin/Priorities/DeathKnightUnholy.simc
+++ b/TheWarWithin/Priorities/DeathKnightUnholy.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/commits/thewarwithin/ActionPriorityLists/deathknight_unholy.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/deathknight_unholy.simc
 ## Up to date with SimC: April 22 2025 - 42dc633
 
 actions.precombat+=/raise_dead

--- a/TheWarWithin/Priorities/DemonHunterHavoc.simc
+++ b/TheWarWithin/Priorities/DemonHunterHavoc.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/demonhunter_havoc.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/demonhunter_havoc.simc
 ## Up to date with SimC: March 9 2025 - 91f125a
 
 actions.precombat+=/variable,name=trinket1_steroids,value=trinket.1.is.improvised_seaforium_pacemaker

--- a/TheWarWithin/Priorities/DemonHunterVengeance.simc
+++ b/TheWarWithin/Priorities/DemonHunterVengeance.simc
@@ -1,3 +1,5 @@
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/demonhunter_vengeance.simc
+
 actions.precombat+=/variable,name=single_target,value=spell_targets.spirit_bomb=1
 actions.precombat+=/variable,name=small_aoe,value=spell_targets.spirit_bomb>=2&spell_targets.spirit_bomb<=5
 actions.precombat+=/variable,name=big_aoe,value=spell_targets.spirit_bomb>=6

--- a/TheWarWithin/Priorities/DruidBalance.simc
+++ b/TheWarWithin/Priorities/DruidBalance.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/druid_balance.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/druid_balance.simc
 ## Up to date with SimC: April 27 - 603b5f7
 
 actions.precombat+=/mark_of_the_wild

--- a/TheWarWithin/Priorities/DruidFeral.simc
+++ b/TheWarWithin/Priorities/DruidFeral.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/commits/thewarwithin/ActionPriorityLists/druid_feral.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/druid_feral.simc
 ## Up to date with SimC: April 12 2025 - d935a4a
 
 actions.precombat+=/mark_of_the_wild

--- a/TheWarWithin/Priorities/DruidGuardian.simc
+++ b/TheWarWithin/Priorities/DruidGuardian.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/druid_guardian.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/druid_guardian.simc
 ## Up to date with SimC: March 8 2025 - ccb7c79
 
 actions.precombat+=/mark_of_the_wild

--- a/TheWarWithin/Priorities/DruidRestoration.simc
+++ b/TheWarWithin/Priorities/DruidRestoration.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/druid_restoration.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/druid_restoration.simc
 ## Up to date with SimC: March 8 2025 - ccb7c79
 
 # Snapshot raid buffed stats before combat begins and pre-potting is done.

--- a/TheWarWithin/Priorities/EvokerAugmentation.simc
+++ b/TheWarWithin/Priorities/EvokerAugmentation.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/evoker_augmentation.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/evoker_augmentation.simc
 ## Up to date with SimC: April 12 2025 - 72033f9
 
 actions.precombat+=/variable,name=spam_heal,default=1,op=reset

--- a/TheWarWithin/Priorities/EvokerDevastation.simc
+++ b/TheWarWithin/Priorities/EvokerDevastation.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/commits/thewarwithin/ActionPriorityLists/evoker_devastation.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/evoker_devastation.simc
 ## Up to date with SimC: March 28 2025 - 74b5dd8
 
 actions.precombat+=/variable,name=trinket_1_buffs,value=trinket.1.has_buff.intellect|trinket.1.has_buff.mastery|trinket.1.has_buff.versatility|trinket.1.has_buff.haste|trinket.1.has_buff.crit|trinket.1.is.mirror_of_fractured_tomorrows|trinket.1.is.signet_of_the_priory

--- a/TheWarWithin/Priorities/HunterBeastMastery.simc
+++ b/TheWarWithin/Priorities/HunterBeastMastery.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/commits/thewarwithin/ActionPriorityLists/hunter_beast_mastery.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/hunter_beast_mastery.simc
 ## Up to date with SimC: March 18 2025 - c8cb5fc
 
 actions.precombat+=/summon_pet

--- a/TheWarWithin/Priorities/HunterMarksmanship.simc
+++ b/TheWarWithin/Priorities/HunterMarksmanship.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/commits/thewarwithin/ActionPriorityLists/hunter_marksmanship.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/hunter_marksmanship.simc
 ## Up to date with SimC: March 28 2025 - 9b7cf47
 
 actions.precombat+=/summon_pet,if=talent.unbreakable_bond

--- a/TheWarWithin/Priorities/HunterSurvival.simc
+++ b/TheWarWithin/Priorities/HunterSurvival.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/hunter_survival.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/hunter_survival.simc
 ## Up to date with SimC: April 26 2025 - 739316d
 
 actions.precombat+=/summon_pet

--- a/TheWarWithin/Priorities/MageArcane.simc
+++ b/TheWarWithin/Priorities/MageArcane.simc
@@ -1,3 +1,4 @@
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/mage_arcane.simc
 ## Updated 20250426
 ## SimC Build 5996557
 

--- a/TheWarWithin/Priorities/MageFire.simc
+++ b/TheWarWithin/Priorities/MageFire.simc
@@ -1,3 +1,5 @@
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/mage_fire.simc
+
 actions.precombat+=/arcane_intellect
 # APL Variable Option: This variable specifies whether Combustion should be used during Firestarter.
 actions.precombat+=/variable,name=firestarter_combustion,default=-1,value=talent.sun_kings_blessing,if=variable.firestarter_combustion<0

--- a/TheWarWithin/Priorities/MageFrost.simc
+++ b/TheWarWithin/Priorities/MageFrost.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/mage_frost.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/mage_frost.simc
 ## Up to date with SimC: March 21 2025 - 19f3b05
 
 actions.precombat+=/arcane_intellect

--- a/TheWarWithin/Priorities/MonkBrewmaster.simc
+++ b/TheWarWithin/Priorities/MonkBrewmaster.simc
@@ -1,3 +1,5 @@
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/monk_brewmaster.simc
+
 actions.precombat+=/potion
 actions.precombat+=/chi_burst,if=talent.chi_burst.enabled
 

--- a/TheWarWithin/Priorities/MonkMistweaver.simc
+++ b/TheWarWithin/Priorities/MonkMistweaver.simc
@@ -1,3 +1,5 @@
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/monk_mistweaver.simc
+
 actions.precombat+=/potion
 actions.precombat+=/chi_burst
 actions.precombat+=/variable,name=tea_up,value=buff.tea_of_plenty_rsk.up|buff.tea_of_plenty_em.up|buff.tea_of_plenty_eh.up|buff.tea_of_serenity_em.up|buff.tea_of_serenity_rm.up|buff.tea_of_serenity_v.up|buff.thunder_focus_tea.up

--- a/TheWarWithin/Priorities/MonkWindwalker.simc
+++ b/TheWarWithin/Priorities/MonkWindwalker.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/monk_windwalker.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/monk_windwalker.simc
 ## Up to date with SimC: March 17 2025 - c02ee75
 
 actions.precombat+=/use_item,name=imperfect_ascendancy_serum

--- a/TheWarWithin/Priorities/PaladinProtection.simc
+++ b/TheWarWithin/Priorities/PaladinProtection.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/paladin_protection.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/paladin_protection.simc
 ## Up to date with SimC: March 13 2025 - a8d374d
 
 ## actions.precombat+=/rite_of_sanctification

--- a/TheWarWithin/Priorities/PaladinRetribution.simc
+++ b/TheWarWithin/Priorities/PaladinRetribution.simc
@@ -1,3 +1,5 @@
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/paladin_retribution.simc
+
 actions.precombat+=/shield_of_vengeance
 actions.precombat+=/variable,name=trinket_1_buffs,value=trinket.1.has_buff.strength|trinket.1.has_buff.mastery|trinket.1.has_buff.versatility|trinket.1.has_buff.haste|trinket.1.has_buff.crit
 actions.precombat+=/variable,name=trinket_2_buffs,value=trinket.2.has_buff.strength|trinket.2.has_buff.mastery|trinket.2.has_buff.versatility|trinket.2.has_buff.haste|trinket.2.has_buff.crit

--- a/TheWarWithin/Priorities/PriestShadow.simc
+++ b/TheWarWithin/Priorities/PriestShadow.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/commits/thewarwithin/ActionPriorityLists/priest_shadow.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/priest_shadow.simc
 ## Up to date with SimC: April 12 2025 - 9b983fb
 
 actions.precombat+=/power_word_fortitude

--- a/TheWarWithin/Priorities/RogueAssassination.simc
+++ b/TheWarWithin/Priorities/RogueAssassination.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/rogue_assassination.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/rogue_assassination.simc
 ## Up to date with SimC: April 7 2025 - 0307d7f
 
 actions.precombat+=/apply_poison

--- a/TheWarWithin/Priorities/RogueOutlaw.simc
+++ b/TheWarWithin/Priorities/RogueOutlaw.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/rogue_outlaw.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/rogue_outlaw.simc
 ## Up to date with SimC: April 16 2025 - b23bf5e
 
 actions.precombat+=/apply_poison

--- a/TheWarWithin/Priorities/RogueSubtlety.simc
+++ b/TheWarWithin/Priorities/RogueSubtlety.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/rogue_subtlety.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/rogue_subtlety.simc
 ## Up to date with SimC: April 5 2025 - ed7963f
 
 actions.precombat+=/apply_poison

--- a/TheWarWithin/Priorities/ShamanElemental.simc
+++ b/TheWarWithin/Priorities/ShamanElemental.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/shaman_elemental.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/shaman_elemental.simc
 ## Up to date with SimC: April 21 2025 - 53f00ae
 
 # Ensure weapon enchant is applied if you've selected Improved Flametongue Weapon.

--- a/TheWarWithin/Priorities/ShamanEnhancement.simc
+++ b/TheWarWithin/Priorities/ShamanEnhancement.simc
@@ -1,4 +1,4 @@
-## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/shaman_enhancement.simc
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/shaman_enhancement.simc
 ## Up to date with SimC: May 4 2025 - d7ce1aa
 
 actions.precombat+=/windfury_weapon

--- a/TheWarWithin/Priorities/WarlockAffliction.simc
+++ b/TheWarWithin/Priorities/WarlockAffliction.simc
@@ -1,3 +1,5 @@
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/warlock_affliction.simc
+
 actions.precombat=fel_domination,if=time>0&!pet.alive
 actions.precombat+=/summon_pet
 actions.precombat+=/variable,name=cleave_apl,value=toggle.funnel

--- a/TheWarWithin/Priorities/WarlockDemonology.simc
+++ b/TheWarWithin/Priorities/WarlockDemonology.simc
@@ -1,3 +1,5 @@
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/warlock_demonology.simc
+
 actions.precombat+=/fel_domination,if=time>0&!pet.alive&!buff.grimoire_of_sacrifice.up
 actions.precombat+=/summon_pet,if=!pet.alive&!buff.grimoire_of_sacrifice.up
 # Sets the expected Tyrant Setup on pull to take a total 12 seconds long

--- a/TheWarWithin/Priorities/WarlockDestruction.simc
+++ b/TheWarWithin/Priorities/WarlockDestruction.simc
@@ -1,3 +1,5 @@
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/warlock_destruction.simc
+
 actions.precombat=fel_domination,if=time>0&!pet.alive
 actions.precombat+=/summon_pet
 actions.precombat+=/variable,name=cleave_apl,value=toggle.funnel

--- a/TheWarWithin/Priorities/WarriorArms.simc
+++ b/TheWarWithin/Priorities/WarriorArms.simc
@@ -1,3 +1,5 @@
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/warrior_arms.simc
+
 actions.precombat+=/battle_shout
 actions.precombat+=/battle_stance,toggle=on
 actions.precombat+=/variable,name=trinket_1_exclude,value=trinket.1.is.treacherous_transmitter

--- a/TheWarWithin/Priorities/WarriorFury.simc
+++ b/TheWarWithin/Priorities/WarriorFury.simc
@@ -1,3 +1,5 @@
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/warrior_fury.simc
+
 actions.precombat+=/battle_shout
 actions.precombat+=/berserker_stance,toggle=on
 actions.precombat+=/variable,name=treacherous_transmitter_precombat_cast,value=2

--- a/TheWarWithin/Priorities/WarriorProtection.simc
+++ b/TheWarWithin/Priorities/WarriorProtection.simc
@@ -1,3 +1,5 @@
+## https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/warrior_protection.simc
+
 actions.precombat+=/battle_stance,toggle=on
 actions.precombat+=/battle_shout
 


### PR DESCRIPTION
With the introduction of the "Blizzard APLs", SimulationCraft has moved all the regular APLs into a folder. This updates the link to them all, commented at the top of our `.simc` files