### PR TITLE
Fel-Scarred Havoc - Stop Applying Fake demonsurge_hardcast

### DIFF
--- a/TheWarWithin/DemonHunterHavoc.lua
+++ b/TheWarWithin/DemonHunterHavoc.lua
@@ -1205,7 +1205,9 @@ spec:RegisterHook( "reset_precast", function ()
         end
         if talent.demonic_intensity.enabled and cooldown.metamorphosis.remains then
             local metaApplied = buff.metamorphosis.applied - 0.2
-            if action.metamorphosis.lastCast >= metaApplied or action.eye_beam.lastCast >= metaApplied then
+            local metaLastCast = action.metamorphosis.lastCast
+            local beamLastCast = action.eye_beam.lastCast
+            if metaLastCast >= metaApplied or ( beamLastCast >= metaApplied and beamLastCast >= metaLastCast ) then
                 applyBuff( "demonsurge_hardcast", metaRemains )
             end
             for _, name in ipairs( demonsurge.hardcast ) do


### PR DESCRIPTION
With returning to the combined eye_beam/abyssal_gaze spell registration, this additional check is needed in reset_precast to ensure it's a hardcast demonsurge. I forgot this piece the first time.

- Fixes https://github.com/Hekili/hekili/issues/5151
- Fixes https://github.com/Hekili/hekili/issues/5154