### PR TITLE
Remove LibItemBuffs-1.0.xml inclusion

### DIFF
--- a/embeds.xml
+++ b/embeds.xml
@@ -21,7 +21,6 @@
 	<Script file="Libs\LibDataBroker-1.1\LibDataBroker-1.1.lua"/>
 	<Script file="Libs\LibDBIcon-1.0\LibDBIcon-1.0.lua"/>
 	<Script file="Libs\LibDualSpec-1.0\LibDualSpec-1.0.lua"/>
-	<Include file="Libs\LibItemBuffs-1.0\LibItemBuffs-1.0.xml"/>
 	<Include file="Libs\LibCustomGlow-1.0\LibCustomGlow-1.0.xml"/>
 	<Include file="Libs\LibChatAnims\LibChatAnims.xml"/>
 	<Include file="Libs\LibTranslit-1.0\LibTranslit-1.0.xml"/>


### PR DESCRIPTION
LibItemBuffs appears to be a dead dependency:
- Per a project search, there is no LibStub call for the library
- Per a project search, there is no call to any named function from it
- Other than the embeds.xml, there is no mention of LibItemBuffs anywhere
- Deleting the embeds entry and Libs/LibItemBuffs seems to cause no issues.
- [LibItemBuffs](https://github.com/AdiAddons/LibItemBuffs-1.0) has not had a release since 2016 and has not been updated since 2018
- The library includes non-Lua code - a 1MB PHP file used to generate the DB outside of WoW in the process of making the addon. While I don't see any harm there, it's unnecessary.