### PR TITLE
strict_if to bool vs raw

### DIFF
--- a/Scripts.lua
+++ b/Scripts.lua
@@ -1303,6 +1303,7 @@ local newModifiers = {
     moving = 'bool',
     only_cwc = 'bool',
     strict = 'bool',
+    strict_if = 'bool',
     target_if = 'bool',
     use_off_gcd = 'bool',
     use_while_casting = 'bool',
@@ -1319,7 +1320,6 @@ local newModifiers = {
     sec = 'raw',
     value = 'raw',
     value_else = 'raw',
-    strict_if = 'raw',
 
     sync = 'string', -- should be an ability's name.
     action_name = 'string',


### PR DESCRIPTION
strict_if as raw is failing the check currently present in the APL for Arcane Mage. The Hekili APL is as follows:
actions+=/call_action_list,name=cd_opener,strict_if=!variable.soul_cd,if=!variable.soul_cd&(cooldown.touch_of_the_magi.remains<2*gcd.max|cooldown.evocation.remains<2*gcd.max|cooldown.arcane_surge.remains<2*gcd.max)
actions+=/call_action_list,name=cd_opener_soul,strict_if=variable.soul_cd,if=variable.soul_cd&(cooldown.touch_of_the_magi.remains<2*gcd.max|cooldown.evocation.remains<2*gcd.max|cooldown.arcane_surge.remains<2*gcd.max)

This will cause variable.soul_cd to be 0 or 1, which the strict_if type of 'raw' will not equate 0 as a boolean of false, since in lua, 0 isn't falsey