### PR TITLE
More resilient set bonus metatable

### DIFF
--- a/State.lua
+++ b/State.lua
@@ -4971,58 +4971,58 @@ local mt_set_bonuses = {
             thewarwithin_season_3 = "tww3",
         }
 
-        -- Match hero tree set bonus: e.g. tww3_rider_of_the_apocalypse_2pc
-        local prefix, heroPieces = k:match( "^(.+)_([24])pc$" )
-        if prefix and heroPieces then
-            local heroSet, heroTree = prefix:match( "^([%w]+)_(.+)$" )
-
-            if heroSet and heroTree then
-                heroSet = aliasMap[ heroSet ] or heroSet
-                heroPieces = tonumber( heroPieces )
-
-                local count = rawget( t, heroSet )
-                if not count then return 0 end
-
-                if state.hero_tree and state.hero_tree.current == heroTree then
-                    return count >= heroPieces and 1 or 0
-                end
-                return 0
-            end
-        end
-
-        -- Match standard set bonus: e.g. tww2_2pc
-        local rawSet, pieces = k:match( "^([%w_]+)_([24])pc$" )
-        if rawSet and pieces then
-            rawSet = aliasMap[ rawSet ] or rawSet
+        -- Match specific set bonus effect checks, 2pc/4pc
+          -- standard (tww2_2pc)
+          -- hero tree (tww3_rider_of_the_apocalypse_2pc)
+        local prefix, pieces = k:match( "^(.+)_([24])pc$" )
+        if prefix and pieces then
             pieces = tonumber( pieces )
 
-            local count = rawget( t, rawSet )
-            if not count then return 0 end
-            return count >= pieces and 1 or 0
-        end
-
-        -- Match hero tree set name only: e.g. tww3_rider_of_the_apocalypse
-        local heroSet, heroTree = k:match( "^([%w]+)_(.+)$" )
-        if heroSet and heroTree then
-            heroSet = aliasMap[ heroSet ] or heroSet
-
-            local count = rawget( t, heroSet )
-            if not count then return 0 end
-
-            if state.hero_tree and state.hero_tree.current == heroTree then
-                return count
+            -- Try as hero tree first (contains additional underscore for hero tree name)
+            local heroSet, heroTree = prefix:match( "^([%w_]+)_(.+)$" )
+            if heroSet and heroTree then
+                heroSet = aliasMap[ heroSet ] or heroSet
+                local count = rawget( t, heroSet )
+                if count and state.hero_tree and state.hero_tree.current == heroTree then
+                    if count >= pieces then
+                        return 1
+                    end
+                end
             end
+
+            -- Try as standard set bonus (no additional hero tree part)
+            local standardSet = aliasMap[ prefix ] or prefix
+            local count = rawget( t, standardSet )
+            if count and count >= pieces then
+                return 1
+            end
+
+            -- No match found for this 2pc/4pc pattern
             return 0
         end
 
-        -- Match basic set name: e.g. tww3
-        local set = aliasMap[ k ] or k
-        local count = rawget( t, set )
-        if count then
-            return count
+        -- Check if this is a basic set name that should be aliased first
+        local aliasedKey = aliasMap[ k ]
+        if aliasedKey then
+            local count = rawget( t, aliasedKey )
+            return count or 0
         end
 
-        return 0
+        -- Match hero tree set name (tww3_rider_of_the_apocalypse)
+        local heroSet, heroTree = k:match( "^([%w_]+)_(.+)$" )
+        if heroSet and heroTree then
+            -- Hero tree set name
+            heroSet = aliasMap[ heroSet ] or heroSet
+            local count = rawget( t, heroSet )
+            if count and state.hero_tree and state.hero_tree.current == heroTree then
+                return count
+            end
+            return 0
+        else
+            -- Basic set name (no alias found, no underscores)
+            local count = rawget( t, k )
+            return count or 0
+        end
     end
 }
 ns.metatables.mt_set_bonuses = mt_set_bonuses


### PR DESCRIPTION
Several expressions were falling through the cracks in this metatable. I restructured it to flow as follows:

- Attempts `_2pc` and `_4pc` matching first
  - if this format is detected, try hero tree first (`tww3_rider_of_the_apocalypse_2pc`)
    - Check alias map within this scope
    - Return 1 or continue on
  - If nothing, try regular (`tww3_2pc` or `thewarwithin_season_3_2pc`)
    - Check alias map within this scope
    - Return 1 or continue on
  - If still nothing return 0. Nothing else to check because it matched the `_2pc`/`_4pc` format.
- If it doesn't fit the `_2pc` /`_4pc` format, then check the "count" format (`set_bonus.tww3 >= 4`)
  - Check alias map first, quick return if found at this point
  - Check hero set (`tww3_rider_of_the_apocalypse`)
    - Check alias of her set (there currently are none related to this, but the framework is in place for future inserts to alias map table)
    - return 0 if nothing found
  - If it didn't match hero set format, check the basic format (`tww3`)
    - Return 0 if nothing

Fixes https://github.com/Hekili/hekili/issues/5236
Fixes https://github.com/Hekili/hekili/issues/5238


<img width="385" height="357" alt="image" src="https://github.com/user-attachments/assets/e260d398-4b24-46d7-9869-4a500d72d22d" />
