### PR TITLE
More User Warnings

### DIFF
--- a/Constants.lua
+++ b/Constants.lua
@@ -104,197 +104,236 @@ ns.Specializations = {
     [250] = {
         key = "blood",
         class = "DEATHKNIGHT",
-        ranged = false
+        ranged = false,
+        current_patch = true
     },
     [251] = {
         key = "frost",
         class = "DEATHKNIGHT",
-        ranged = false
+        ranged = false,
+        current_patch = true
     },
     [252] = {
         key = "unholy",
         class = "DEATHKNIGHT",
-        ranged = false
+        ranged = false,
+        current_patch = true
     },
     [102] = {
         key = "balance",
         class = "DRUID",
-        ranged = true
+        ranged = true,
+        current_patch = true
     },
     [103] = {
         key = "feral",
         class = "DRUID",
-        ranged = false
+        ranged = false,
+        current_patch = true
     },
     [104] = {
         key = "guardian",
         class = "DRUID",
-        ranged = false
+        ranged = false,
+        current_patch = true
     },
     [105] = {
         key = "restoration",
         class = "DRUID",
-        ranged = true
+        ranged = true,
+        current_patch = true
     },
     [253] = {
         key = "beast_mastery",
         class = "HUNTER",
-        ranged = true
+        ranged = true,
+        current_patch = true
     },
     [254] = {
         key = "marksmanship",
         class = "HUNTER",
-        ranged = true
+        ranged = true,
+        current_patch = true
     },
     [255] = {
         key = "survival",
         class = "HUNTER",
-        ranged = false
+        ranged = false,
+        current_patch = true
     },
     [62] = {
         key = "arcane",
         class = "MAGE",
-        ranged = true
+        ranged = true,
+        current_patch = true
     },
     [63] = {
         key = "fire",
         class = "MAGE",
-        ranged = true
+        ranged = true,
+        current_patch = true
     },
     [64] = {
         key = "frost",
         class = "MAGE",
-        ranged = true
+        ranged = true,
+        current_patch = true
     },
     [268] = {
         key = "brewmaster",
         class = "MONK",
-        ranged = false
+        ranged = false,
+        current_patch = false
     },
     [269] = {
         key = "windwalker",
         class = "MONK",
-        ranged = false
+        ranged = false,
+        current_patch = false
     },
     [270] = {
         key = "mistweaver",
         class = "MONK",
-        ranged = false
+        ranged = false,
+        current_patch = true
     },
     [65] = {
         key = "holy",
         class = "PALADIN",
-        ranged = false
+        ranged = false,
+        current_patch = true
     },
     [66] = {
         key = "protection",
         class = "PALADIN",
-        ranged = false
+        ranged = false,
+        current_patch = true
     },
     [70] = {
         key = "retribution",
         class = "PALADIN",
-        ranged = false
+        ranged = false,
+        current_patch = true
     },
     [256] = {
         key = "discipline",
         class = "PRIEST",
-        ranged = true
+        ranged = true,
+        current_patch = true
     },
     [257] = {
         key = "holy",
         class = "PRIEST",
-        ranged = true
+        ranged = true,
+        current_patch = true
     },
     [258] = {
         key = "shadow",
         class = "PRIEST",
-        ranged = true
+        ranged = true,
+        current_patch = true
     },
     [259] = {
         key = "assassination",
         class = "ROGUE",
-        ranged = false
+        ranged = false,
+        current_patch = true
     },
     [260] = {
         key = "outlaw",
         class = "ROGUE",
-        ranged = false
+        ranged = false,
+        current_patch = true
     },
     [261] = {
         key = "subtlety",
         class = "ROGUE",
-        ranged = false
+        ranged = false,
+        current_patch = true
     },
     [262] = {
         key = "elemental",
         class = "SHAMAN",
-        ranged = true
+        ranged = true,
+        current_patch = true
     },
     [263] = {
         key = "enhancement",
         class = "SHAMAN",
-        ranged = false
+        ranged = false,
+        current_patch = true
     },
     [264] = {
         key = "restoration",
         class = "SHAMAN",
-        ranged = true
+        ranged = true,
+        current_patch = true
     },
     [265] = {
         key = "affliction",
         class = "WARLOCK",
-        ranged = true
+        ranged = true,
+        current_patch = false
     },
     [266] = {
         key = "demonology",
         class = "WARLOCK",
-        ranged = true
+        ranged = true,
+        current_patch = false
     },
     [267] = {
         key = "destruction",
         class = "WARLOCK",
-        ranged = true
+        ranged = true,
+        current_patch = false
     },
     [71] = {
         key = "arms",
         class = "WARRIOR",
-        ranged = false
+        ranged = false,
+        current_patch = true
     },
     [72] = {
         key = "fury",
         class = "WARRIOR",
-        ranged = false
+        ranged = false,
+        current_patch = true
     },
     [73] = {
         key = "protection",
         class = "WARRIOR",
-        ranged = false
+        ranged = false,
+        current_patch = true
     },
     [577] = {
         key = "havoc",
         class = "DEMONHUNTER",
-        ranged = false
+        ranged = false,
+        current_patch = false
     },
     [581] = {
         key = "vengeance",
         class = "DEMONHUNTER",
-        ranged = false
+        ranged = false,
+        current_patch = false
     },
     [1467] = {
         key = "devastation",
         class = "EVOKER",
-        ranged = true
+        ranged = true,
+        current_patch = true
     },
     [1468] = {
         key = "preservation",
         class = "EVOKER",
-        ranged = true
+        ranged = true,
+        current_patch = true
     },
     [1473] = {
         key = "augmentation",
         class = "EVOKER",
-        ranged = true
+        ranged = true,
+        current_patch = true
     },
 }
 

--- a/Events.lua
+++ b/Events.lua
@@ -1197,10 +1197,10 @@ local incompleteSpecWarned = false
 -- Need to make caching system.
 RegisterUnitEvent( "UNIT_SPELLCAST_SUCCEEDED", "player", "target", function( event, unit, _, spellID )
     if not noClassWarned and not class.initialized then
-        Hekili:Notify( UnitClass( "player" ) .. " does not have any Hekili modules loaded (yet).\nWatch for updates.", 5 )
+        Hekili:Notify( UnitClass( "player" ) .. " does not have any Hekili modules loaded (yet).\nWatch for updates.", 10 )
         noClassWarned = true
     elseif not lowLevelWarned and UnitLevel( "player" ) < maxLevel then
-        Hekili:Notify( "Hekili is designed for level " .. maxLevel .. " content.\nUse below level " .. maxLevel .. " at your own risk.", 5 )
+        Hekili:Notify( "Hekili is designed for level " .. maxLevel .. " characters.\nYou may experience issues with the addon while below level " .. maxLevel .. ".", 10 )
         lowLevelWarned = true
     elseif not incompleteSpecWarned and class.initialized then
         local specID = ns.getSpecializationID()

--- a/Events.lua
+++ b/Events.lua
@@ -1189,18 +1189,38 @@ do
     end
 end
 
-
+local maxLevel = GetMaxLevelForLatestExpansion()
 local lowLevelWarned = false
 local noClassWarned = false
+local incompleteSpecWarned = false
 
 -- Need to make caching system.
 RegisterUnitEvent( "UNIT_SPELLCAST_SUCCEEDED", "player", "target", function( event, unit, _, spellID )
     if not noClassWarned and not class.initialized then
         Hekili:Notify( UnitClass( "player" ) .. " does not have any Hekili modules loaded (yet).\nWatch for updates.", 5 )
         noClassWarned = true
-    elseif not lowLevelWarned and UnitLevel( "player" ) < 70 then
-        Hekili:Notify( "Hekili is designed for current content.\nUse below level 70 at your own risk.", 5 )
+    elseif not lowLevelWarned and UnitLevel( "player" ) < maxLevel then
+        Hekili:Notify( "Hekili is designed for level " .. maxLevel .. " content.\nUse below level " .. maxLevel .. " at your own risk.", 5 )
         lowLevelWarned = true
+    elseif not incompleteSpecWarned and class.initialized then
+        local specID = ns.getSpecializationID()
+        local specInfo = ns.Specializations[ specID ]
+
+        if specInfo and specInfo.current_patch == false then
+            local specName = select( 2, GetSpecializationInfo( GetSpecialization() ) )
+            local className = UnitClass( "player" )
+
+            -- Get patch version in format "11.2.0"
+            local version, _, _, _ = GetBuildInfo()
+            local patchVersion = version or "the current patch"
+
+            Hekili:Notify(
+                specName .. " has not been fully updated for patch " .. patchVersion .. "\n" ..
+                "Please check for Hekili updates regularly in the first 1-2 weeks of a patch!",
+                12
+            )
+            incompleteSpecWarned = true
+        end
     end
 
     if unit == "player" then


### PR DESCRIPTION
Hopefully this can relieve/prevent some amount of headache. :)

## Low Level Warning
- More clear communication to user
- Automatically updates the max level every expansion via API call

<img width="905" height="785" alt="Screenshot 2025-08-09 000725" src="https://github.com/user-attachments/assets/04da0d0c-d5e4-4d45-9ed1-37b57d6d50e2" />

## Spec Not Up To Date
Partially automated warnings to the user, which hopefully prevents repeated discord questions and tickets at the beginning of a patch.
- Automatically retrieve patch info with API call
- Uses a constants table to track if a spec is updated or not. At the beginning of a new major patch, flip them all to false. When you PR a spec, or feel that it's "ready", flip its flag to true.

<img width="885" height="745" alt="Screenshot 2025-08-09 000752" src="https://github.com/user-attachments/assets/addce3f9-c1d2-4881-86bc-96d68face17c" />
