### PR TITLE
Handle Voidbinding CDR

### DIFF
--- a/State.lua
+++ b/State.lua
@@ -3336,8 +3336,8 @@ do
                         when 10s passes, the spell CD will jump from 5s to 6.5s.
                     ]]--
 
-                    if debuff.voidbinding.up and modRate and modRate ~= 1 then
-                        local extraTime = start + duration - query_time - debuff.voidbinding.remains                        
+                    if state.debuff.voidbinding.up and modRate and modRate ~= 1 then
+                        local extraTime = start + duration - state.query_time - state.debuff.voidbinding.remains
                         if extraTime > 0 then
                             if Hekili.ActiveDebug then Hekili:Debug( "Extending '%s' remaining cooldown by %.2f because the cooldown exceeds Voidbinding's remaining time by %.2f.", ( extraTime * 0.3 ), extraTime ) end
                             duration = duration + ( extraTime * 0.3 )

--- a/State.lua
+++ b/State.lua
@@ -3321,11 +3321,27 @@ do
                 local start, duration = 0, 0
 
                 if id > 0 then
-                    start, duration = GetCooldown( id )
+                    local _, modRate = nil, 1
+                    start, duration, _, modRate = GetCooldown( id )
+
                     local lossStart, lossDuration = GetSpellLossOfControlCooldown( id )
                     if lossStart and lossDuration and lossStart + lossDuration > start + duration then
                         start = lossStart
                         duration = lossDuration
+                    end
+
+                    --[[ 
+                        Void Emissary: Voidbinding
+                        If Voidbinding has 10s remaining, and the affected spell shows 15s remaining on its cooldown, then
+                        when 10s passes, the spell CD will jump from 5s to 6.5s.
+                    ]]--
+
+                    if debuff.voidbinding.up and modRate and modRate ~= 1 then
+                        local extraTime = start + duration - query_time - debuff.voidbinding.remains                        
+                        if extraTime > 0 then
+                            if Hekili.ActiveDebug then Hekili:Debug( "Extending '%s' remaining cooldown by %.2f because the cooldown exceeds Voidbinding's remaining time by %.2f.", ( extraTime * 0.3 ), extraTime ) end
+                            duration = duration + ( extraTime * 0.3 )
+                        end
                     end
                 end
 
@@ -3362,6 +3378,8 @@ do
                 if ability.charges and ability.charges > 1 then
                     local charges, _
                     charges, _, start, duration = GetSpellCharges( id )
+
+                    -- TODO: Determine if any charged abilities matter enough to solve for Voidbinding CDR.
 
                     if not duration then duration = max( ability.recharge or 0, ability.cooldown or 0 ) end
 

--- a/TheWarWithin/Classes.lua
+++ b/TheWarWithin/Classes.lua
@@ -1393,3 +1393,13 @@ do
 
     class.interruptibleFilters = interruptibleFilters
 end
+
+local all = class.specs[ 0 ]
+
+-- TWW (de)buff granted by Void Emissary; has 30% CD regeneration effect.
+
+all:RegisterAura( "voidbinding", {
+    id = 462661,
+    duration = 30,
+    max_stack = 1
+} )

--- a/TheWarWithin/Classes.lua
+++ b/TheWarWithin/Classes.lua
@@ -1393,13 +1393,3 @@ do
 
     class.interruptibleFilters = interruptibleFilters
 end
-
-local all = class.specs[ 0 ]
-
--- TWW (de)buff granted by Void Emissary; has 30% CD regeneration effect.
-
-all:RegisterAura( "voidbinding", {
-    id = 462661,
-    duration = 30,
-    max_stack = 1
-} )


### PR DESCRIPTION
So, this is annoying to test but the Voidbinding CDR buff in M+ can cause priority failures for extremely time-sensitive specializations.

If an ability's remaining cooldown is longer than the remaining time on Voidbinding, then when Voidbinding expires, the leftover time will snap back to the normal rate and move farther out.

Example:
 * Summon Demonic Tyrant has 45s remaining.
 * Voidbinding is applied for 30s causing cooldowns to recover 30% faster.  For every actual second that passes, 1.3s of cooldown time is recovered.
 * SDT's displayed cooldown goes from 45 to ( 45 * 1 / 1.3 ) = ~34.6s.  This number is based on the entire 45s being reduced.
 * After 30 seconds, Voidbinding expires.
 * SDT's displayed cooldown goes from ~4.6s to ~6s.

This lines up with Voidbinding causing 39s of cooldown recovery in 30s (30 * 1.3 = 39).  After 30 seconds, SDT's original 45s cooldown will have recovered 39s, leaving 6 normal seconds remaining.

For Demonology, timing Tyrant vs. Felguard, Vilefiend, or Dreadstalkers is very sensitive.

Example:
 * Voidbinding has 3 seconds remaining.
 * Summon Demonic Tyrant shows 13s remaining.
 * After 3s, Voidbinding expires.
 * SDT's displayed cooldown goes from 10s to ( 10 * 1.3 ) = 13s again.

SDT's 13s cooldown was actually 13 * 1.3 = 16.9s of real time, except Voidbinding's 3s recovered 3.9s of cooldown.  16.9 - 3.9 = 13.

*I think.*  This one is kinda hard to test since it requires a bunch of API checking and snapshots in M+ just before Voidbinding expires and just after Voidbinding expires.