### PR TITLE
Shadow Crash has a fixed speed, not velocity

### DIFF
--- a/TheWarWithin/PriestShadow.lua
+++ b/TheWarWithin/PriestShadow.lua
@@ -2144,7 +2144,7 @@ spec:RegisterAbilities( {
         talent = "shadow_crash",
         startsCombat = true,
 
-        velocity = 2,
+        flightTime = 1.5,
 
         cycle = "vampiric_touch",
 


### PR DESCRIPTION
Shadow Crash was written with velocity, where the time to impact is calculated based off distance. See the wago.tools SpellMisc table for the spell, with the speed section. It is 1.5:
https://wago.tools/db2/SpellMisc?filter%5BSpellID%5D=205385&page=1

When looking at simc class modules also, it is outlined the same (and annotated for fixed travel time):
https://github.com/simulationcraft/simc/blob/thewarwithin/engine/class_modules/priest/sc_priest_shadow.cpp#L1841

Regardless of where you cast shadow crash, it'll always take 1.5 seconds to hit. No more, no less.