### PR TITLE
Support new format of Tww3 tier sets in SimC

### DIFF
--- a/TheWarWithin/HunterBeastMastery.lua
+++ b/TheWarWithin/HunterBeastMastery.lua
@@ -1721,7 +1721,7 @@ spec:RegisterAbilities( {
     call_of_the_wild = {
         id = 359844,
         cast = 0,
-        cooldown = function() if set_bonus.tww3>=2 and hero_tree.dark_ranger then return 60 else return 120 end end,
+        cooldown = function() if set_bonus.tww3_dark_ranger >=2 then return 60 else return 120 end end,
         gcd = "spell",
         school = "nature",
 

--- a/TheWarWithin/HunterMarksmanship.lua
+++ b/TheWarWithin/HunterMarksmanship.lua
@@ -1529,7 +1529,7 @@ spec:RegisterAbilities( {
     trueshot = {
         id = 288613,
         cast = 0,
-        cooldown = function() return 120 - ( talent.calling_the_shots.enabled and 30 or 0 ) - ( set_bonus.tww3 >=2 and hero_tree.dark_ranger and 30 or 0 ) end,
+        cooldown = function() return 120 - ( talent.calling_the_shots.enabled and 30 or 0 ) - ( set_bonus.tww3_dark_ranger >=2 and 30 or 0 ) end,
         gcd = "off",
         school = "physical",
 

--- a/TheWarWithin/MageArcane.lua
+++ b/TheWarWithin/MageArcane.lua
@@ -1414,7 +1414,7 @@ spec:RegisterAbilities( {
             end -- Use this to catch "5th" cast of Arcane Blast.
             gain( 1, "arcane_charges" )
 
-            if set_bonus.tww3 >= 2 and hero_tree.spellslinger then
+            if set_bonus.tww3_spellslinger >= 2 then
                 addStack( "arcane_harmony" )
                 if buff.arcane_harmony.at_max_stacks then applyBuff( "intuition" ) end
             end
@@ -1603,7 +1603,7 @@ spec:RegisterAbilities( {
         tick = function ()
             if talent.arcane_harmony.enabled or legendary.arcane_harmony.enabled then
                 addStack( "arcane_harmony", nil, 1 )
-                if buff.arcane_harmony.at_max_stacks and set_bonus.tww3 >= 4 and hero_tree.spellslinger then applyBuff( "intuition" ) end
+                if buff.arcane_harmony.at_max_stacks and set_bonus.tww3_spellslinger >= 4 then applyBuff( "intuition" ) end
             end
         end,
     },
@@ -1632,7 +1632,7 @@ spec:RegisterAbilities( {
 
         impact = function ()
             gain( true_active_enemies, "arcane_charges" )
-            if set_bonus.tww3 >= 4 and hero_tree.spellslinger then
+            if set_bonus.tww3_spellslinger >= 4 then
                 addStack( "arcane_harmony", min( 8, true_active_enemies ) )
                 if buff.arcane_harmony.at_max_stacks then applyBuff( "intuition" ) end
             end

--- a/TheWarWithin/MonkWindwalker.lua
+++ b/TheWarWithin/MonkWindwalker.lua
@@ -1768,7 +1768,7 @@ spec:RegisterAbilities( {
         texture = 1029596,
 
         handler = function ()
-            if set_bonus.tww3 >= 2 and hero_tree.conduit_of_the_celestials then applyBuff( "heart_of_the_jade_serpent_cdr", 8 ) end
+            if set_bonus.tww3_conduit_of_the_celestials >= 2 then applyBuff( "heart_of_the_jade_serpent_cdr", 8 ) end
         end,
     },
 

--- a/TheWarWithin/PriestDiscipline.lua
+++ b/TheWarWithin/PriestDiscipline.lua
@@ -700,7 +700,7 @@ spec:RegisterHook( "runHandler", function( a )
     if buff.premonition_of_insight.up then
         reduceCooldown( a, insight_value )
         removeStack( "premonition_of_insight" )
-        if set_bonus.tww3 >= 4 and hero_tree.oracle then addStack( "visionary_velocity" ) end
+        if set_bonus.tww3_oracle >= 4 then addStack( "visionary_velocity" ) end
     end
 end )
 
@@ -1361,7 +1361,7 @@ spec:RegisterAbilities( {
                 rift_extensions = rift_extensions + 1
             end
 
-            if set_bonus.tww3 >= 4 and hero_tree.voidweaver then removeBuff( "overflowing_void" ) end
+            if set_bonus.tww3_voidweaver >= 4 then removeBuff( "overflowing_void" ) end
         end,
 
         copy = { 585, "void_blast", 450215, 450405, 450983 }

--- a/TheWarWithin/PriestHoly.lua
+++ b/TheWarWithin/PriestHoly.lua
@@ -526,7 +526,7 @@ spec:RegisterHook( "runHandler", function( a )
     if buff.premonition_of_insight.up then
         reduceCooldown( a, insight_value )
         removeStack( "premonition_of_insight" )
-        if set_bonus.tww3 >= 4 and hero_tree.oracle then addStack( "visionary_velocity" ) end
+        if set_bonus.tww3_oracle >= 4 then addStack( "visionary_velocity" ) end
     end
 end )
 

--- a/TheWarWithin/PriestShadow.lua
+++ b/TheWarWithin/PriestShadow.lua
@@ -2406,7 +2406,7 @@ spec:RegisterAbilities( {
             end
             if talent.idol_of_cthun.enabled then applyDebuff( "target", "void_tendril_mind_flay" ) end
             if talent.void_volley.enabled then applyBuff( "void_volley" ) end
-            if set_bonus.tww3 >= 4 and hero_tree.voidweaver then removeBuff( "overflowing_void" ) end
+            if set_bonus.tww3_voidweaver >= 4 then removeBuff( "overflowing_void" ) end
         end,
 
     },

--- a/TheWarWithin/ShamanElemental.lua
+++ b/TheWarWithin/ShamanElemental.lua
@@ -1577,7 +1577,7 @@ spec:RegisterAbilities( {
             spec.abilities.flame_shock.handler()
             spec.abilities.lava_burst.handler()
             active_dot.flame_shock = min( true_active_enemies, active_dot.flame_shock + 6 )
-            if set_bonus.tww3 >= 2 and hero_tree.stormbringer then
+            if set_bonus.tww3_stormbringer >= 2 then
                 addStack( "tempest" )
                 if set_bonus.tww3 >= 4 then
                     applyBuff( "storms_eye", nil, 2 )

--- a/TheWarWithin/ShamanEnhancement.lua
+++ b/TheWarWithin/ShamanEnhancement.lua
@@ -1528,7 +1528,7 @@ spec:RegisterAbilities( {
         toggle = "cooldowns",
 
         handler = function ()
-            if set_bonus.tww3 >= 2 and hero_tree.stormbringer then
+            if set_bonus.tww3_stormbringer >= 2 then
                 addStack( "tempest" )
                 if set_bonus.tww3 >= 4 then
                     applyBuff( "storms_eye", nil, 2 )
@@ -2367,7 +2367,7 @@ spec:RegisterAbilities( {
                 if set_bonus.tww3 >= 2 then TriggerTWW3Totemic2pc() end
             end
 
-            if set_bonus.tww3 >= 2 and hero_tree.totemic then
+            if set_bonus.tww3_totemic >= 2 then
                 removeStack( "elemental_overflow" )
             end
 
@@ -2384,7 +2384,7 @@ spec:RegisterAbilities( {
             if talent.molten_assault.enabled and debuff.flame_shock.up then
                 active_dot.flame_shock = min( active_enemies, active_dot.flame_shock + 5 )
                 removeBuff( "whirling_earth" )
-                if set_bonus.tww3 >= 2 and hero_tree.totemic then TriggerTWW3Totemic2pc() end
+                if set_bonus.tww3_totemic >= 2 then TriggerTWW3Totemic2pc() end
             end
             if buff.vesper_totem.up and vesper_totem_dmg_charges > 0 then trigger_vesper_damage() end
         end,

--- a/TheWarWithin/WarlockDemonology.lua
+++ b/TheWarWithin/WarlockDemonology.lua
@@ -2066,7 +2066,7 @@ spec:RegisterAbilities( {
             if extra_shards > 0 then insert( guldan_v, query_time + 0.8 ) end
             if extra_shards > 1 then
                 insert( guldan_v, query_time + 1 )
-                if set_bonus.tww3 >= 2 and hero_tree.diabolist then
+                if set_bonus.tww3_diabolist >= 2 then
                     addStack( "demonic_oculus" )
                 end
             end

--- a/TheWarWithin/WarlockDestruction.lua
+++ b/TheWarWithin/WarlockDestruction.lua
@@ -1478,7 +1478,7 @@ spec:RegisterAbilities( {
                 if debuff.immolate.remains <= 5 then removeDebuff( "target", "immolate" )
                 else debuff.immolate.expires = debuff.immolate.expires - 5 end
             end
-            if set_bonus.tww3 >= 2 and hero_tree.diabolist then
+            if set_bonus.tww3_diabolist >= 2 then
                 addStack( "demonic_oculus" )
             end
         end,
@@ -1866,7 +1866,7 @@ spec:RegisterAbilities( {
             if talent.burn_to_ashes.enabled then
                 addStack( "burn_to_ashes", nil, 2 )
             end
-            if set_bonus.tww3 >= 2 and hero_tree.diabolist then
+            if set_bonus.tww3_diabolist >= 2 then
                 addStack( "demonic_oculus" )
             end
         end,
@@ -2008,7 +2008,7 @@ spec:RegisterAbilities( {
                 applyDebuff( "target", "eradication" )
                 active_dot.eradication = max( active_dot.eradication, active_dot.bane_of_havoc )
             end
-            if set_bonus.tww3 >= 2 and hero_tree.diabolist then
+            if set_bonus.tww3_diabolist >= 2 then
                 addStack( "demonic_oculus" )
             end
         end,

--- a/TheWarWithin/WarriorArms.lua
+++ b/TheWarWithin/WarriorArms.lua
@@ -1338,7 +1338,7 @@ spec:RegisterAbilities( {
             removeBuff( "battlelord" )
             if talent.dominance_of_the_colossus.enabled and buff.colossal_might.stack == 10 then reduceCooldown( "demolish", 2 ) end
             if talent.colossal_might.enabled then addStack( "colossal_might" ) end
-            if set_bonus.tww3 >= 4 and hero_tree.colossus then removeStack( "critical_conclusion" ) end
+            if set_bonus.tww3_colossus >= 4 then removeStack( "critical_conclusion" ) end
             if talent.rend.enabled and target.health.pct < 35 and talent.bloodletting.enabled then
                 applyDebuff ( "target", "rend" )
             end

--- a/TheWarWithin/WarriorProtection.lua
+++ b/TheWarWithin/WarriorProtection.lua
@@ -1612,7 +1612,7 @@ spec:RegisterAbilities( {
             -- Hero / TWW
             if talent.dominance_of_the_colossus.enabled and buff.colossal_might.stack == 10 then reduceCooldown( "demolish", 2 ) end
             if talent.colossal_might then addStack( "colossal_might" ) end
-            if set_bonus.tww3 >= 4 and hero_tree.colossus then removeStack( "critical_conclusion" ) end
+            if set_bonus.tww3_colossus >= 4 then removeStack( "critical_conclusion" ) end
 
             -- Legacy
 


### PR DESCRIPTION
rip `& hero_tree.x`

Example format from SimulationCraft: `set_bonus.tww3_rider_of_the_apocalypse_2pc`

in-game test swapping between 2 trees

<img width="701" height="460" alt="image" src="https://github.com/user-attachments/assets/d0dbb979-9b87-4b0f-a502-25154541cbb6" />
<img width="707" height="466" alt="image" src="https://github.com/user-attachments/assets/a9890093-43ce-43a0-82a8-769e08c1824b" />
