### PR TITLE
Arcane Intuition Improvements

### DIFF
--- a/TheWarWithin/MageArcane.lua
+++ b/TheWarWithin/MageArcane.lua
@@ -767,6 +767,10 @@ local intuition_blp_last_er_ae_timestamp = 0
 local intuition_blp_has_clearcasting = false
 local intuition_blp_is_harmony_intuition = false
 
+-- Intuition consumption tracking for charge flicker fix
+local intuition_just_consumed = false
+local intuition_consumed_timestamp = 0
+
 -- Spell IDs that can trigger BLP stack increment
 local intuitionBLPSpellIDs = {
     [30451] = true,   -- arcane_blast
@@ -829,6 +833,9 @@ spec:RegisterHook( "COMBAT_LOG_EVENT_UNFILTERED", function( _, subtype, _, sourc
                 elseif subtype == "SPELL_AURA_REMOVED" then
                     if not intuition_blp_is_harmony_intuition then
                         intuitionBLPStacks = 0 -- Reset BLP on normal intuition consumption
+                        -- Track consumption for charge flicker fix
+                        intuition_just_consumed = true
+                        intuition_consumed_timestamp = now
                     end
                     intuition_blp_is_harmony_intuition = false
                 end
@@ -848,6 +855,9 @@ end, false )
 
 spec:RegisterEvent( "PLAYER_REGEN_ENABLED", function ()
     totm_casts = 0
+    -- Clear intuition consumption tracking
+    intuition_just_consumed = false
+    intuition_consumed_timestamp = 0
 end )
 
 -- Reset BLP tracking on encounter/M+ start
@@ -1315,6 +1325,18 @@ spec:RegisterHook( "reset_precast", function ()
     end
 
     if arcane_charges.current > 0 then applyBuff( "arcane_charge", nil, arcane_charges.current ) end
+
+    -- Fix charge flicker after Intuition consumption
+    if talent.intuition.enabled and intuition_just_consumed then
+        local time_since_consumption = query_time - intuition_consumed_timestamp
+        -- If within the flicker window (0.5 seconds), fake having 4 charges
+        if time_since_consumption < gcd.max and arcane_charges.current < 4 then
+            applyBuff( "arcane_charge", nil, 4 )
+        elseif time_since_consumption >= gcd.max then
+            -- Clear the flag after the flicker period
+            intuition_just_consumed = false
+        end
+    end
 
     if buff.arcane_surge.up and set_bonus.tier30_4pc > 0 then
         state:QueueAuraEvent( "arcane_overload", TriggerArcaneOverloadT30, buff.arcane_surge.expires, "AURA_EXPIRATION" )

--- a/TheWarWithin/MageArcane.lua
+++ b/TheWarWithin/MageArcane.lua
@@ -824,7 +824,7 @@ spec:RegisterHook( "COMBAT_LOG_EVENT_UNFILTERED", function( _, subtype, _, sourc
                 if subtype == "SPELL_AURA_APPLIED" then
                     local harmony_aura = GetPlayerAuraBySpellID( 384455 ) -- arcane_harmony
                     local harmony_stacks = harmony_aura and harmony_aura.applications or 0
-                    intuition_blp_is_harmony_intuition = ( harmony_stacks == 20 ) and state.set_bonus.tww2 >= 4 and state.hero_tree.spellslinger
+                    intuition_blp_is_harmony_intuition = ( harmony_stacks == 20 ) and state.set_bonus.tww3_spellslinger >= 4 or false
 
                 elseif subtype == "SPELL_AURA_REMOVED" then
                     if not intuition_blp_is_harmony_intuition then
@@ -1123,7 +1123,7 @@ spec:RegisterHook( "runHandler", function( action )
     -- Virtually increment BLP for intuition tracking
     if talent.intuition.enabled and not buff.intuition.up then
         local spellID = class.abilities[ action ] and class.abilities[ action ].id
-        if spellID and intuitionBLPSpellIDs[ spellID ] or action == "arcane_orb" then
+        if ( spellID and intuitionBLPSpellIDs[ spellID ] or action == "arcane_orb" ) and buff.intuition.down then
             if intuition_blp_stacks == 10 then
                 applyBuff( "intuition" )
                 intuition_blp_stacks = 0
@@ -1302,6 +1302,14 @@ spec:RegisterHook( "reset_precast", function ()
    --[[ if pet.rune_of_power.up then applyBuff( "rune_of_power", pet.rune_of_power.remains )
     else removeBuff( "rune_of_power" ) end --]]
 
+        -- Initialize BLP tracking state for clearcasting detection and reset virtual counter
+    if talent.intuition.enabled then
+        intuition_blp_has_clearcasting = buff.clearcasting.up
+        intuition_blp_stacks = nil -- Reset to sync with real CLEU variable
+        if buff.intuition.up then intuition_blp_stacks = 0 end
+        if Hekili.ActiveDebug then Hekili:Debug( strformat( "Intuition Bad Luck protection: %s of 10 unlucky casts. Next cast will grant buff: %s", intuitionBLPStacks, ( intuitionBLPStacks == 10 and "Yes" or "No" ) ) ) end
+    end
+
     if buff.casting.up and buff.casting.v1 == 5143 and abs( action.arcane_missiles.lastCast - clearcasting_consumed ) < 0.15 then
         applyBuff( "clearcasting_channel", buff.casting.remains )
     end
@@ -1328,11 +1336,6 @@ spec:RegisterHook( "reset_precast", function ()
         state:QueueAuraExpiration( "touch_of_the_magi", NetherMunitions, debuff.touch_of_the_magi.expires )
     end
 
-    -- Initialize BLP tracking state for clearcasting detection and reset virtual counter
-    if talent.intuition.enabled then
-        intuition_blp_has_clearcasting = buff.clearcasting.up
-        intuition_blp_stacks = nil -- Reset to sync with real CLEU variable
-    end
 end )
 
 -- Abilities

--- a/TheWarWithin/MageArcane.lua
+++ b/TheWarWithin/MageArcane.lua
@@ -768,6 +768,11 @@ local intuitionBLPHasClearcasting = false
 local intuitionBLPIsHarmonyIntuition = false
 local hasIntuitionBuff = false
 
+local function delayedIntuitionBLPStack()
+    if hasIntuitionBuff then return end
+    intuitionBLPStacks = intuitionBLPStacks + 1
+end
+
 -- Intuition consumption tracking for charge flicker fix
 local intuition_just_consumed = false
 local intuition_consumed_timestamp = 0
@@ -783,15 +788,13 @@ local intuitionBLPSpellIDs = {
 
 spec:RegisterHook( "COMBAT_LOG_EVENT_UNFILTERED", function( _, subtype, _, sourceGUID, sourceName, _, _, destGUID, destName, destFlags, _, spellID, spellName )
     if sourceGUID == GUID then
-
         if subtype == "SPELL_CAST_SUCCESS" and spellID == 321507 then
             totm_casts = ( totm_casts + 1 ) % 2
 
         elseif ( subtype == "SPELL_AURA_APPLIED" or subtype == "SPELL_AURA_REFRESH" ) and spellID == 458411 then
             -- Handle Arcane Orb projectile.
-            local now = GetTime()
             local travel = ( UnitExists( "target" ) and select( 2, RC:GetRange( "target" ) ) or 40 ) / 30
-            state:QueueEvent( "arcane_orb", now, 0.05 + travel, "PROJECTILE_IMPACT", UnitGUID( "target" ), true )
+            state:QueueEvent( "arcane_orb", GetTime(), 0.05 + travel, "PROJECTILE_IMPACT", UnitGUID( "target" ), true )
 
         elseif subtype == "SPELL_AURA_REMOVED" and ( spellID == 276743 or spellID == 263725 ) then
             -- Clearcasting was consumed.
@@ -808,11 +811,7 @@ spec:RegisterHook( "COMBAT_LOG_EVENT_UNFILTERED", function( _, subtype, _, sourc
                     intuitionBLPStacks = intuitionBLPStacks + 1
 
                 elseif subtype == "SPELL_CAST_SUCCESS" and spellID == 1449 and intuitionBLPHasClearcasting then -- echoed arcane explosion
-                    C_Timer.After( 0.5, function()
-                        if not hasIntuitionBuff then
-                            intuitionBLPStacks = intuitionBLPStacks + 1
-                        end
-                    end )
+                    C_Timer.After( 0.5, delayedIntuitionBLPStack )
 
                 elseif subtype == "SPELL_DAMAGE" and spellID == 461508 then -- energy reconstitution arcane explosion
                     local now = GetTime()
@@ -830,7 +829,7 @@ spec:RegisterHook( "COMBAT_LOG_EVENT_UNFILTERED", function( _, subtype, _, sourc
                     if state.set_bonus.tww3_spellslinger >= 4 then
                         local harmony_aura = GetPlayerAuraBySpellID( 384455 ) -- arcane_harmony
                         local harmony_stacks = harmony_aura and harmony_aura.applications or 0
-                        intuitionBLPIsHarmonyIntuition = ( harmony_stacks == 20 ) or false
+                        intuitionBLPIsHarmonyIntuition = ( harmony_stacks == 20 )
                     end
                 elseif subtype == "SPELL_AURA_REMOVED" then
                     hasIntuitionBuff = false
@@ -838,7 +837,7 @@ spec:RegisterHook( "COMBAT_LOG_EVENT_UNFILTERED", function( _, subtype, _, sourc
                         intuitionBLPStacks = 0 -- Reset BLP on normal intuition consumption
                         -- Track consumption for charge flicker fix
                         intuition_just_consumed = true
-                        intuition_consumed_timestamp = now
+                        intuition_consumed_timestamp = GetTime()
                     end
                     intuitionBLPIsHarmonyIntuition = false
                 end
@@ -865,7 +864,7 @@ end )
 
 -- Reset BLP tracking on encounter/M+ start
 spec:RegisterEvent( "ENCOUNTER_START", function ()
-        intuitionBLPStacks = 0
+    intuitionBLPStacks = 0
 end )
 
 spec:RegisterEvent( "CHALLENGE_MODE_START", function ()
@@ -1312,10 +1311,7 @@ local NetherMunitions = setfenv( function()
 end, state )
 
 spec:RegisterHook( "reset_precast", function ()
-   --[[ if pet.rune_of_power.up then applyBuff( "rune_of_power", pet.rune_of_power.remains )
-    else removeBuff( "rune_of_power" ) end --]]
-
-        -- Initialize BLP tracking state for clearcasting detection and reset virtual counter
+    -- Initialize BLP tracking state for clearcasting detection and reset virtual counter
     if talent.intuition.enabled then
         intuitionBLPHasClearcasting = buff.clearcasting.up
         intuition_blp_stacks = nil -- Reset to sync with real CLEU variable
@@ -1332,12 +1328,10 @@ spec:RegisterHook( "reset_precast", function ()
     -- Fix charge flicker after Intuition consumption
     if talent.intuition.enabled and intuition_just_consumed then
         local time_since_consumption = query_time - intuition_consumed_timestamp
-        -- If within the flicker window (0.5 seconds), fake having 4 charges
-        if time_since_consumption < gcd.max and arcane_charges.current < 4 then
+        if time_since_consumption >= gcd.max then intuition_just_consumed = false
+        elseif time_since_consumption < gcd.max and arcane_charges.current < 4 then
+            -- If within the flicker window (GCD), fake having 4 charges
             applyBuff( "arcane_charge", nil, 4 )
-        elseif time_since_consumption >= gcd.max then
-            -- Clear the flag after the flicker period
-            intuition_just_consumed = false
         end
     end
 
@@ -1360,7 +1354,6 @@ spec:RegisterHook( "reset_precast", function ()
     if talent.nether_munitions.enabled and debuff.touch_of_the_magi.up then
         state:QueueAuraExpiration( "touch_of_the_magi", NetherMunitions, debuff.touch_of_the_magi.expires )
     end
-
 end )
 
 -- Abilities

--- a/TheWarWithin/MageArcane.lua
+++ b/TheWarWithin/MageArcane.lua
@@ -21,7 +21,7 @@ local abs, ceil, floor, max, sqrt = math.abs, math.ceil, math.floor, math.max, m
 -- local GetSpellCastCount = C_Spell.GetSpellCastCount
 -- local GetSpellInfo = C_Spell.GetSpellInfo
 -- local GetSpellInfo = ns.GetUnpackedSpellInfo
--- local GetPlayerAuraBySpellID = C_UnitAuras.GetPlayerAuraBySpellID
+local GetPlayerAuraBySpellID = C_UnitAuras.GetPlayerAuraBySpellID
 local FindUnitBuffByID, FindUnitDebuffByID = ns.FindUnitBuffByID, ns.FindUnitDebuffByID
 -- local IsSpellOverlayed = C_SpellActivationOverlay.IsSpellOverlayed
 local IsSpellKnownOrOverridesKnown = C_SpellBook.IsSpellInSpellBook
@@ -761,25 +761,102 @@ end )
 local totm_casts = 0
 local clearcasting_consumed = 0
 
+-- Intuition Bad Luck Protection tracking
+local intuitionBLPStacks = 0
+local intuition_blp_last_er_ae_timestamp = 0
+local intuition_blp_has_clearcasting = false
+local intuition_blp_is_harmony_intuition = false
+
+-- Spell IDs that can trigger BLP stack increment
+local intuitionBLPSpellIDs = {
+    [30451] = true,   -- arcane_blast
+    [5143] = true,    -- arcane_missiles
+    [44425] = true,   -- arcane_barrage
+    [1449] = true,    -- arcane_explosion
+    [365350] = true,  -- arcane_surge
+}
+
 spec:RegisterHook( "COMBAT_LOG_EVENT_UNFILTERED", function( _, subtype, _, sourceGUID, sourceName, _, _, destGUID, destName, destFlags, _, spellID, spellName )
     if sourceGUID == GUID then
+        local now = GetTime()
+
         if subtype == "SPELL_CAST_SUCCESS" and spellID == 321507 then
             totm_casts = ( totm_casts + 1 ) % 2
 
         elseif ( subtype == "SPELL_AURA_APPLIED" or subtype == "SPELL_AURA_REFRESH" ) and spellID == 458411 then
             -- Handle Arcane Orb projectile.
             local travel = ( UnitExists( "target" ) and select( 2, RC:GetRange( "target" ) ) or 40 ) / 30
-            state:QueueEvent( "arcane_orb", GetTime(), 0.05 + travel, "PROJECTILE_IMPACT", UnitGUID( "target" ), true )
+            state:QueueEvent( "arcane_orb", now, 0.05 + travel, "PROJECTILE_IMPACT", UnitGUID( "target" ), true )
 
         elseif subtype == "SPELL_AURA_REMOVED" and ( spellID == 276743 or spellID == 263725 ) then
             -- Clearcasting was consumed.
-            clearcasting_consumed = GetTime()
+            clearcasting_consumed = now
+
+        -- Intuition BLP tracking
+        elseif state.talent.intuition.enabled then
+            local has_intuition_buff = GetPlayerAuraBySpellID( 1223797 ) -- intuition buff
+
+            -- Handle BLP stack increments (only when Intuition buff is not active)
+            if not has_intuition_buff then
+                if subtype == "SPELL_CAST_SUCCESS" and intuitionBLPSpellIDs[ spellID ] then
+                    intuitionBLPStacks = intuitionBLPStacks + 1
+
+                elseif subtype == "SPELL_ENERGIZE" and spellID == 153626 then -- arcane_orb
+                    intuitionBLPStacks = intuitionBLPStacks + 1
+
+                elseif subtype == "SPELL_CAST_SUCCESS" and spellID == 1449 and intuition_blp_has_clearcasting then -- echoed arcane explosion
+                    C_Timer.After( 0.5, function()
+                        if not GetPlayerAuraBySpellID( 1223797 ) then
+                            intuitionBLPStacks = intuitionBLPStacks + 1
+                        end
+                    end )
+
+                elseif subtype == "SPELL_DAMAGE" and spellID == 461508 then -- energy reconstitution arcane explosion
+                    if now - intuition_blp_last_er_ae_timestamp > 0.1 then
+                        intuition_blp_last_er_ae_timestamp = now
+                        intuitionBLPStacks = intuitionBLPStacks + 1
+                    end
+                end
+            end
+
+            -- Handle Intuition proc consumption and BLP reset
+            if spellID == 1223797 then -- intuition
+                if subtype == "SPELL_AURA_APPLIED" then
+                    local harmony_aura = GetPlayerAuraBySpellID( 384455 ) -- arcane_harmony
+                    local harmony_stacks = harmony_aura and harmony_aura.applications or 0
+                    intuition_blp_is_harmony_intuition = ( harmony_stacks == 20 ) and state.set_bonus.tww2 >= 4 and state.hero_tree.spellslinger
+
+                elseif subtype == "SPELL_AURA_REMOVED" then
+                    if not intuition_blp_is_harmony_intuition then
+                        intuitionBLPStacks = 0 -- Reset BLP on normal intuition consumption
+                    end
+                    intuition_blp_is_harmony_intuition = false
+                end
+            end
+
+            -- Track clearcasting for echoed arcane explosion detection
+            if spellID == 263725 or spellID == 276743 then -- clearcasting
+                if subtype == "SPELL_AURA_APPLIED" or subtype == "SPELL_AURA_APPLIED_DOSE" then
+                    intuition_blp_has_clearcasting = true
+                elseif subtype == "SPELL_AURA_REMOVED" then
+                    intuition_blp_has_clearcasting = false
+                end
+            end
         end
     end
 end, false )
 
 spec:RegisterEvent( "PLAYER_REGEN_ENABLED", function ()
     totm_casts = 0
+end )
+
+-- Reset BLP tracking on encounter/M+ start
+spec:RegisterEvent( "ENCOUNTER_START", function ()
+        intuitionBLPStacks = 0
+end )
+
+spec:RegisterEvent( "CHALLENGE_MODE_START", function ()
+    intuitionBLPStacks = 0
 end )
 
 -- actions.precombat+=/variable,name=conserve_mana,op=set,value=0
@@ -1042,6 +1119,19 @@ spec:RegisterHook( "runHandler", function( action )
         local ability = class.abilities[ action ]
         if ability and ability.cast > 0 and ability.cast < 10 then removeStack( "ice_floes" ) end
     end
+
+    -- Virtually increment BLP for intuition tracking
+    if talent.intuition.enabled and not buff.intuition.up then
+        local spellID = class.abilities[ action ] and class.abilities[ action ].id
+        if spellID and intuitionBLPSpellIDs[ spellID ] or action == "arcane_orb" then
+            if intuition_blp_stacks == 10 then
+                applyBuff( "intuition" )
+                intuition_blp_stacks = 0
+            else
+                intuition_blp_stacks = intuition_blp_stacks + 1
+            end
+        end
+    end
 end )
 
 spec:RegisterStateTable( "incanters_flow", {
@@ -1199,6 +1289,10 @@ spec:RegisterStateExpr( "full_reduction", function ()
     return action.shifting_power.cdr
 end )
 
+spec:RegisterStateExpr( "intuition_blp_stacks", function ()
+    return talent.intuition.enabled and intuitionBLPStacks or 0
+end )
+
 local NetherMunitions = setfenv( function()
     applyDebuff( "target", "nether_munitions" )
     active_dot.nether_munitions = true_active_enemies
@@ -1232,6 +1326,12 @@ spec:RegisterHook( "reset_precast", function ()
 
     if talent.nether_munitions.enabled and debuff.touch_of_the_magi.up then
         state:QueueAuraExpiration( "touch_of_the_magi", NetherMunitions, debuff.touch_of_the_magi.expires )
+    end
+
+    -- Initialize BLP tracking state for clearcasting detection and reset virtual counter
+    if talent.intuition.enabled then
+        intuition_blp_has_clearcasting = buff.clearcasting.up
+        intuition_blp_stacks = nil -- Reset to sync with real CLEU variable
     end
 end )
 
@@ -1437,7 +1537,7 @@ spec:RegisterAbilities( {
 
         startsCombat = true,
 
-        usable = function () return not settings.check_explosion_range or target.maxR < 10, "target out of range" end,
+        usable = function () if state.spec.arcane then return not settings.check_explosion_range or target.maxR < 10, "target out of range" end end,
         handler = function ()
             if buff.expanded_potential.up then removeBuff( "expanded_potential" )
             else

--- a/TheWarWithin/MageArcane.lua
+++ b/TheWarWithin/MageArcane.lua
@@ -763,9 +763,10 @@ local clearcasting_consumed = 0
 
 -- Intuition Bad Luck Protection tracking
 local intuitionBLPStacks = 0
-local intuition_blp_last_er_ae_timestamp = 0
-local intuition_blp_has_clearcasting = false
-local intuition_blp_is_harmony_intuition = false
+local intuitionBLPLastErAeTimestamp = 0
+local intuitionBLPHasClearcasting = false
+local intuitionBLPIsHarmonyIntuition = false
+local hasIntuitionBuff = false
 
 -- Intuition consumption tracking for charge flicker fix
 local intuition_just_consumed = false
@@ -782,42 +783,41 @@ local intuitionBLPSpellIDs = {
 
 spec:RegisterHook( "COMBAT_LOG_EVENT_UNFILTERED", function( _, subtype, _, sourceGUID, sourceName, _, _, destGUID, destName, destFlags, _, spellID, spellName )
     if sourceGUID == GUID then
-        local now = GetTime()
 
         if subtype == "SPELL_CAST_SUCCESS" and spellID == 321507 then
             totm_casts = ( totm_casts + 1 ) % 2
 
         elseif ( subtype == "SPELL_AURA_APPLIED" or subtype == "SPELL_AURA_REFRESH" ) and spellID == 458411 then
             -- Handle Arcane Orb projectile.
+            local now = GetTime()
             local travel = ( UnitExists( "target" ) and select( 2, RC:GetRange( "target" ) ) or 40 ) / 30
             state:QueueEvent( "arcane_orb", now, 0.05 + travel, "PROJECTILE_IMPACT", UnitGUID( "target" ), true )
 
         elseif subtype == "SPELL_AURA_REMOVED" and ( spellID == 276743 or spellID == 263725 ) then
             -- Clearcasting was consumed.
-            clearcasting_consumed = now
+            clearcasting_consumed = GetTime()
 
         -- Intuition BLP tracking
         elseif state.talent.intuition.enabled then
-            local has_intuition_buff = GetPlayerAuraBySpellID( 1223797 ) -- intuition buff
-
             -- Handle BLP stack increments (only when Intuition buff is not active)
-            if not has_intuition_buff then
+            if not hasIntuitionBuff then
                 if subtype == "SPELL_CAST_SUCCESS" and intuitionBLPSpellIDs[ spellID ] then
                     intuitionBLPStacks = intuitionBLPStacks + 1
 
                 elseif subtype == "SPELL_ENERGIZE" and spellID == 153626 then -- arcane_orb
                     intuitionBLPStacks = intuitionBLPStacks + 1
 
-                elseif subtype == "SPELL_CAST_SUCCESS" and spellID == 1449 and intuition_blp_has_clearcasting then -- echoed arcane explosion
+                elseif subtype == "SPELL_CAST_SUCCESS" and spellID == 1449 and intuitionBLPHasClearcasting then -- echoed arcane explosion
                     C_Timer.After( 0.5, function()
-                        if not GetPlayerAuraBySpellID( 1223797 ) then
+                        if not hasIntuitionBuff then
                             intuitionBLPStacks = intuitionBLPStacks + 1
                         end
                     end )
 
                 elseif subtype == "SPELL_DAMAGE" and spellID == 461508 then -- energy reconstitution arcane explosion
-                    if now - intuition_blp_last_er_ae_timestamp > 0.1 then
-                        intuition_blp_last_er_ae_timestamp = now
+                    local now = GetTime()
+                    if now - intuitionBLPLastErAeTimestamp > 0.1 then
+                        intuitionBLPLastErAeTimestamp = now
                         intuitionBLPStacks = intuitionBLPStacks + 1
                     end
                 end
@@ -826,27 +826,30 @@ spec:RegisterHook( "COMBAT_LOG_EVENT_UNFILTERED", function( _, subtype, _, sourc
             -- Handle Intuition proc consumption and BLP reset
             if spellID == 1223797 then -- intuition
                 if subtype == "SPELL_AURA_APPLIED" then
-                    local harmony_aura = GetPlayerAuraBySpellID( 384455 ) -- arcane_harmony
-                    local harmony_stacks = harmony_aura and harmony_aura.applications or 0
-                    intuition_blp_is_harmony_intuition = ( harmony_stacks == 20 ) and state.set_bonus.tww3_spellslinger >= 4 or false
-
+                    hasIntuitionBuff = true
+                    if state.set_bonus.tww3_spellslinger >= 4 then
+                        local harmony_aura = GetPlayerAuraBySpellID( 384455 ) -- arcane_harmony
+                        local harmony_stacks = harmony_aura and harmony_aura.applications or 0
+                        intuitionBLPIsHarmonyIntuition = ( harmony_stacks == 20 ) or false
+                    end
                 elseif subtype == "SPELL_AURA_REMOVED" then
-                    if not intuition_blp_is_harmony_intuition then
+                    hasIntuitionBuff = false
+                    if not intuitionBLPIsHarmonyIntuition then
                         intuitionBLPStacks = 0 -- Reset BLP on normal intuition consumption
                         -- Track consumption for charge flicker fix
                         intuition_just_consumed = true
                         intuition_consumed_timestamp = now
                     end
-                    intuition_blp_is_harmony_intuition = false
+                    intuitionBLPIsHarmonyIntuition = false
                 end
             end
 
             -- Track clearcasting for echoed arcane explosion detection
             if spellID == 263725 or spellID == 276743 then -- clearcasting
                 if subtype == "SPELL_AURA_APPLIED" or subtype == "SPELL_AURA_APPLIED_DOSE" then
-                    intuition_blp_has_clearcasting = true
+                    intuitionBLPHasClearcasting = true
                 elseif subtype == "SPELL_AURA_REMOVED" then
-                    intuition_blp_has_clearcasting = false
+                    intuitionBLPHasClearcasting = false
                 end
             end
         end
@@ -1314,7 +1317,7 @@ spec:RegisterHook( "reset_precast", function ()
 
         -- Initialize BLP tracking state for clearcasting detection and reset virtual counter
     if talent.intuition.enabled then
-        intuition_blp_has_clearcasting = buff.clearcasting.up
+        intuitionBLPHasClearcasting = buff.clearcasting.up
         intuition_blp_stacks = nil -- Reset to sync with real CLEU variable
         if buff.intuition.up then intuition_blp_stacks = 0 end
         if Hekili.ActiveDebug then Hekili:Debug( strformat( "Intuition Bad Luck protection: %s of 10 unlucky casts. Next cast will grant buff: %s", intuitionBLPStacks, ( intuitionBLPStacks == 10 and "Yes" or "No" ) ) ) end


### PR DESCRIPTION
# Additional minor change (not intuition)
Modify arcane explosion `usable` so that it doesn't lock frost and fire out of custom APL entries that want to be out of range (weird mana drain thing for a trinket). 

Caused by spell inherited from Arcane, but range check setting not being inherited and thus inaccessible.
# The First Intuition Problem
There is a delay before you receive the 4 charges, which can cause arcane orb recommendation flickers depending on exactly when the engine does a reset.
## Solution
Use real events to determine if we consumed intuition and arcane charges are on their way, fake it in `reset_precast`, much the same way we fake lots of delayed events. This successfully prevents arcane orb from briefly appearing then going away after using an intuition-barrage.

# The Second Intuition Problem
Arcane mage intuition: Every damaging spell has a 5% chance to grant intuition. However, if you go "dry" 10 spells in a row, your 11th cast is guaranteed to proc the buff.

This proc also generally changes the rotation, so when it comes it is a surprise to the user. By correctly predicting this bad luck protection on the 11th cast, we can cause some (not all) of the intuition procs to be stable.
## Solution
Very similar to ascendance procs for Enhance shaman.
- Unqueryable hidden tracker
- Use CLEU to increment a local variable
- Use state expression to return variable, with proper nil-ing
- Use expression to virtually apply intuition if we can
- Reset local variable when appropriate

## Sample rotation improvements.

### Excerpt 1 - Buff predicted on new code
This except demonstrates when we predicted the buff succesfully (confirmed with weakaura side-by-side), granted by recommendation #1, utilized in recommendation #2
```
### Auras ###

player_buffs:
     n  | ID      | Token                     | Name                     | A. Count | A. Remains | S. Count | S. Remains
    --- | ------- | ------------------------- | ------------------------ | -------- | ---------- | -------- | ----------
     1  |  458388 |  aether_attunement_stack  | Aether Attunement        |        2 |    3600.00 |        2 |    3599.64
     2  |  210126 |  arcane_familiar          | Arcane Familiar          |        1 |    3489.41 |        1 |    3489.41
     3  |    1459 |  arcane_intellect         | Arcane Intellect         |        1 |    3489.41 |        1 |    3489.41
     4  |  383997 |  arcane_tempo             | Arcane Tempo             |        3 |       4.54 |        3 |       4.54
     5  |  263725 |  clearcasting             | Clearcasting             |        1 |      17.83 |        1 |      17.83
     6  |      -1 | *dawnthread_lining        | Dawnthread Lining        |        1 |    3600.00 |       -1 |      -1.00
     7  | 1217242 |  enlightened              | Enlightened              |        1 |    3600.00 |        1 |    3599.64
     8  |  116267 |  incanters_flow           | Incanter's Flow          |        4 |    3600.00 |        4 |    3599.64
     9  |  394195 |  overflowing_energy       | Overflowing Energy       |        3 |       7.26 |        3 |       7.26
     10 |      -1 | *sign_of_battle           | Sign of Battle           |        1 |    3600.00 |       -1 |      -1.00
     11 |      -1 | *unstable_power_suit_core | Unstable Power Suit Core |        1 |      12.71 |       -1 |      -1.00
     12 |      -1 | *viziers_supremacy        | Vizier's Supremacy       |        1 |    3600.00 |       -1 |      -1.00

...
New Recommendations for [ Primary ] requested at 15:49:09 ( 584958.70 ); using built-in ( Arcane ) priority.
*** START OF NEW DISPLAY: Primary ***
Purged 780 marked values in 0.17ms.
Intuition Bad Luck protection: 10 of 10 unlucky casts. Next cast will grant buff: Yes
Combat Timer: 11.44
...

        43.  arcane_missiles ( spellslinger - 10 )
        The action (arcane_missiles) is usable at (0.00 + 0.00).
         - the action is ready before the current recommendation (at +0.00 vs. +3.35).
        List ( spellslinger ) called from ( Arcane:default:20 ) would PASS at 0.00.
        ! talent.spellfire_spheres.enabled[false]
         - this entry's criteria PASSES: ( buff.clearcasting.up[true] & buff.nether_precision.down[true] & ( ( cooldown.touch_of_the_magi.remains[34.64] > gcd.max[1.20] * 7 & cooldown.arcane_surge.remains[90.00] > gcd.max[1.20] * 7 ) | buff.clearcasting.stack[1.00] > 1 | ! talent.magis_spark.enabled[true] | ( cooldown.touch_of_the_magi.remains[34.64] < gcd.max[1.20] * 4 & buff.aether_attunement.down[true] ) | set_bonus.thewarwithin_season_2_4pc[0.00] ) ) | ( fight_remains[569.08] < 5 & buff.clearcasting.up[true] )
        Action chosen:  arcane_missiles at 0.00!
        Texture shown:  %s
        Exiting spellslinger with recommendation of arcane_missiles at +0.00s.
        Returned from list (spellslinger), current recommendation is arcane_missiles (+0.00).
        - spellslinger
        The recommended action (arcane_missiles) is ready in less than 0.2s; exiting list (default).
        Exiting default with recommendation of arcane_missiles at +0.00s.
    
    Completed default action list [ Arcane - default ].
    Recommendation is arcane_missiles at 0.00 + 0.00.
    Recommendation #1 is arcane_missiles at 0.00s (0.00s).
    Queueing arcane_missiles channel finish at 578879.41 [0.00+1.60].
    Queued arcane_missiles from 578877.81 to 578879.41 (CHANNEL_FINISH).
    Queued arcane_missiles from 578877.81 to 578878.21 (CHANNEL_TICK).
    Queued arcane_missiles from 578877.81 to 578878.61 (CHANNEL_TICK).
    Queued arcane_missiles from 578877.81 to 578879.01 (CHANNEL_TICK).
    Queued arcane_missiles from 578877.81 to 578879.41 (CHANNEL_TICK).
    Queued 4 ticks of channel arcane_missiles.
    Queued arcane_missiles from 578877.81 to 578879.01 (GCD_FINISH).
    Running arcane_missiles at 578877.81.

RECOMMENDATION #2 ( Offset: 0.00, GCD: 1.20, Channeling: 1.99 ).

        45.  arcane_barrage ( spellslinger - 12 )
        The action (arcane_barrage) is usable at (1.20 + 0.00).
         - the action is ready before the current recommendation (at +0.00 vs. +0.39).
        List ( spellslinger ) called from ( Arcane:default:20 ) would PASS at 0.00.
        ! talent.spellfire_spheres.enabled[false]
         - this entry's criteria PASSES: buff.intuition.up[true]
        Action chosen:  arcane_barrage at 0.00!
        Texture shown:  %s
        Exiting spellslinger with recommendation of arcane_barrage at +0.00s.
        Returned from list (spellslinger), current recommendation is arcane_barrage (+0.00).
        - spellslinger
        The recommended action (arcane_barrage) is ready in less than 0.2s; exiting list (default).
        Exiting default with recommendation of arcane_barrage at +0.00s.

```

### Excerpt 2 - buff not predicted
This is where **_I commented out the virtual application of the buff_**, mimicking current live behaviour. We can see it doesn't know intuition is coming for recommendation #2
```
### Auras ###

player_buffs:
     n  | ID      | Token                     | Name                     | A. Count | A. Remains | S. Count | S. Remains
    --- | ------- | ------------------------- | ------------------------ | -------- | ---------- | -------- | ----------
     1  |  453601 |  aether_attunement        | Aether Attunement        |        1 |      29.46 |        1 |      29.46
     2  |  210126 |  arcane_familiar          | Arcane Familiar          |        1 |    3342.45 |        1 |    3342.45
     3  |  384455 |  arcane_harmony           | Arcane Harmony           |        8 |    3600.00 |        8 |    3599.63
     4  |    1459 |  arcane_intellect         | Arcane Intellect         |        1 |    3342.45 |        1 |    3342.45
     5  |  383997 |  arcane_tempo             | Arcane Tempo             |        4 |       6.59 |        4 |       6.59
     6  |      -1 | *dawnthread_lining        | Dawnthread Lining        |        1 |    3600.00 |       -1 |      -1.00
     7  | 1217242 |  enlightened              | Enlightened              |        1 |    3600.00 |        1 |    3599.63
     8  |  116267 |  incanters_flow           | Incanter's Flow          |        1 |    3600.00 |        1 |    3599.63
     9  |  383783 |  nether_precision         | Nether Precision         |        2 |       7.87 |        2 |       7.87
     10 |  394195 |  overflowing_energy       | Overflowing Energy       |        3 |       7.55 |        3 |       7.55
     11 |      -1 | *sign_of_battle           | Sign of Battle           |        1 |    3600.00 |       -1 |      -1.00
     12 |      -1 | *unstable_power_suit_core | Unstable Power Suit Core |        1 |      10.74 |       -1 |      -1.00
     13 |      -1 | *viziers_supremacy        | Vizier's Supremacy       |        1 |    3600.00 |       -1 |      -1.00

...
Intuition Bad Luck protection: 10 of 10 unlucky casts. Next cast will grant buff: Yes
...

        47.  arcane_blast ( spellslinger - 14 )
        The action (arcane_blast) is usable at (0.00 + 0.00) with cost of 378124 mana (have 2806631).
         - the action is ready before the current recommendation (at +0.00 vs. +5.42).
        List ( spellslinger ) called from ( Arcane:default:20 ) would PASS at 0.00.
        ! talent.spellfire_spheres.enabled[false]
         - this entry's criteria PASSES: buff.nether_precision.up[true] & buff.arcane_harmony.stack[8.00] <= 16 & buff.arcane_charge.stack[4.00] = 4 & active_enemies[1.00] = 1
        Action chosen:  arcane_blast at 0.00!
        Texture shown:  %s
        Exiting spellslinger with recommendation of arcane_blast at +0.00s.
        Returned from list (spellslinger), current recommendation is arcane_blast (+0.00).
        - spellslinger
        The recommended action (arcane_blast) is ready in less than 0.2s; exiting list (default).
        Exiting default with recommendation of arcane_blast at +0.00s.
    
    Completed default action list [ Arcane - default ].
    Recommendation is arcane_blast at 0.00 + 0.00.
    Recommendation #1 is arcane_blast at 0.00s (0.00s).
    Queueing arcane_blast cast finish at 579025.97 [+1.20] on Creature-0-3138-2552-11589-225985-000031D1AD.
    Queued arcane_blast from 579024.78 to 579025.97 (CAST_FINISH).

RECOMMENDATION #2 ( Offset: 0.00, GCD: 1.17, Casting: 1.20 ).

        45.  arcane_barrage ( spellslinger - 12 )
        The action (arcane_barrage) is usable at (1.20 + 0.00).
         - the action is ready before the current recommendation (at +0.00 vs. +4.23).
        List ( spellslinger ) called from ( Arcane:default:20 ) would PASS at 0.00.
        ! talent.spellfire_spheres.enabled[false]
         - this entry's criteria FAILS: buff.intuition.up[false]
        There were no recheck events to check.
        Time spent on this action:  0.05ms
        TimeData:Arcane-spellslinger-12:arcane_barrage:x0:0.05:Ability Known, Enabled(0.01):Post-TTR and Essential(0.01):Post Cycle(0.00):Post Usable(0.00):Post Ready/Clash(0.01):Post Stack(0.01):Pre-Script(0.00):Post-Script(0.00):Pre-Recheck(0.00):Post-Recheck Times(0.00):Post Recheck(0.00)
        

        
        47.  arcane_blast ( spellslinger - 14 )
        The action (arcane_blast) is usable at (1.20 + 0.00) with cost of 378124 mana (have 2507171).
         - the action is ready before the current recommendation (at +0.00 vs. +4.23).
        List ( spellslinger ) called from ( Arcane:default:20 ) would PASS at 0.00.
        ! talent.spellfire_spheres.enabled[false]
         - this entry's criteria PASSES: buff.nether_precision.up[true] & buff.arcane_harmony.stack[8.00] <= 16 & buff.arcane_charge.stack[4.00] = 4 & active_enemies[1.00] = 1
        Action chosen:  arcane_blast at 0.00!
        Texture shown:  %s
        Exiting spellslinger with recommendation of arcane_blast at +0.00s.
        Returned from list (spellslinger), current recommendation is arcane_blast (+0.00).
        - spellslinger
        The recommended action (arcane_blast) is ready in less than 0.2s; exiting list (default).
        Exiting default with recommendation of arcane_blast at +0.00s.
    
    Completed default action list [ Arcane - default ].
    Recommendation is arcane_blast at 1.20 + 0.00.
    Recommendation #2 is arcane_blast at 0.00s (1.20s).
    Queueing arcane_blast cast finish at 579027.17 [+2.40] on Creature-0-3138-2552-11589-225985-000031D1AD.
    Queued arcane_blast from 579025.97 to 579027.17 (CAST_FINISH).
```

### Excerpt 3 - Recommendation Jump
This is immediately after excerpt 2, I casted the blast and then took this. Can see that the recommendation #2 changed itself to exactly what we predicted with excerpt 1.

```
### Auras ###

player_buffs:
     n  | ID      | Token                     | Name                     | A. Count | A. Remains | S. Count | S. Remains
    --- | ------- | ------------------------- | ------------------------ | -------- | ---------- | -------- | ----------
     1  |  453601 |  aether_attunement        | Aether Attunement        |        1 |      24.81 |        1 |      24.81
     2  |  210126 |  arcane_familiar          | Arcane Familiar          |        1 |    3337.80 |        1 |    3337.80
     3  |  384455 |  arcane_harmony           | Arcane Harmony           |        8 |    3600.00 |        8 |    3599.84
     4  |    1459 |  arcane_intellect         | Arcane Intellect         |        1 |    3337.80 |        1 |    3337.80
     5  |  383997 |  arcane_tempo             | Arcane Tempo             |        4 |       1.94 |        4 |       1.94
     6  |  263725 |  clearcasting             | Clearcasting             |        1 |      17.38 |        1 |      17.38
     7  |      -1 | *dawnthread_lining        | Dawnthread Lining        |        1 |    3600.00 |       -1 |      -1.00
     8  | 1217242 |  enlightened              | Enlightened              |        1 |    3600.00 |        1 |    3599.84
     9  |  116267 |  incanters_flow           | Incanter's Flow          |        5 |    3600.00 |        5 |    3599.84
     10 | 1223797 |  intuition                | Intuition                |        1 |       2.38 |        1 |       2.38
     11 |  383783 |  nether_precision         | Nether Precision         |        1 |       3.21 |        1 |       3.21
     12 |  394195 |  overflowing_energy       | Overflowing Energy       |        4 |       5.52 |        4 |       5.52
     13 |      -1 | *sign_of_battle           | Sign of Battle           |        1 |    3600.00 |       -1 |      -1.00
     14 |      -1 | *unstable_power_suit_core | Unstable Power Suit Core |        1 |       6.09 |       -1 |      -1.00
     15 |      -1 | *viziers_supremacy        | Vizier's Supremacy       |        1 |    3600.00 |       -1 |      -1.00

        45.  arcane_barrage ( spellslinger - 12 )
        The action (arcane_barrage) is usable at (0.00 + 0.00).
         - the action is ready before the current recommendation (at +0.00 vs. +0.77).
        List ( spellslinger ) called from ( Arcane:default:20 ) would PASS at 0.00.
        ! talent.spellfire_spheres.enabled[false]
         - this entry's criteria PASSES: buff.intuition.up[true]
        Action chosen:  arcane_barrage at 0.00!
        Texture shown:  %s
        Exiting spellslinger with recommendation of arcane_barrage at +0.00s.
        Returned from list (spellslinger), current recommendation is arcane_barrage (+0.00).
        - spellslinger
        The recommended action (arcane_barrage) is ready in less than 0.2s; exiting list (default).
        Exiting default with recommendation of arcane_barrage at +0.00s.
    
    Completed default action list [ Arcane - default ].
    Recommendation is arcane_barrage at 0.00 + 0.00.
    Recommendation #1 is arcane_barrage at 0.00s (0.00s).
    Running arcane_barrage at 579029.43.

RECOMMENDATION #2 ( Offset: 0.00, GCD: 1.17, Casting: 0.00 ).
```