### PR TITLE
Fix: Minor Frost DK issues

### DIFF
--- a/TheWarWithin/DeathKnightFrost.lua
+++ b/TheWarWithin/DeathKnightFrost.lua
@@ -1010,6 +1010,10 @@ spec:RegisterCombatLogEvent( function( _, subtype, _, sourceGUID, sourceName, so
 
 end )
 
+local BreathOfSindragosaExpire = setfenv( function()
+    gain( 2, "runes" )
+end, state )
+
 spec:RegisterHook( "reset_precast", function ()
     local control_expires = action.control_undead.lastCast + 300
     if talent.control_undead.enabled and control_expires > now and pet.up then
@@ -1031,9 +1035,7 @@ spec:RegisterHook( "reset_precast", function ()
 
 end )
 
-local BreathOfSindragosaExpire = setfenv( function()
-    gain( 2, "runes" )
-end, state )
+
 
 local KillingMachineConsumer = setfenv( function ()
 


### PR DESCRIPTION
 Hi @syrifgit, noticed a few small things I believe are missing or could be optimized slightly:
 
  ### Biting Cold
  - Replaced cast-time check with tick handler to properly detect "first time RW hits 3+
  enemies", which could occur _after_ cast time if an enemy moved into range
  - Added tracking buff with handler/tick/finish lifecycle and cleanup

  ### Razorice
  - corrected `buff.razorice.stack` → `debuff.razorice.stack` in 3
  abilities: Frost Strike, Glacial Advance, and Howling Blast + Avalanche talent

  ### Breath of Sindragosa
  - Added finish handler that grants 2 runes when channeling ends per spell data