### PR TITLE
Spooky Scary Skeletons

### DIFF
--- a/Constants.lua
+++ b/Constants.lua
@@ -691,3 +691,30 @@ ns.FrameStratas = {
     FULLSCREEN_DIALOG = 7,
     TOOLTIP = 8
 }
+
+-- Skeleton Generator Talent Enhancements
+ns.SkeletonTalentEnhancements = {
+    talentCopies = {
+        [102] = {
+            incarnation_chosen_of_elune = "incarnation"
+        },
+        [103] = {
+            incarnation_avatar_of_ashamane = "incarnation"
+        },
+        [104] = {
+            incarnation_guardian_of_ursoc = "incarnation"
+        },
+        [105] = {
+            incarnation_tree_of_life = "incarnation"
+        }
+        -- Add more specs/talents as needed
+    },
+
+    -- Choice node suffix mappings (same name, different spellIDs, same node)
+    choiceNodeSuffixes = {
+        earthquake      = { [61882]     = "_ground", [462620]   = "_targeted" },
+        rain_of_fire    = { [5740]      = "_ground", [1214467]  = "_targeted" },
+        shadow_crash    = { [205385]    = "_ground", [457042]   = "_targeted" }
+        -- Add more choice nodes as discovered
+    }
+}


### PR DESCRIPTION
# Skeleton Generator Enhancements
## Purpose
Main purpose is to stop me from forgetting custom talent tweaks (*cough* see the multiple guardian druid tickets about incarn because I forgot to add it back in).

Apparently its purpose was also to teach me a **_lot_** about the talent system structure and API. God that debugging took forever.
## Changes / Improvements
- Automatic handling of choice node talents that keep getting added, which have the same name, same nodeID, but different spell ID. This is typically a choice between `[@cursor]` targeting and `[@target]` targeting, see: Earthquake, Shadow Crash, Rain of Fire. No longer will they be forgotten. 
  - It will also detect new talents like this, and give generic suffixes. Then we can investigate them and add to the constants table.
- Automatic handling of "duplicate" talents (see: Healing Stream Totem, Raise Dead). No longer will they be forgotten.
- Automatic handling of talent copies that were previously done manually, via the constants table (see: Druid Incarnation copy talent for all 4 specs)
- Automatic handling of "Fake" / bad data talents, like the Unholy DK Defile duplicate
- Improvements to the top of the skeleton, in line with my recent PR standardizing the tops of the files. Now also adds the patch number, all of the local API declarations.
## Samples
Here are some diffs of the top excerpt of the skeleton, taken with and without this PR. Shows the tops of the files as well as some differences in how the talents were grabbed. All 3 demonstrate a better talent outcome.
### Ground vs Target choice talent
Shadowpriest: https://www.diffchecker.com/w7cT4nhC/
### Duplicate Talent
Unholy DK: https://www.diffchecker.com/QNReK0Oi/
### Manual Talent Copies
Guardian Druid: https://www.diffchecker.com/Alr7jwgS/
