### PR TITLE
Hammer of Light

### DIFF
--- a/TheWarWithin/PaladinRetribution.lua
+++ b/TheWarWithin/PaladinRetribution.lua
@@ -1111,6 +1111,8 @@ spec:RegisterCombatLogEvent( function( _, subtype, _,  sourceGUID, sourceName, _
                 willBeFree = false
             end
         end
+
+        if SpellID == 427453 and freeHOLApplied > 0 then freeHOLApplied = 0 end
     end
 end )
 
@@ -1218,6 +1220,20 @@ spec:RegisterHook( "reset_precast", function ()
         -- This is the case where we've already seen it in combatlogs
         addStack( "hammer_of_light_ready" )
 
+    end
+
+    -- Debug snapshot for hammer_of_light
+    if Hekili.ActiveDebug then
+        Hekili:Debug( "Hammer of Light - freeHOLApplied: %.2f, willBeFree: %s, hammer_of_light_is_free: %s, hammer_of_light_will_be_free: %s, buff.hammer_of_light_ready.stack: %d, set_bonus.tww3: %d, buff.lights_deliverance.stack: %d, action.wake_of_ashes.time_since: %.2f",
+            freeHOLApplied or 0,
+            willBeFree and "TRUE" or "FALSE",
+            hammer_of_light_is_free and "TRUE" or "FALSE",
+            hammer_of_light_will_be_free and "TRUE" or "FALSE",
+            buff.hammer_of_light_ready.stack or 0,
+            set_bonus.tww3 or 0,
+            buff.lights_deliverance.stack or 0,
+            action.wake_of_ashes.time_since or 0
+        )
     end
 
 end )

--- a/TheWarWithin/PaladinRetribution.lua
+++ b/TheWarWithin/PaladinRetribution.lua
@@ -38,7 +38,6 @@ spec:RegisterResource( Enum.PowerType.Mana )
 
 -- Talents
 spec:RegisterTalents( {
-
     -- Paladin
     a_just_reward                  = { 103858,  469411, 1 }, -- After Cleanse Toxins successfully removes an effect from an ally, they are healed for $s1
     afterimage                     = {  93189,  385414, 1 }, -- After you spend $s1 Holy Power, your next Word of Glory echoes onto a nearby ally at $s2% effectiveness
@@ -1062,12 +1061,10 @@ local willBeFree = false
 
 spec:RegisterStateExpr( "hammer_of_light_is_free", function ()
     return ( query_time - freeHOLApplied ) < 12
-
 end )
 
 spec:RegisterStateExpr( "hammer_of_light_will_be_free", function ()
     return willBeFree
-
 end )
 
 local empyreanHammerCallers = {
@@ -1077,8 +1074,7 @@ local empyreanHammerCallers = {
     [336872] = true,
     [85256] = true,
     [427453] = true,
-
-     }
+}
 
 spec:RegisterCombatLogEvent( function( _, subtype, _,  sourceGUID, sourceName, _, _, destGUID, destName, destFlags, _, spellID, spellName )
     if sourceGUID == state.GUID then
@@ -1097,7 +1093,7 @@ spec:RegisterCombatLogEvent( function( _, subtype, _,  sourceGUID, sourceName, _
             -- This is the event where you actually gain the free cast for 12 seconds, separate from the 20 second cast window
             freeHOLApplied = ( subtype == "SPELL_AURA_APPLIED" ) and GetTime() or 0
             willBeFree = false
-            Hekili:ForceUpdate( "HAMMER_OF_LIGHT", true )
+            Hekili:ForceUpdate( "HAMMER_OF_LIGHT_APPLIED", true )
         elseif subtype == "SPELL_CAST_SUCCESS" and state.talent.lights_deliverance.enabled and empyreanHammerCallers[ spellID ] and state.talent.hammerfall.enabled then
             -- Not all-inclusive, but this adds more strength to the free HoL predictions
             local wake = GetSpellCooldown( 255937 )
@@ -1112,7 +1108,10 @@ spec:RegisterCombatLogEvent( function( _, subtype, _,  sourceGUID, sourceName, _
             end
         end
 
-        if SpellID == 427453 and freeHOLApplied > 0 then freeHOLApplied = 0 end
+        if spellID == 427453 and freeHOLApplied > 0 then
+            freeHOLApplied = 0 end
+            Hekili:ForceUpdate( "HAMMER_OF_LIGHT_CAST", true )
+        end
     end
 end )
 


### PR DESCRIPTION
## Summary
Overall, this change moves the handling of Hammer of Light into the combatlogs instead of simulation/trickery. I discovered a spell aura event, [433732](https://www.wowhead.com/spell=433732) whose application and removal directly correlate with the 12 second free cast window of the Lights Deliverance free cast. Note that this 12 second window is part of a 20 second buff, where after 12 seconds you **_can_** still cast it, but it will cost 5 holy power. The aura isn't "visible", but the events are shown in combatlog

More than 1 person mentioned this issue popping up after receiving season 3 ret pal tier, and the addon suggesting to cast it with insufficient resources.
## Hammer of Light combatlogs changes
- Remove all pre-existing code from `reset_precast` ... sorry. :)
- Declare `GetPlayerAuraBySpellID`, `GetSpellCooldown`
- `hammer_of_light_ready` had a spellID change this season. When testing on PTR, I thought it was a separate aura.
- `lights_deliverance` consumes at 50 instead of 60 now
- Move all stack handling into a `DeliverLight( incomingStacks )` function
- convert all buff / spend checks to account for the removal of the virtual aura `buff.hammer_of_light_free`
### Combatlogs setup
If `newly discovered hidden aura` is applied, then we know we have a 12 second free window. Once it fades, we know that the "free" hammer of light actually has a cost again, even though 8 seconds remain on the visible aura.

There are also a set of spells where, after a short delay, if you have 48-49 stacks, then you **_will_** have a free cast. While this is simulated in  handlers, this log entry keeps it grounded through multiple resets, and keeps the 2nd hammer recommendation more stable (less flickering) during that delay. The weird wake check with the category is to stop bad recommendations when the 50 stacks can't consume, and the category is to stop the GCD from temporarily showing hammer for ~1 second, because that call does return a cooldown during GCD.
## Unrelated fixes
- Divine hammer cooldown is 2 minutes, not 1
- Divine hammer extensions are 0.3, not 0.5
- Divine hammer cost doesn't depend on a non-existent talent anymore
- redundant blessing of dawn removal
