### PR TITLE
wrong Veng SHA

### DIFF
--- a/TheWarWithin/Priorities/DemonHunterVengeance.simc
+++ b/TheWarWithin/Priorities/DemonHunterVengeance.simc
@@ -1,5 +1,5 @@
 ## Upstream: https://github.com/simulationcraft/simc/blob/thewarwithin/ActionPriorityLists/default/demonhunter_vengeance.simc
-## SimulationCraft Commit Sync: 04a038d
+## SimulationCraft Commit Sync: 65d756b
 ## Date: 2025-08-11
 
 actions.precombat+=/variable,name=single_target,value=active_enemies=1


### PR DESCRIPTION
The [latest commit](<https://github.com/simulationcraft/simc/commit/65d756bcf7ed919294e79a236c64e6008edae8f8>) is reflected in our version, dated Aug 11 (Aug 5th for SimC)