### PR TITLE
11.2 Monk Fixes

### DIFF
--- a/Constants.lua
+++ b/Constants.lua
@@ -706,7 +706,24 @@ ns.SkeletonTalentEnhancements = {
         },
         [105] = {
             incarnation_tree_of_life = "incarnation"
-        }
+        },
+        [259] = {
+            inevitabile_end = "inevitable_end"
+        },
+        [261] = {
+            inevitabile_end = "inevitable_end"
+        },
+        [268] = {
+            invoke_niuzao_the_black_ox = "invoke_niuzao",
+            improved_invoke_niuzao_the_black_ox = "improved_invoke_niuzao"
+        },
+        [269] = {
+            invoke_xuen_the_white_tiger = "invoke_xuen"
+        },
+        [270] = {
+            invoke_yulon_the_jade_serpent = "invoke_yulon",
+            invoke_chiji_the_red_crane = "invoke_chiji"
+        },
         -- Add more specs/talents as needed
     },
 

--- a/TheWarWithin/MonkMistweaver.lua
+++ b/TheWarWithin/MonkMistweaver.lua
@@ -112,7 +112,9 @@ spec:RegisterTalents( {
     gift_of_the_celestials         = { 101113,  388212, 1 }, -- Reduces the cooldown of Invoke Chi-Ji, the Red Crane by $s1 min, but decreases its duration to $s2 sec
     healing_elixir                 = { 101109,  122280, 1 }, -- You consume a healing elixir when you drop below $s1% health or generate excess healing elixirs, instantly healing you for $s2% of your maximum health. You generate $s3 healing elixir every $s4 sec, stacking up to $s5 times
     invigorating_mists             = { 101110,  274586, 1 }, -- Vivify heals all allies with your Renewing Mist active for $s1, reduced beyond $s2 allies
+    invoke_chiji                   = { 101129,  325197, 1 }, -- Summon an effigy of Chi-Ji for $s1 sec that kicks up $s2 Gust of Mists when you Blackout Kick, Rising Sun Kick, or Spinning Crane Kick, healing up to $s3 allies for $s4, and reducing the cost and cast time of your next Enveloping Mist by $s5%, stacking. Chi-Ji's presence makes you immune to movement impairing effects
     invoke_chiji_the_red_crane     = { 101129,  325197, 1 }, -- Summon an effigy of Chi-Ji for $s1 sec that kicks up $s2 Gust of Mists when you Blackout Kick, Rising Sun Kick, or Spinning Crane Kick, healing up to $s3 allies for $s4, and reducing the cost and cast time of your next Enveloping Mist by $s5%, stacking. Chi-Ji's presence makes you immune to movement impairing effects
+    invoke_yulon                   = { 101129,  322118, 1 }, -- Summons an effigy of Yu'lon, the Jade Serpent for $s1 sec. Yu'lon will heal injured allies with Soothing Breath, healing the target and up to $s2 allies for $s3 over $s4 sec. Enveloping Mist costs $s5% less mana while Yu'lon is active
     invoke_yulon_the_jade_serpent  = { 101129,  322118, 1 }, -- Summons an effigy of Yu'lon, the Jade Serpent for $s1 sec. Yu'lon will heal injured allies with Soothing Breath, healing the target and up to $s2 allies for $s3 over $s4 sec. Enveloping Mist costs $s5% less mana while Yu'lon is active
     invokers_delight               = { 101123,  388661, 1 }, -- You gain $s1% haste for $s2 sec after summoning your Celestial
     jade_bond                      = { 101113,  388031, 1 }, -- Chi Cocoons now apply Enveloping Mist for $s1 sec when they expire or are consumed, and Chi-Ji's Gusts of Mists healing is increased by $s2% and Yu'lon's Soothing Breath healing is increased by $s3%
@@ -191,19 +193,19 @@ spec:RegisterTalents( {
 
 -- PvP Talents
 spec:RegisterPvpTalents( {
-    absolute_serenity              = 5642, -- (455945)
-    counteract_magic               =  679, -- (353502)
-    dematerialize                  = 5398, -- (353361) Demateralize into mist while stunned, reducing damage taken by $s1%. Each second you remain stunned reduces this bonus by $s2%
-    eminence                       =   70, -- (353584)
-    feather_feet                   = 5669, -- (474441)
+    absolute_serenity              = 5642, -- (455945) Celestial Conduit now prevents all crowd control for its duration
+    counteract_magic               =  679, -- (353502) Removing hostile magic effects from a target increases the healing they receive from you by $s1% for $s2 sec, stacking up to $s3 times
+    dematerialize                  = 5398, -- (353361)
+    eminence                       =   70, -- (353584) Transcendence: Transfer can now be cast if you are stunned. Cooldown reduced by $s1 sec if you are not
+    feather_feet                   = 5669, -- (474441) You may now cast while moving during Lighter Than Air and its duration is now $s1 sec
     grapple_weapon                 = 3732, -- (233759) You fire off a rope spear, grappling the target's weapons and shield, returning them to you for $s1 sec
-    healing_sphere                 =  683, -- (205234)
-    jadefire_accord                = 5565, -- (406888)
+    healing_sphere                 =  683, -- (205234) Coalesces a Healing Sphere out of the mists at the target location after $s1 sec. If allies walk through it, they consume the sphere, healing themselves for $s2 and dispelling all harmful periodic magic effects. Maximum of $s3 Healing Spheres can be active by the Monk at any given time
+    jadefire_accord                = 5565, -- (406888) Jadefire Stomp's cooldown is reduced by $s1 sec. Enemies struck by Jadefire Stomp are snared by $s2% for $s3 sec
     mighty_ox_kick                 = 5539, -- (202370) You perform a Mighty Ox Kick, hurling your enemy a distance behind you
-    peaceweaver                    = 5395, -- (353313)
+    peaceweaver                    = 5395, -- (353313) Revival's cooldown is reduced by $s1%, and provides immunity to magical damage and harmful effects for $s2 sec
     rodeo                          = 5645, -- (355917) Every $s1 sec while Clash is off cooldown, your next Clash can be reactivated immediately to wildly Clash an additional enemy. This effect can stack up to $s2 times
-    zen_focus_tea                  = 1928, -- (468430)
-    zen_spheres                    = 5603, -- (410777)
+    zen_focus_tea                  = 1928, -- (468430) Thunder Focus Tea provides immunity to Silence and Interrupt effects for $s1 sec
+    zen_spheres                    = 5603, -- (410777) Forms a sphere of Hope or Despair above the target. Only one of each sphere can be active at a time.  Sphere of Hope: Heals for $s4 and increases your healing done to the target by $s5%.  Sphere of Despair: Deals $s$s8 Nature damage, Target deals $s9% less damage, and takes $s10% increased damage from all sources
 } )
 
 -- Auras

--- a/TheWarWithin/MonkWindwalker.lua
+++ b/TheWarWithin/MonkWindwalker.lua
@@ -136,6 +136,7 @@ spec:RegisterTalents( {
     hardened_soles                 = { 101047,  391383, 1 }, -- Blackout Kick critical strike chance increased by $s1% and critical damage increased by $s2%
     hit_combo                      = { 101216,  196740, 1 }, -- Each successive attack that triggers Combo Strikes in a row grants $s1% increased damage, stacking up to $s2 times
     inner_peace                    = { 101214,  397768, 1 }, -- Increases maximum Energy by $s1. Tiger Palm's Energy cost reduced by $s2
+    invoke_xuen                    = { 101206,  123904, 1 }, -- Summons an effigy of Xuen, the White Tiger for $s2 sec. Xuen attacks your primary target, and strikes $s3 enemies within $s4 yards every $s5 sec with Tiger Lightning for $s$s6 Nature damage. Every $s7 sec, Xuen strikes your enemies with Empowered Tiger Lightning dealing $s8% of the damage you have dealt to those targets in the last $s9 sec
     invoke_xuen_the_white_tiger    = { 101206,  123904, 1 }, -- Summons an effigy of Xuen, the White Tiger for $s2 sec. Xuen attacks your primary target, and strikes $s3 enemies within $s4 yards every $s5 sec with Tiger Lightning for $s$s6 Nature damage. Every $s7 sec, Xuen strikes your enemies with Empowered Tiger Lightning dealing $s8% of the damage you have dealt to those targets in the last $s9 sec
     invokers_delight               = { 101207,  388661, 1 }, -- You gain $s1% haste for $s2 sec after summoning your Celestial
     jade_ignition                  = { 101050,  392979, 1 }, -- Whenever you deal damage to a target with Fists of Fury, you gain a stack of Chi Energy up to a maximum of $s3 stacks. Using Spinning Crane Kick will cause the energy to detonate in a Chi Explosion, dealing $s$s4 Nature damage to all enemies within $s5 yards, reduced beyond $s6 targets$s$s7 The damage is increased by $s8% for each stack of Chi Energy
@@ -171,7 +172,7 @@ spec:RegisterTalents( {
 
     -- Conduit Of The Celestials
     august_dynasty                 = { 101235,  442818, 1 }, -- Casting Jadefire Stomp increases the damage of your next Rising Sun Kick by $s1%
-    celestial_conduit              = { 101243,  443028, 1 }, -- The August Celestials empower you, causing you to radiate $s$s2 Nature damage onto enemies and $s3 healing onto up to $s4 injured allies within $s5 yds over $s6 sec, split evenly among them. Healing and damage increased by $s7% per enemy struck, up to $s8%. You may move while channeling, but casting other healing or damaging spells cancels this effect
+    celestial_conduit              = { 101243,  443028, 1 }, -- The August Celestials empower you, causing you to radiate $s1 million Nature damage onto enemies and $s2 healing onto up to $s3 injured allies within $s4 yds over $s5 sec, split evenly among them. Healing and damage increased by $s6% per enemy struck, up to $s7%. You may move while channeling, but casting other healing or damaging spells cancels this effect
     chijis_swiftness               = { 101240,  443566, 1 }, -- Your movement speed is increased by $s1% during Celestial Conduit and by $s2% for $s3 sec after being assisted by any Celestial
     courage_of_the_white_tiger     = { 101242,  443087, 1 }, -- Tiger Palm has a chance to cause Xuen to claw your target for $s$s2 Physical damage, healing a nearby ally for $s3% of the damage done. Invoke Xuen, the White Tiger guarantees your next cast activates this effect
     flight_of_the_red_crane        = { 101234,  443255, 1 }, -- Rushing Jade Wind and Spinning Crane Kick have a chance to cause Chi-Ji to increase your energy regeneration by $s2% for $s3 sec and quickly rush to $s4 enemies, dealing $s$s5 Physical damage to each target struck
@@ -207,15 +208,15 @@ spec:RegisterTalents( {
 spec:RegisterPvpTalents( {
     absolute_serenity              = 5641, -- (455945) Celestial Conduit now prevents all crowd control for its duration
     grapple_weapon                 = 3052, -- (233759) You fire off a rope spear, grappling the target's weapons and shield, returning them to you for $s1 sec
-    perpetual_paralysis            = 5448, -- (357495)
-    predestination                 = 3744, -- (345829)
-    ride_the_wind                  =   77, -- (201372)
-    rising_dragon_sweep            = 5643, -- (460276)
+    perpetual_paralysis            = 5448, -- (357495) Paralysis range reduced by $s1 yards, but spreads to $s2 new enemies when removed
+    predestination                 = 3744, -- (345829) Killing a player with Touch of Death reduces the remaining cooldown of Touch of Karma by $s1 sec
+    ride_the_wind                  =   77, -- (201372) Flying Serpent Kick clears all snares from you when used and forms a path of wind in its wake, causing all allies who stand in it to have $s1% increased movement speed and to be immune to movement slowing effects
+    rising_dragon_sweep            = 5643, -- (460276) Whirling Dragon Punch knocks enemies up into the air and causes them to fall slowly until they reach the ground
     rodeo                          = 5644, -- (355917) Every $s1 sec while Clash is off cooldown, your next Clash can be reactivated immediately to wildly Clash an additional enemy. This effect can stack up to $s2 times
-    stormspirit_strikes            = 5610, -- (411098)
+    stormspirit_strikes            = 5610, -- (411098) Striking more than one enemy with Fists of Fury summons a Storm Spirit to focus your secondary target for $s1 sec, which will mimic any of your attacks that do not also strike the target for $s2% of normal damage
     tigereye_brew                  =  675, -- (247483) Consumes up to $s1 stacks of Tigereye Brew to empower your Physical abilities with wind for $s2 sec per stack consumed. Damage of your strikes are reduced, but bypass armor. For each $s3 Chi you consume, you gain a stack of Tigereye Brew
-    turbo_fists                    = 3745, -- (287681)
-    wind_waker                     = 3737, -- (357633)
+    turbo_fists                    = 3745, -- (287681) Fists of Fury now reduces all targets movement speed by $s1%, and you Parry all attacks while channelling Fists of Fury
+    wind_waker                     = 3737, -- (357633) Your movement enhancing abilities increases Windwalking on allies by $s1%, stacking $s2 additional times. Movement impairing effects are removed at $s3 stacks
 } )
 
 -- Auras


### PR DESCRIPTION
- All invoke celestial talents needed manual copies
- Manual copies now added to skeleton constants table. To quote Lt. Col John McRae in his poem, *In Flanders Fields*, "we will remember them".
  - Also added Rogue inevitable end spelling copies to constants table
- Merge Celestial Infusion and Celestial Brew into 1 spell, given that they basically function identically except apply a different buff, and given that Brew has no new APL yet. This allows the talent to work with the existing APL.