### PR TITLE
Clean up table.x, math.x, string.x calls

### DIFF
--- a/Classes.lua
+++ b/Classes.lua
@@ -19,7 +19,8 @@ local getSpecializationKey = ns.getSpecializationKey
 
 local LSR = LibStub( "SpellRange-1.0" )
 
-local insert, wipe = table.insert, table.wipe
+-- Tables
+local insert, remove, sort, wipe = table.insert, table.remove, table.sort, table.wipe
 
 local mt_resource = ns.metatables.mt_resource
 
@@ -594,7 +595,7 @@ local HekiliSpecMixin = {
                 if arg2.items then
                     for _, item in ipairs( arg2.items ) do
                         if not gear[ item ] then
-                            table.insert( gear, item )
+                            insert( gear, item )
                             gear[ item ] = true
                             found = true
                         end
@@ -615,7 +616,7 @@ local HekiliSpecMixin = {
                     local item = select( i, ... )
 
                     if not gear[ item ] then
-                        table.insert( gear, item )
+                        insert( gear, item )
                         gear[ item ] = true
                         found = true
                     end
@@ -859,7 +860,7 @@ local HekiliSpecMixin = {
                                 else
                                     if self.pendingItemSpells[ a.itemSpellName ] then
                                         if type( self.pendingItemSpells[ a.itemSpellName ] ) == "table" then
-                                            table.insert( self.pendingItemSpells[ a.itemSpellName ], ability )
+                                            insert( self.pendingItemSpells[ a.itemSpellName ], ability )
                                         else
                                             local first = self.pendingItemSpells[ a.itemSpellName ]
                                             self.pendingItemSpells[ a.itemSpellName ] = {
@@ -956,7 +957,7 @@ local HekiliSpecMixin = {
                         if v == a then class.abilityList[ k ] = nil end
                     end
                     Hekili.InvalidSpellIDs = Hekili.InvalidSpellIDs or {}
-                    table.insert( Hekili.InvalidSpellIDs, a.id )
+                    insert( Hekili.InvalidSpellIDs, a.id )
                     Hekili:Error( "Name info not available for " .. a.id .. "." )
                     return
                 end
@@ -1197,7 +1198,7 @@ local HekiliSpecMixin = {
     RegisterSetting = function( self, key, value, option )
         CommitKey( key )
 
-        table.insert( self.settings, {
+        insert( self.settings, {
             name = key,
             default = value,
             info = option
@@ -3536,7 +3537,7 @@ do
         { "prized_aspirants_badge_of_ferocity", 229491 },
         { "prized_gladiators_badge_of_ferocity", 229780 },
         { "astral_aspirants_badge_of_ferocity", 230352 },
-        { "astral_gladiators_badge_of_ferocity", 230638 }  
+        { "astral_gladiators_badge_of_ferocity", 230638 }
     }
 
     local pvp_badges_copy = {}
@@ -3808,7 +3809,7 @@ all:RegisterAbility( "the_horsemans_sinister_slicer", {
 
 ns.addToggle = function( name, default, optionName, optionDesc )
 
-    table.insert( class.toggles, {
+    insert( class.toggles, {
         name = name,
         state = default,
         option = optionName,
@@ -3824,7 +3825,7 @@ end
 
 ns.addSetting = function( name, default, options )
 
-    table.insert( class.settings, {
+    insert( class.settings, {
         name = name,
         state = default,
         option = options
@@ -3839,7 +3840,7 @@ end
 
 ns.addWhitespace = function( name, size )
 
-    table.insert( class.settings, {
+    insert( class.settings, {
         name = name,
         option = {
             name = " ",

--- a/Core.lua
+++ b/Core.lua
@@ -23,7 +23,7 @@ local trim = string.trim
 
 
 local tcopy = ns.tableCopy
-local tinsert, tremove, twipe = table.insert, table.remove, table.wipe
+local tinsert, tremove, twipe, tsort = table.insert, table.remove, table.wipe, table.sort
 
 
 -- checkImports()
@@ -302,7 +302,7 @@ local function blockHelper( ... )
         end
     end
 
-    table.sort( blockValues )
+    tsort( blockValues )
 end
 
 
@@ -2282,11 +2282,11 @@ function Hekili:DumpFrameInfo()
 
             db.peak = v.peakUsage
 
-            table.insert( usedCPU, db )
+            tinsert( usedCPU, db )
         end
     end
 
-    table.sort( usedCPU, function( a, b ) return a.usage < b.usage end )
+    tsort( usedCPU, function( a, b ) return a.usage < b.usage end )
 
     print( "Frame CPU Usage Data" )
     for i, v in ipairs( usedCPU ) do

--- a/Events.lua
+++ b/Events.lua
@@ -2184,7 +2184,7 @@ local function ReadKeybindings( event )
         -- Bartender4 support; if BT4 bindings are set, use them, otherwise fall back on default UI bindings below.
         -- This will still get viewed as misleading...
         if _G["Bartender4"] then
-            table.wipe( slotsUsed )
+            wipe( slotsUsed )
 
             for i = 1, 180 do
                 local keybind = "CLICK BT4Button" .. i .. ":Keybind"
@@ -2198,7 +2198,7 @@ local function ReadKeybindings( event )
 
         -- Dominos support
         elseif C_AddOns.IsAddOnLoaded("Dominos") then
-            table.wipe( slotsUsed )
+            wipe( slotsUsed )
 
             for i = 1, 14 do
                 local bar = _G["DominosFrame" .. i]
@@ -2242,7 +2242,7 @@ local function ReadKeybindings( event )
 
         -- Use ElvUI's actionbars only if they are actually enabled.
         elseif _G["ElvUI"] and _G[ "ElvUI_Bar1Button1" ] then
-            table.wipe( slotsUsed )
+            wipe( slotsUsed )
 
             for i = 1, 15 do
                 for b = 1, 12 do

--- a/Options/ChatCommands.lua
+++ b/Options/ChatCommands.lua
@@ -21,11 +21,11 @@ function Hekili:countPriorities()
 
     for priority, data in pairs( Hekili.DB.profile.packs ) do
         if data.spec == spec then
-            table.insert( priorities, priority )
+            insert( priorities, priority )
         end
     end
 
-    table.sort( priorities )
+    sort( priorities )
     return priorities
 end
 
@@ -42,7 +42,7 @@ function Hekili:CmdLine( input )
     -- Parse arguments into a table
     local args = {}
     for arg in string.gmatch( input, "%S+" ) do
-        table.insert( args, arg )
+        insert( args, arg )
     end
 
     -- Alias maps for argument substitutions

--- a/Options/DevTools.lua
+++ b/Options/DevTools.lua
@@ -242,7 +242,7 @@ function SkeletonGen:GetBuffTooltip( unit, index, filter )
     for i = 1, tooltip:NumLines() do
         local line = _G[ "HekiliTooltipTextLeft" .. i ]
         if line then
-            table.insert( tooltipText, line:GetText() or "" )
+            insert( tooltipText, line:GetText() or "" )
         end
     end
 
@@ -293,11 +293,11 @@ end
 
 --[[
 local function trackAuraApplication( token, spellID, time )
-    table.insert( SkeletonGen._applications, { token = token, id = spellID, time = time } )
+    insert( SkeletonGen._applications, { token = token, id = spellID, time = time } )
 end
 
 local function trackAuraRemoval( token, spellID, time )
-    table.insert( SkeletonGen._removals, { token = token, id = spellID, time = time } )
+    insert( SkeletonGen._removals, { token = token, id = spellID, time = time } )
 end
 
 local function assignAuraToLastCast( auraType, token, spellID )
@@ -609,14 +609,14 @@ function SkeletonGen:PrepareSpecData()
                                                 if not existingTalent.alternativeNodes then
                                                     existingTalent.alternativeNodes = {}
                                                 end
-                                                table.insert( existingTalent.alternativeNodes, nodeID )
+                                                insert( existingTalent.alternativeNodes, nodeID )
                                             end
                                         else
                                             -- Same node, same spell ID = should not happen, but track as alternative
                                             if not existingTalent.alternativeNodes then
                                                 existingTalent.alternativeNodes = {}
                                             end
-                                            table.insert( existingTalent.alternativeNodes, nodeID )
+                                            insert( existingTalent.alternativeNodes, nodeID )
                                         end
                                     end
 
@@ -707,7 +707,7 @@ function SkeletonGen:PrepareSpecData()
                 if not nameToSpells[ baseName ] then
                     nameToSpells[ baseName ] = {}
                 end
-                table.insert( nameToSpells[ baseName ], { token = token, spellID = talent.id, talent = talent, spellName = spellName } )
+                insert( nameToSpells[ baseName ], { token = token, spellID = talent.id, talent = talent, spellName = spellName } )
             end
         end
     end
@@ -727,7 +727,7 @@ function SkeletonGen:PrepareSpecData()
 
             if #spells == 2 and uniqueSpellCount == 2 then -- Only handle pairs with different spell IDs
                 -- Sort spells by ID to ensure consistent ordering
-                table.sort( spells, function( a, b ) return a.spellID < b.spellID end )
+                sort( spells, function( a, b ) return a.spellID < b.spellID end )
 
                 -- Check if we have custom suffixes for this talent in config
                 local customSuffixes = choiceNodeSuffixes[ baseName ]
@@ -792,9 +792,9 @@ function SkeletonGen:PrepareSpecData()
     local sorted = {}
     for k, v in pairs( self.pvptalents ) do
         v.name = k
-        table.insert( sorted, v )
+        insert( sorted, v )
     end
-    table.sort( sorted, function( a, b ) return a.name < b.name end )
+    sort( sorted, function( a, b ) return a.name < b.name end )
     self.pvptalents = {}
     for _, v in ipairs( sorted ) do
         self.pvptalents[ v.name ] = v
@@ -977,17 +977,17 @@ function SkeletonGen:Generate()
     for k, v in pairs( self.talents ) do
         local talentType = v.isHero and formatKey( v.tree or "unknown" ) or v.isSpec and specName or className
         groups[ talentType ] = groups[ talentType ] or {}
-        table.insert( groups[ talentType ], { k, v } )
+        insert( groups[ talentType ], { k, v } )
     end
 
     -- Capture hero tree keys for sorting
     local heroKeys = {}
     for k in pairs( groups ) do
         if k ~= className and k ~= specName then
-            table.insert( heroKeys, k )
+            insert( heroKeys, k )
         end
     end
-    table.sort( heroKeys )
+    sort( heroKeys )
 
     -- Class and Spec talents
     for _, section in ipairs( { className, specName } ) do
@@ -1005,7 +1005,7 @@ function SkeletonGen:Generate()
     for _, key in ipairs( heroKeys ) do
         local list = groups[ key ]
         if list then
-            table.sort( list, function( a, b ) return a[ 1 ] < b[ 1 ] end )
+            sort( list, function( a, b ) return a[ 1 ] < b[ 1 ] end )
             self:Blank()
             self:Append( "-- " .. TitleCase( key ) )
             for _, entry in ipairs( list ) do

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -4145,7 +4145,7 @@ self:ForceUpdate( "SPEC_PACKAGE_CHANGED" )
                 width = 1.5,
                 order = 2,
                 values = function ()
-                    table.wipe( toggles )
+                    wipe( toggles )
 
                     local t = class.abilities[ v ].toggle or "none"
                     if t == "essences" then t = "covenants" end
@@ -4280,7 +4280,7 @@ self:ForceUpdate( "SPEC_PACKAGE_CHANGED" )
                         width = 1.5,
                         order = 1.2,
                         values = function ()
-                            table.wipe( toggles )
+                            wipe( toggles )
 
                             local t = class.abilities[ v ].toggle or "none"
                             if t == "essences" then t = "covenants" end
@@ -4567,7 +4567,7 @@ found = true end
                 width = 1.5,
                 order = 3,
                 values = function ()
-                    table.wipe( toggles )
+                    wipe( toggles )
 
                     toggles.none = "None"
                     toggles.default = "Default" .. ( class.abilities[ v ].toggle and ( " |cffffd100(" .. class.abilities[ v ].toggle .. ")|r" ) or " |cffffd100(none)|r" )
@@ -4683,7 +4683,7 @@ found = true end
                         width = 1.5,
                         order = 3,
                         values = function ()
-                            table.wipe( toggles )
+                            wipe( toggles )
 
                             toggles.none = "None"
                             toggles.default = "Default" .. ( class.abilities[ v ].toggle and ( " |cffffd100(" .. class.abilities[ v ].toggle .. ")|r" ) or " |cffffd100(none)|r" )
@@ -5204,11 +5204,11 @@ found = true end
                                             "\nThis setting determines how much time can be used to generate recommendations.\n\n" ..
                                             "|cFFFFD100• Higher values|r allow recommendations to |cFF00FF00update more quickly|r but may risk lowering your frame rate, " ..
                                             "especially when other addons are working at the same time.\n" ..
-                                            "|cFFFFD100• Lower values|r mean recommendations may update more slowly but may |cFF00FF00preserve your frame rate|r.\n\n" .. 
-                                            
+                                            "|cFFFFD100• Lower values|r mean recommendations may update more slowly but may |cFF00FF00preserve your frame rate|r.\n\n" ..
+
                                             "Adjust this budget to balance |cFF00FF00smooth gameplay|r and |cFF00FF00responsive recommendations|r. " ..
                                             "Use the highest value that feels smooth on your system without your screen freezing or stuttering.\n\n" ..
-                                            
+
                                             "|cFF00B4FFDefault (recommended)|r: |cFFFFD10070%|r\n\n" ..
 
                                             "At |cFFFFD700" .. format( "%.1f", fps ) .. " FPS|r, a budget of |cFFFFD700" .. ( budget * 100 ) .. "%|r " ..
@@ -5676,7 +5676,7 @@ found = true end
                                                     insert( listNames, k )
                                                 end
 
-                                                table.sort( listNames )
+                                                sort( listNames )
 
                                                 local o
 
@@ -7424,7 +7424,7 @@ n = tonumber( n ) + 1
                                                 local body = entry.text or "|cff777777<No message provided>|r"
                                                 local coloredKey = ColorizeAPLIdentifier( key )
 
-                                                table.insert( output, format(
+                                                insert( output, format(
                                                     "|cff888888[%s (%dx)]|r %s\n%s",
                                                     entry.last or "??", entry.n or 1, coloredKey, body
                                                 ))
@@ -7440,20 +7440,20 @@ n = tonumber( n ) + 1
 
                                         -- 1. Stress Test
                                         if type( stressTestResults ) == "string" and stressTestResults ~= "" then
-                                            table.insert( finalOutput, "|cffa0a0ffAutomatic Stress Test:|r " .. stressTestResults )
+                                            insert( finalOutput, "|cffa0a0ffAutomatic Stress Test:|r " .. stressTestResults )
                                         end
                                         -- 2. Header
                                         if exportData.linked then
-                                            table.insert( finalOutput, "|cffff0000WARNING:|r There are unresolved Warnings related to this priority. Please review before exporting." )
+                                            insert( finalOutput, "|cffff0000WARNING:|r There are unresolved Warnings related to this priority. Please review before exporting." )
                                         elseif exportData.unrelated then
-                                            table.insert( finalOutput, "|cffffff00NOTICE:|r There are unresolved Warnings since reloading the UI. These may not be related to this priority." )
+                                            insert( finalOutput, "|cffffff00NOTICE:|r There are unresolved Warnings since reloading the UI. These may not be related to this priority." )
                                         end
                                         -- 3. Error entries
                                         for _, line in ipairs( output ) do
-                                            table.insert( finalOutput, line )
+                                            insert( finalOutput, line )
                                         end
                                         if not exportData.linked and not exportData.unrelated and #output == 0 then
-                                            table.insert( finalOutput, "|cff00ff00No warnings or errors detected!|r\n" )
+                                            insert( finalOutput, "|cff00ff00No warnings or errors detected!|r\n" )
                                         end
 
                                         exportData.stress = table.concat( finalOutput, "\n\n" )

--- a/Scripts.lua
+++ b/Scripts.lua
@@ -18,7 +18,7 @@ local safeMax = ns.safeMax
 
 local format, trim = string.format, string.trim
 
-local twipe, insert = table.wipe, table.insert
+local twipe, insert, tremove = table.wipe, table.insert, table.remove
 
 
 -- Forgive the name, but this should properly replace ! characters with not, accounting for appropriate bracketing.
@@ -451,13 +451,13 @@ do
                     local subExpr = scripts:SplitExpr( meat )
 
                     for _, v in ipairs( subExpr ) do
-                        table.insert( output, v )
+                        insert( output, v )
                     end
                 else
-                    table.insert( output, expr )
+                    insert( output, expr )
                 end
             else
-                table.insert( output, expr )
+                insert( output, expr )
             end
             str = str:sub( finish + 2, str:len() )
         end
@@ -556,7 +556,7 @@ do
         { "^time_to_imps%.(.+)$" , "time_to_imps[%1]"             }, -- Demo Warlock
         { "^!?diabolic_ritual$"  , "buff.diabolic_ritual.remains" }, -- Warlocks
         { "^!?demonic_art$"      , "buff.demonic_art.remains"     },
-        
+
         { "^!?two_cast_imps>(.-)$" , "time_to_n_cast_imps_exceeds_y(2,1+(%1))" },
         { "^!?last_cast_imps>(.-)$", "time_to_n_cast_imps_exceeds_y(1,1+(%1))" },
 
@@ -935,7 +935,7 @@ do
                 if depth == 0 then
                     local expr = p:sub( 1, i )
 
-                    table.insert( results, {
+                    insert( results, {
                         s = expr:trim(),
                         t = "expr"
                     } )
@@ -951,7 +951,7 @@ do
                 if i > 1 then
                     local expr = p:sub( 1, i - 1 )
 
-                    table.insert( results, {
+                    insert( results, {
                         s = expr:trim(),
                         t = "expr"
                     } )
@@ -961,7 +961,7 @@ do
 
                 c = p:sub( i ):match( "^([&%|%-%+*%%/><!%?=%~@][&%|%-%+*/><%?=%~]?)" )
 
-                table.insert( results, {
+                insert( results, {
                     s = c,
                     t = "op",
                     a = c:trim() --sub(1,1)
@@ -979,7 +979,7 @@ do
         p = p:trim()
 
         if p:len() > 0 then
-            table.insert( results, {
+            insert( results, {
                     s = p:trim(),
                     t = "expr",
                     l = true
@@ -999,7 +999,7 @@ do
 
             -- If we get a math op (*) followed by a not (!) followed by an expression, we want to safely wrap up the !expr in safenum().
             if prev and prev.t == "op" and math_ops[ prev.a ] and piece.t == "op" and piece.a == "!" and next and next.t == "expr" then
-                table.remove( results, i )
+                tremove( results, i )
                 piece = results[ i ]
                 next = results[ i + 1 ]
                 piece.s = "(!" .. piece.s .. ")"
@@ -1023,7 +1023,7 @@ do
                         if abss then orig = orig:gsub( "@", " abs " ) end
 
                         esDepth = esDepth - 1
-                        table.remove( tree )
+                        tremove( tree )
 
                         return orig
                     end
@@ -1119,7 +1119,7 @@ do
         output = output:gsub( "%(%s*(%b())%s*%)", "%1" )
 
         esDepth = esDepth - 1
-        table.remove( tree )
+        tremove( tree )
         return output
     end
 end
@@ -1466,7 +1466,7 @@ local function ConvertScript( node, hasModifiers, header )
 
             if k:sub( 1, 8 ) == "variable" then
                 varPool = varPool or {}
-                table.insert( varPool, k:sub( 10 ) )
+                insert( varPool, k:sub( 10 ) )
             end
         end
 
@@ -1579,7 +1579,7 @@ local function ConvertScript( node, hasModifiers, header )
                         for k, v in pairs( modElements[ m ] ) do
                             if k:sub( 1, 8 ) == "variable" then
                                 varPool = varPool or {}
-                                table.insert( varPool, k:sub( 10 ) )
+                                insert( varPool, k:sub( 10 ) )
                             end
                         end
                     end

--- a/State.lua
+++ b/State.lua
@@ -1567,7 +1567,7 @@ do
                     v.name = k
 
                     if i > 0 and v.next >= 0 then
-                        table.insert( events, v )
+                        insert( events, v )
                     end
                 end
             end
@@ -1587,7 +1587,7 @@ do
             iter = iter + 1
 
             if e.next > finish or not r or not r.actual then
-                table.remove( events, 1 )
+                remove( events, 1 )
             else
                 now = e.next
 
@@ -1597,7 +1597,7 @@ do
                 local channel = ( e.channel and state.buff.casting.expires < now )
 
                 if stop or aura or channel then
-                    table.remove( events, 1 )
+                    remove( events, 1 )
                     local v = max( 0, min( r.max, r.forecast[ r.fcount ].v + bonus ) )
                     local idx
 
@@ -1642,7 +1642,7 @@ do
                     if e.next > finish or step < 0 or
                        ( e.aura and state[ e.debuff and "debuff" or "buff" ][ e.aura ].expires < e.next ) or
                        ( e.channel and state.buff.casting.expires < e.next ) then
-                        table.remove( events, 1 )
+                        remove( events, 1 )
                     end
                 end
 
@@ -6748,8 +6748,8 @@ function state:RunHandler( key, noStart )
     self.prev.last = key
     self[ ability.gcd == "off" and "prev_off_gcd" or "prev_gcd" ].last = key
 
-    table.insert( self.predictions, 1, key )
-    table.insert( self[ ability.gcd == "off" and 'predictionsOff' or 'predictionsOn' ], 1, key )
+    insert( self.predictions, 1, key )
+    insert( self[ ability.gcd == "off" and 'predictionsOff' or 'predictionsOn' ], 1, key )
 
     self.history.casts[ key ] = self.query_time
 

--- a/Targets.lua
+++ b/Targets.lua
@@ -753,7 +753,7 @@ end
 
 ns.wipeDebuffs = function()
     for k, _ in pairs(debuffs) do
-        table.wipe(debuffs[k])
+        wipe(debuffs[k])
         debuffCount[k] = 0
     end
 end

--- a/Targets.lua
+++ b/Targets.lua
@@ -752,9 +752,9 @@ function ns.saveDebuffModifier( id, val )
 end
 
 ns.wipeDebuffs = function()
-    for k, _ in pairs(debuffs) do
-        wipe(debuffs[k])
-        debuffCount[k] = 0
+    for k, _ in pairs( debuffs ) do
+        wipe( debuffs[ k ] )
+        debuffCount[ k ] = 0
     end
 end
 
@@ -763,22 +763,22 @@ ns.actorHasDebuff = function( target, spell )
 end
 
 ns.trackDebuff = function( spell, target, time, application, snapshotHaste )
-    debuffs[spell] = debuffs[spell] or {}
-    debuffCount[spell] = debuffCount[spell] or 0
+    debuffs[ spell ] = debuffs[ spell ] or {}
+    debuffCount[ spell ] = debuffCount[ spell ] or 0
 
     if not time then
-        if debuffs[spell][target] then
+        if debuffs[ spell ][target] then
             -- Remove it.
-            debuffs[spell][target] = nil
-            debuffCount[spell] = max( 0, debuffCount[spell] - 1 )
+            debuffs[ spell ][ target ] = nil
+            debuffCount[ spell ] = max( 0, debuffCount[ spell ] - 1 )
         end
     else
-        if not debuffs[spell][target] then
-            debuffs[spell][target] = {}
-            debuffCount[spell] = debuffCount[spell] + 1
+        if not debuffs[ spell ][ target ] then
+            debuffs[ spell ][ target ]= {}
+            debuffCount[ spell ] = debuffCount[ spell ] + 1
         end
 
-        local debuff = debuffs[spell][target]
+        local debuff = debuffs[ spell ][ target ]
 
         debuff.last_seen = time
         debuff.applied = debuff.applied or time

--- a/TheWarWithin/DeathKnightBlood.lua
+++ b/TheWarWithin/DeathKnightBlood.lua
@@ -40,7 +40,7 @@ spec:RegisterResource( Enum.PowerType.Runes, {
 
         interval = function( time, val )
             local r = state.runes
-            val = math.floor( val )
+            val = floor( val )
 
             if val == 6 then return -1 end
             return r.expiry[ val + 1 ] - time
@@ -72,17 +72,17 @@ spec:RegisterResource( Enum.PowerType.Runes, {
             t.expiry[ i ] = ready and 0 or ( start + duration )
             t.cooldown = duration
         end
-        table.sort( t.expiry )
+        sort( t.expiry )
         t.actual = nil -- Reset actual to force recalculation
     end,
 
     gain = function( amount )
         local t = state.runes
         for i = 1, amount do
-            table.insert( t.expiry, 0 )
+            insert( t.expiry, 0 )
             t.expiry[ 7 ] = nil
         end
-        table.sort( t.expiry )
+        sort( t.expiry )
         t.actual = nil
     end,
 
@@ -91,7 +91,7 @@ spec:RegisterResource( Enum.PowerType.Runes, {
 
         for i = 1, amount do
             t.expiry[ 1 ] = ( t.expiry[ 4 ] > 0 and t.expiry[ 4 ] or state.query_time ) + t.cooldown
-            table.sort( t.expiry )
+            sort( t.expiry )
         end
 
         local rpGainMultiplier = state.buff.rune_of_hysteria.up and 1.2 or 1
@@ -257,7 +257,7 @@ spec:RegisterCombatLogEvent( function( _, subtype, _, sourceGUID, sourceName, so
             end
 
             -- May require tuning.
-            local tOffset = math.abs( info.expirationTime - info.duration - GetTime() )
+            local tOffset = abs( info.expirationTime - info.duration - GetTime() )
             if tOffset < matchThreshold then
                 insert( storage, info.auraInstanceID )
                 while( #storage > 3 ) do storage[ remove( storage, 1 ) ] = nil end

--- a/TheWarWithin/DeathKnightFrost.lua
+++ b/TheWarWithin/DeathKnightFrost.lua
@@ -65,17 +65,17 @@ spec:RegisterResource( Enum.PowerType.Runes, {
             t.expiry[ i ] = ready and 0 or ( start + duration )
             t.cooldown = duration
         end
-        table.sort( t.expiry )
+        sort( t.expiry )
         t.actual = nil -- Reset actual to force recalculation
     end,
 
     gain = function( amount )
         local t = state.runes
         for i = 1, amount do
-            table.insert( t.expiry, 0 )
+            insert( t.expiry, 0 )
             t.expiry[ 7 ] = nil
         end
-        table.sort( t.expiry )
+        sort( t.expiry )
         t.actual = nil
     end,
 
@@ -83,8 +83,8 @@ spec:RegisterResource( Enum.PowerType.Runes, {
         local t = state.runes
         for i = 1, amount do
             local nextReady = ( t.expiry[ 4 ] > 0 and t.expiry[ 4 ] or state.query_time ) + t.cooldown
-            table.remove( t.expiry, 1 )
-            table.insert( t.expiry, nextReady )
+            remove( t.expiry, 1 )
+            insert( t.expiry, nextReady )
         end
 
         state.gain( amount * 10, "runic_power" )

--- a/TheWarWithin/DeathKnightUnholy.lua
+++ b/TheWarWithin/DeathKnightUnholy.lua
@@ -61,17 +61,17 @@ spec:RegisterResource( Enum.PowerType.Runes, {
             t.expiry[ i ] = ready and 0 or ( start + duration )
             t.cooldown = duration
         end
-        table.sort( t.expiry )
+        sort( t.expiry )
         t.actual = nil -- Reset actual to force recalculation
     end,
 
     gain = function( amount )
         local t = state.runes
         for i = 1, amount do
-            table.insert( t.expiry, 0 )
+            insert( t.expiry, 0 )
             t.expiry[ 7 ] = nil
         end
-        table.sort( t.expiry )
+        sort( t.expiry )
         t.actual = nil
     end,
 
@@ -79,8 +79,8 @@ spec:RegisterResource( Enum.PowerType.Runes, {
         local t = state.runes
         for i = 1, amount do
             local nextReady = ( t.expiry[ 4 ] > 0 and t.expiry[ 4 ] or state.query_time ) + t.cooldown
-            table.remove( t.expiry, 1 )
-            table.insert( t.expiry, nextReady )
+            remove( t.expiry, 1 )
+            insert( t.expiry, nextReady )
         end
 
         state.gain( amount * 10, "runic_power" )
@@ -1538,7 +1538,7 @@ local runeforges = {
 }
 
 local function ResetRuneforges()
-    table.wipe( state.death_knight.runeforge )
+    wipe( state.death_knight.runeforge )
 end
 
 local function UpdateRuneforge( slot, item )

--- a/TheWarWithin/DemonHunterVengeance.lua
+++ b/TheWarWithin/DemonHunterVengeance.lua
@@ -31,6 +31,7 @@ local IsSpellKnownOrOverridesKnown = C_SpellBook.IsSpellInSpellBook
 -- local IsActiveSpell = ns.IsActiveSpell
 
 -- Specialization-specific local functions (if any)
+local concat = table.concat
 
 spec:RegisterResource( Enum.PowerType.Fury, {
     -- Immolation Aura now grants 8 up front, then 2 per second
@@ -945,7 +946,7 @@ spec:RegisterHook( "reset_precast", function ()
         for i, activation_time in ipairs( true_inactive_fragments ) do
             insert( real_times, strformat( "%.2fs", activation_time - GetTime() ) )
         end
-        local real_str = #real_times > 0 and table.concat( real_times, ", " ) or "none"
+        local real_str = #real_times > 0 and concat( real_times, ", " ) or "none"
 
         Hekili:Debug( "Soul Fragments - Active: %d, Inactive: %d, Total: %d, Buff Stack: %d, Next: %.2fs, Real: [%s]",
             soul_fragments.active or 0,

--- a/TheWarWithin/DruidBalance.lua
+++ b/TheWarWithin/DruidBalance.lua
@@ -34,6 +34,8 @@ local GetSpellBookItemName = function( index, bookType )
     return C_SpellBook.GetSpellBookItemName( index, spellBank );
 end
 
+local concat = table.concat
+
 spec:RegisterResource( Enum.PowerType.Rage )
 spec:RegisterResource( Enum.PowerType.LunarPower, {
     fury_of_elune = {
@@ -1207,7 +1209,6 @@ do
 
     -- Flow:  Cast -> In Flight -> Application -> Ticks -> Removal -> In Flight -> Application -> Ticks -> Removal -> ...
     -- If the swarm target dies, it will jump again.
-    local insert, remove = table.insert, table.remove
 
     function Hekili:EmbedAdaptiveSwarm( s )
         s:RegisterCombatLogEvent( function( _, subtype, _,  sourceGUID, sourceName, _, _, destGUID, destName, destFlags, _, spellID, spellName )
@@ -1397,7 +1398,7 @@ do
         function Hekili:DumpSwarmInfo()
             local line = "Flights:"
             for k, v in pairs( flights ) do
-                line = line .. " " .. k .. ":" .. table.concat( v, ":" )
+                line = line .. " " .. k .. ":" .. concat( v, ":" )
             end
             print( line )
 

--- a/TheWarWithin/DruidFeral.lua
+++ b/TheWarWithin/DruidFeral.lua
@@ -1540,14 +1540,14 @@ spec:RegisterStateFunction( "time_to_bt_triggers", function( n )
     if not talent.bloodtalons.enabled or buff.bt_triggers.stack == n then return 0 end
     if buff.bt_triggers.stack < n then return 3600 end
 
-    table.wipe( bt_remainingTime )
+    wipe( bt_remainingTime )
 
     for bt_aura in pairs( bt_auras ) do
         local rem = buff[ bt_aura ].remains
         if rem > 0 then bt_remainingTime[ bt_aura ] = rem end
     end
 
-    table.sort( bt_remainingTime )
+    sort( bt_remainingTime )
     return bt_remainingTime[ n ]
 end )
 

--- a/TheWarWithin/MonkBrewmaster.lua
+++ b/TheWarWithin/MonkBrewmaster.lua
@@ -913,7 +913,7 @@ local function trackBrewmasterDamage( _, subtype, _, sourceGUID, sourceName, _, 
             local now = GetTime()
 
             if arg1 == destGUID and arg5 == 115069 then
-                local dmg = table.remove( staggered_damage_pool, 1 ) or {}
+                local dmg = remove( staggered_damage_pool, 1 ) or {}
 
                 dmg.t = now
                 dmg.d = arg8
@@ -921,10 +921,10 @@ local function trackBrewmasterDamage( _, subtype, _, sourceGUID, sourceName, _, 
 
                 total_staggered = total_staggered + arg8
 
-                table.insert( staggered_damage, 1, dmg )
+                insert( staggered_damage, 1, dmg )
 
             elseif arg8 == 115069 then
-                local dmg = table.remove( staggered_damage_pool, 1 ) or {}
+                local dmg = remove( staggered_damage_pool, 1 ) or {}
 
                 dmg.t = now
                 dmg.d = arg11
@@ -932,11 +932,11 @@ local function trackBrewmasterDamage( _, subtype, _, sourceGUID, sourceName, _, 
 
                 total_staggered = total_staggered + arg11
 
-                table.insert( staggered_damage, 1, dmg )
+                insert( staggered_damage, 1, dmg )
 
             end
         elseif subtype == "SPELL_PERIODIC_DAMAGE" and sourceGUID == state.GUID and arg1 == 124255 then
-            table.insert( stagger_ticks, 1, arg4 )
+            insert( stagger_ticks, 1, arg4 )
             stagger_ticks[ 31 ] = nil
 
         end
@@ -947,7 +947,7 @@ end
 spec:RegisterCombatLogEvent( trackBrewmasterDamage )
 
 spec:RegisterEvent( "PLAYER_REGEN_ENABLED", function ()
-    table.wipe( stagger_ticks )
+    wipe( stagger_ticks )
 end )
 
 function stagger_in_last( t )
@@ -956,7 +956,7 @@ function stagger_in_last( t )
     for i = #staggered_damage, 1, -1 do
         if staggered_damage[ i ].t + 10 < now then
             total_staggered = max( 0, total_staggered - staggered_damage[ i ].d )
-            staggered_damage_pool[ #staggered_damage_pool + 1 ] = table.remove( staggered_damage, i )
+            staggered_damage_pool[ #staggered_damage_pool + 1 ] = remove( staggered_damage, i )
         end
     end
 

--- a/TheWarWithin/MonkWindwalker.lua
+++ b/TheWarWithin/MonkWindwalker.lua
@@ -28,6 +28,7 @@ local GetSpellCastCount = C_Spell.GetSpellCastCount
 -- local IsActiveSpell = ns.IsActiveSpell
 
 -- Specialization-specific local functions (if any)
+local upper = string.upper
 
 spec:RegisterResource( Enum.PowerType.Energy, {
     crackling_jade_lightning = {
@@ -924,12 +925,12 @@ local XuenCasts = 0
 spec:RegisterCombatLogEvent( function( _, subtype, _, sourceGUID, sourceName, _, _, destGUID, destName, destFlags, _, spellID, spellName )
     if sourceGUID == state.GUID then
         local ability = class.abilities[ spellID ] and class.abilities[ spellID ].key
-        
+
         if ability then
             if ability == "tiger_palm" and subtype == "SPELL_MISSED" and not state.talent.hit_combo.enabled then
-                if ns.castsAll[1] == "tiger_palm" then table.remove( ns.castsAll, 1 ) end
-                if ns.castsAll[2] == "tiger_palm" then table.remove( ns.castsAll, 2 ) end
-                if ns.castsOn[1]  == "tiger_palm" then table.remove( ns.castsOn, 1  ) end
+                if ns.castsAll[1] == "tiger_palm" then remove( ns.castsAll, 1 ) end
+                if ns.castsAll[2] == "tiger_palm" then remove( ns.castsAll, 2 ) end
+                if ns.castsOn[1]  == "tiger_palm" then remove( ns.castsOn, 1  ) end
 
                 actual_combo = ns.castsOn[ 1 ] or "none"
                 Hekili:ForceUpdate( "WW_MISSED" )
@@ -947,7 +948,7 @@ spec:RegisterCombatLogEvent( function( _, subtype, _, sourceGUID, sourceName, _,
             if subtype == "SPELL_CAST_SUCCESS" and spellID == spec.abilities.invoke_xuen.id then
                 print( strformat( "Added Xuen Cast %d.", XuenCasts ) )
             end
-        
+
         elseif subtype == "SPELL_AURA_REMOVED" then
             if spellID == class.auras.flurry_charge.id then ShadoPanFlurryChargeEnergy = 0
             elseif spellID == class.auras.flurry_charge_tww3_tier.id then TWW3FlurryChargeEnergy = 0 end
@@ -1024,14 +1025,14 @@ spec:RegisterHook( "spend", function( amt, resource )
         if amt > 50 and talent.efficient_training.enabled then
             reduceCooldown( "storm_earth_and_fire", 1 )
         end
-        
+
         if buff.flurry_charge.up then
             if flurry_charge_energy + amt > 240 then
                 flurry_charge_energy = 0
                 removeBuff( "flurry_charge" )
             else flurry_charge_energy = flurry_charge_energy + amt end
         end
-        
+
         if buff.flurry_charge_tww3_tier.up then
             if flurry_charge_tww3_energy + amt > ( set_bonus.tww3 > 3 and buff.storm_earth_and_fire.up and 120 or 240 ) then
                 flurry_charge_tww3_energy = 0
@@ -1161,7 +1162,7 @@ spec:RegisterTotems( {
 
 spec:RegisterUnitEvent( "UNIT_POWER_UPDATE", "player", nil, function( event, unit, resource )
     if resource == "CHI" then
-        if UnitPower( "player", Enum.PowerType.Chi ) < 2 and ns.castsOn[ 1 ] == "tiger_palm" then table.remove( ns.castsOn, 1 ) end
+        if UnitPower( "player", Enum.PowerType.Chi ) < 2 and ns.castsOn[ 1 ] == "tiger_palm" then remove( ns.castsOn, 1 ) end
         Hekili:ForceUpdate( event, true )
     end
 end )
@@ -2019,7 +2020,7 @@ spec:RegisterAbilities( {
 
         handler = function ()
             applyDebuff( "target", "strike_of_the_windlord" )
-            
+
             -- if talent.darting_hurricane.enabled then addStack( "darting_hurricane", nil, 2 ) end
             if talent.gale_force.enabled then applyDebuff( "target", "gale_force" ) end
             if talent.heart_of_the_jade_serpent.enabled then applyBuff( "heart_of_the_jade_serpent_cdr" ) end
@@ -2140,7 +2141,7 @@ spec:RegisterAbilities( {
         id = 122470,
         cast = 0,
         cooldown = 90,
-        gcd = "off",        
+        gcd = "off",
         school = "physical",
 
         startsCombat = true,
@@ -2364,7 +2365,7 @@ spec:RegisterSetting( "use_diffuse", false, {
         local t = class.abilities.diffuse_magic.toggle
         if t then
             local active = Hekili.DB.profile.toggles[ t ].value
-            m = m .. "\n\n" .. ( active and "|cFF00FF00" or "|cFFFF0000" ) .. "Requires " .. t:gsub("^%l", string.upper) .. " Toggle|r"
+            m = m .. "\n\n" .. ( active and "|cFF00FF00" or "|cFFFF0000" ) .. "Requires " .. t:gsub("^%l", upper) .. " Toggle|r"
         end
 
         return m

--- a/TheWarWithin/RogueOutlaw.lua
+++ b/TheWarWithin/RogueOutlaw.lua
@@ -42,7 +42,7 @@ spec:RegisterResource( Enum.PowerType.ComboPoints, {
             local app  = state.buff.casting.applied    -- channel started here
             local tick = 0.5 * state.haste
             local t    = state.query_time
-            return app + math.floor( ( t - app ) / tick ) * tick
+            return app + floor( ( t - app ) / tick ) * tick
         end,
         interval = function () return 0.5 * state.haste end,
         value    = 1,                                  -- add 1 combo-point per tick
@@ -581,7 +581,7 @@ local restless_blades_list = {
 
 spec:RegisterCombatLogEvent( function( _, subtype, _,  sourceGUID, sourceName, _, _, destGUID, destName, destFlags, _, spellID, spellName )
     if sourceGUID ~= state.GUID then return end
-    
+
     -- SPELL_CAST_SUCCESS
     if subtype == "SPELL_CAST_SUCCESS" then
         local now = GetTime()
@@ -842,7 +842,7 @@ spec:RegisterHook( "runHandler", function( ability )
                 applyBuff( "subterfuge" )
             end
         end
-        
+
         if talent.double_jeopardy.enabled then
             applyBuff( "double_jeopardy" )
         end
@@ -1432,7 +1432,7 @@ spec:RegisterAbilities( {
         -- No tick_time/tick, no finish-refund – resource model does it.
         start = function ()
             if buff.double_jeopardy.up and combo_points.current > 4 then removeBuff( "double_jeopardy" ) end
-                
+
             applyBuff( "killing_spree" )
             spend( combo_points.current, "combo_points" )
             removeStack( "supercharged_combo_points" )

--- a/TheWarWithin/RogueSubtlety.lua
+++ b/TheWarWithin/RogueSubtlety.lua
@@ -496,7 +496,7 @@ spec:RegisterStateTable( "time_to_sht", setmetatable( {}, {
         local oh_speed = swings.offhand_speed
         local oh_next = ( swings.offhand > now - 3 ) and ( swings.offhand + oh_speed ) or now
 
-        table.wipe( sht )
+        wipe( sht )
 
         if mh_speed and mh_speed > 0 then
             for i = 1, 4 do
@@ -514,14 +514,14 @@ spec:RegisterStateTable( "time_to_sht", setmetatable( {}, {
 
         while( sht[i] ) do
             if sht[i] < last_shadow_techniques + 3 then
-                table.remove( sht, i )
+                remove( sht, i )
             else
                 i = i + 1
             end
         end
 
         if #sht > 0 and n - swings_since_sht < #sht then
-            table.sort( sht )
+            sort( sht )
             return max( 0, sht[ n - swings_since_sht ] - query_time )
         else
             return 3600

--- a/TheWarWithin/ShamanElemental.lua
+++ b/TheWarWithin/ShamanElemental.lua
@@ -956,7 +956,6 @@ local death_events = {
 }
 
 local summon = {}
-local wipe = table.wipe
 
 local vesper_heal = 0
 local vesper_damage = 0
@@ -1593,7 +1592,7 @@ spec:RegisterHook( "reset_precast", function ()
     if talent.elemental_equilibrium.enabled then
         elemental_equilibrium.refresh_timers()
     end
-    
+
     if talent.fusion_of_elements.enabled then
         local FusionDuration = 20 - action.icefury.time_since
         local FusionBoth = FusionDuration > 19.5 and not ( FusionFire or FusionNature )
@@ -1632,7 +1631,7 @@ local fol_spells = {}
 spec:RegisterStateFunction( "flash_of_lightning", function()
     if #fol_spells == 0 then
         for k, v in pairs( class.abilityList ) do
-            if v.school == "nature" then table.insert( fol_spells, k ) end
+            if v.school == "nature" then insert( fol_spells, k ) end
         end
     end
 

--- a/TheWarWithin/WarlockDemonology.lua
+++ b/TheWarWithin/WarlockDemonology.lua
@@ -246,36 +246,36 @@ spec:RegisterCombatLogEvent( function( _, subtype, _, source, _, _, _, destGUID,
             -- Wild Imp: 104317 (40) and 279910 (20).
             if spellID == 104317 or spellID == 279910 then
                 local dur = ( spellID == 279910 and 20 or 40 )
-                table.insert( wild_imps, now + dur )
+                insert( wild_imps, now + dur )
 
                 imps[ destGUID ] = {
                     t = now,
                     casts = 0,
-                    expires = math.ceil( now + dur ),
-                    max = math.ceil( now + dur )
+                    expires = ceil( now + dur ),
+                    max = ceil( now + dur )
                 }
 
                 if guldan[ 1 ] then
                     -- If this imp is impacting within 0.15s of the expected queued imp, remove that imp from the queue.
                     if abs( now - guldan[ 1 ] ) < 0.15 then
-                        table.remove( guldan, 1 )
+                        remove( guldan, 1 )
                     end
                 end
 
                 -- Expire missed/lost Gul'dan predictions.
                 while( guldan[ 1 ] ) do
                     if guldan[ 1 ] < now then
-                        table.remove( guldan, 1 )
+                        remove( guldan, 1 )
                     else
                         break
                     end
                 end
 
             -- Grimoire Felguard
-            elseif spellID == 111898 then table.insert( grim_felguard, now + 17 )
+            elseif spellID == 111898 then insert( grim_felguard, now + 17 )
 
             -- Demonic Tyrant: 265187, 15 seconds uptime.
-            elseif spellID == 265187 then table.insert( demonic_tyrant, now + 15 )
+            elseif spellID == 265187 then insert( demonic_tyrant, now + 15 )
                 for i = 1, #dreadstalkers do dreadstalkers[ i ] = dreadstalkers[ i ] + 15 end
                 for i = 1, #vilefiend do vilefiend[ i ] = vilefiend[ i ] + 15 end
                 for i = 1, #grim_felguard do grim_felguard[ i ] = grim_felguard[ i ] + 15 end
@@ -303,8 +303,8 @@ spec:RegisterCombatLogEvent( function( _, subtype, _, source, _, _, _, destGUID,
             -- 267995 - Wrathguard
             -- 267996 - Darkhound
             -- 268001 - Ur'zul
-            elseif spellID >= 267986 and spellID <= 268001 then table.insert( other_demon, now + 15 )
-            elseif spellID == 387590 then table.insert( pit_lord, now + 10 ) end -- Pit Lord from Gul'dan's Ambition
+            elseif spellID >= 267986 and spellID <= 268001 then insert( other_demon, now + 15 )
+            elseif spellID == 387590 then insert( pit_lord, now + 10 ) end -- Pit Lord from Gul'dan's Ambition
 
         elseif spellID == 387458 and imps[ destGUID ] then
             imps[ destGUID ].boss = true
@@ -316,13 +316,13 @@ spec:RegisterCombatLogEvent( function( _, subtype, _, source, _, _, _, destGUID,
         elseif subtype == "SPELL_CAST_SUCCESS" then
             -- Implosion.
             if spellID == 196277 then
-                table.wipe( wild_imps )
-                table.wipe( imps )
+                wipe( wild_imps )
+                wipe( imps )
 
             -- Power Siphon.
             elseif spellID == 264130 then
-                if wild_imps[1] then table.remove( wild_imps, 1 ) end
-                if wild_imps[1] then table.remove( wild_imps, 1 ) end
+                if wild_imps[1] then remove( wild_imps, 1 ) end
+                if wild_imps[1] then remove( wild_imps, 1 ) end
 
                 for i = 1, 2 do
                     local lowest
@@ -343,10 +343,10 @@ spec:RegisterCombatLogEvent( function( _, subtype, _, source, _, _, _, destGUID,
             elseif spellID == 105174 then
                 hog_time = now
 
-                if shards_for_guldan >= 1 then table.insert( guldan, now + 0.6 ) end
-                if shards_for_guldan >= 2 then table.insert( guldan, now + 0.8 ) end
-                if shards_for_guldan >= 3 then table.insert( guldan, now + 1 ) end
-            
+                if shards_for_guldan >= 1 then insert( guldan, now + 0.6 ) end
+                if shards_for_guldan >= 2 then insert( guldan, now + 0.8 ) end
+                if shards_for_guldan >= 3 then insert( guldan, now + 1 ) end
+
             -- Call Dreadstalkers (use travel time to determine buffer delay for Demonic Cores).
             elseif spellID == 104316 then
                 local info = GetSpellInfo( 104316 )
@@ -400,7 +400,7 @@ spec:RegisterHook( "reset_precast", function()
 
     while( wild_imps[ i ] ) do
         if wild_imps[ i ] < now then
-            table.remove( wild_imps, i )
+            remove( wild_imps, i )
         else
             i = i + 1
         end
@@ -410,17 +410,17 @@ spec:RegisterHook( "reset_precast", function()
     wipe( imp_gang_boss_v )
 
     for n, t in pairs( imps ) do
-        table.insert( wild_imps_v, t.expires )
-        if t.boss then table.insert( imp_gang_boss_v, t.expires ) end
+        insert( wild_imps_v, t.expires )
+        if t.boss then insert( imp_gang_boss_v, t.expires ) end
     end
 
-    table.sort( wild_imps_v )
-    table.sort( imp_gang_boss_v )
+    sort( wild_imps_v )
+    sort( imp_gang_boss_v )
 
     local difference = #wild_imps_v - GetSpellCastCount( 196277 )
 
     while difference > 0 do
-        table.remove( wild_imps_v, 1 )
+        remove( wild_imps_v, 1 )
         difference = difference - 1
     end
 
@@ -430,7 +430,7 @@ spec:RegisterHook( "reset_precast", function()
     i = 1
     while( other_demon[ i ] ) do
         if other_demon[ i ] < now then
-            table.remove( other_demon, i )
+            remove( other_demon, i )
         else
             i = i + 1
         end
@@ -443,7 +443,7 @@ spec:RegisterHook( "reset_precast", function()
     local pl_expires = 0
     while( pit_lord[ i ] ) do
         if pit_lord[ i ] < now then
-            table.remove( pit_lord, i )
+            remove( pit_lord, i )
         elseif pit_lord[ i ] > pl_expires then
             pl_expires = pit_lord[ i ]
             i = i + 1
@@ -488,10 +488,10 @@ spec:RegisterHook( "reset_precast", function()
 
     end
 
-    if #grim_felguard_v > 1 then table.sort( grim_felguard_v ) end
-    if #vilefiend_v > 1 then table.sort( vilefiend_v ) end
-    if #dreadstalkers_v > 1 then table.sort( dreadstalkers_v ) end
-    if #demonic_tyrant_v > 1 then table.sort( demonic_tyrant_v ) end
+    if #grim_felguard_v > 1 then sort( grim_felguard_v ) end
+    if #vilefiend_v > 1 then sort( vilefiend_v ) end
+    if #dreadstalkers_v > 1 then sort( dreadstalkers_v ) end
+    if #demonic_tyrant_v > 1 then sort( demonic_tyrant_v ) end
 
     if demonic_tyrant_v[ 1 ] and demonic_tyrant_v[ 1 ] > now then
         summonPet( "demonic_tyrant", demonic_tyrant_v[ 1 ] - now )
@@ -716,7 +716,7 @@ spec:RegisterStateFunction( "summon_demon", function( name, duration, count )
     last_summon.count = count
 
     for i = 1, count do
-        table.insert( db, expires )
+        insert( db, expires )
     end
 end )
 
@@ -749,12 +749,12 @@ spec:RegisterStateFunction( "consume_demons", function( name, count )
     elseif name == "demonic_tyrant"    then db = demonic_tyrant_v end
 
     if type( count ) == "string" and count == "all" then
-        table.wipe( db )
+        wipe( db )
 
         -- Wipe queued Guldan imps that should have landed by now.
         if name == "wild_imps" then
             while( guldan_v[ 1 ] ) do
-                if guldan_v[ 1 ] < now then table.remove( guldan_v, 1 )
+                if guldan_v[ 1 ] < now then remove( guldan_v, 1 )
                 else break end
             end
         end
@@ -765,17 +765,17 @@ spec:RegisterStateFunction( "consume_demons", function( name, count )
 
     if count >= #db then
         count = count - #db
-        table.wipe( db )
+        wipe( db )
     end
 
     while( count > 0 ) do
         if not db[1] then break end
 
-        local d = table.remove( db, 1 )
+        local d = remove( db, 1 )
         if name == "wild_imps" and #imp_gang_boss_v > 0 then
             for i, v in ipairs( imp_gang_boss_v ) do
                 if d == v then
-                    table.remove( imp_gang_boss_v, i )
+                    remove( imp_gang_boss_v, i )
                     break
                 end
             end
@@ -787,7 +787,7 @@ spec:RegisterStateFunction( "consume_demons", function( name, count )
     if name == "wild_imps" and count > 0 then
         while( count > 0 ) do
             if not guldan_v[1] or guldan_v[1] > now then break end
-            table.remove( guldan_v, 1 )
+            remove( guldan_v, 1 )
             count = count - 1
         end
     end
@@ -1227,7 +1227,7 @@ spec:RegisterAuras( {
         max_stack = 1,
         generate = function( t )
             local expires = gcd.max + doom_core_consumed
-            
+
             -- Expiration is based on actual reset time; virtual used_core will get applied in handlers.
             if expires > now then
                 t.name = "Demonic Core Consumed"

--- a/TheWarWithin/WarlockDestruction.lua
+++ b/TheWarWithin/WarlockDestruction.lua
@@ -2186,9 +2186,9 @@ spec:RegisterSetting( "immolate_macro", nil, {
 } )
 
 spec:RegisterSetting( "low_ttd_dot", 11, {
-    name = function () return string.format( "%s: Enemy Time-to-Die", Hekili:GetSpellLinkWithTexture( state.talent.wither.enabled and spec.auras.wither.id or spec.auras.immolate.id ) ) end,
+    name = function () return strformat( "%s: Enemy Time-to-Die", Hekili:GetSpellLinkWithTexture( state.talent.wither.enabled and spec.auras.wither.id or spec.auras.immolate.id ) ) end,
     type = "range",
-    desc = function () return string.format( "If set above zero, %s should not be recommended unless your target / enemies will survive for at least this many seconds.", Hekili:GetSpellLinkWithTexture( state.talent.wither.enabled and spec.auras.wither.id or spec.auras.immolate.id ) ) end,
+    desc = function () return strformat( "If set above zero, %s should not be recommended unless your target / enemies will survive for at least this many seconds.", Hekili:GetSpellLinkWithTexture( state.talent.wither.enabled and spec.auras.wither.id or spec.auras.immolate.id ) ) end,
     min = 0,
     max = 21,
     step = 0.5,
@@ -2196,9 +2196,9 @@ spec:RegisterSetting( "low_ttd_dot", 11, {
 } )
 
 spec:RegisterSetting( "cataclysm_ttd", 11, {
-    name = function () return string.format( "%s: Enemy Time-to-Die", Hekili:GetSpellLinkWithTexture( spec.abilities.cataclysm.id ) ) end,
+    name = function () return strformat( "%s: Enemy Time-to-Die", Hekili:GetSpellLinkWithTexture( spec.abilities.cataclysm.id ) ) end,
     type = "range",
-    desc = function () return string.format( "If set above zero, %s should not be recommended unless your target or one of your enemies will survive for at least this many seconds.", Hekili:GetSpellLinkWithTexture( spec.abilities.cataclysm.id ) ) end,
+    desc = function () return strformat( "If set above zero, %s should not be recommended unless your target or one of your enemies will survive for at least this many seconds.", Hekili:GetSpellLinkWithTexture( spec.abilities.cataclysm.id ) ) end,
     min = 0,
     max = 21,
     step = 0.5,

--- a/UI.lua
+++ b/UI.lua
@@ -38,7 +38,7 @@ end
 local GetSpecialization = C_SpecializationInfo.GetSpecialization
 local GetSpecializationInfo = C_SpecializationInfo.GetSpecializationInfo
 
-local floor, format, insert = math.floor, string.format, table.insert
+local floor, format, insert, wipe = math.floor, string.format, table.insert, table.wipe
 
 local HasVehicleActionBar, HasOverrideActionBar, IsInPetBattle, UnitHasVehicleUI, UnitOnTaxi = HasVehicleActionBar, HasOverrideActionBar, C_PetBattles.IsInBattle, UnitHasVehicleUI, UnitOnTaxi
 local Tooltip = ns.Tooltip
@@ -1372,7 +1372,7 @@ do
                         self.flashColor.r, self.flashColor.g, self.flashColor.b = unpack( conf.flash.color )
 
                         catchFlash = GetTime()
-                        table.wipe( lastFramesFlashed )
+                        wipe( lastFramesFlashed )
 
                         if ability.item then
                             local iname = LSF.ItemName( ability.item )
@@ -2075,7 +2075,7 @@ do
                     else events[ k ] = 1 end
                 end
 
-                table.wipe( self.eventsTriggered )
+                wipe( self.eventsTriggered )
             end ]]
         -- end
 

--- a/Utils.lua
+++ b/Utils.lua
@@ -5,7 +5,7 @@ local addon, ns = ...
 local Hekili = _G[ addon ]
 
 local format, gsub, lower = string.format, string.gsub, string.lower
-local insert, remove = table.insert, table.remove
+local insert, remove, sort, wipe = table.insert, table.remove, table.sort, table.wipe
 
 local class = Hekili.Class
 local state = Hekili.State
@@ -162,7 +162,7 @@ local tblUnpack = {}
 
 ns.multiUnpack = function( ... )
 
-    table.wipe( tblUnpack )
+    wipe( tblUnpack )
 
     for i = 1, select( '#', ... ) do
         for _, value in ipairs( select( i, ... ) ) do
@@ -239,9 +239,9 @@ local function __genOrderedIndex( t )
     end
 
     for key in pairs( t ) do
-        table.insert( orderedIndex, key )
+        insert( orderedIndex, key )
     end
-    table.sort( orderedIndex, sortHelper )
+    sort( orderedIndex, sortHelper )
     return orderedIndex
 end
 


### PR DESCRIPTION
Given standardized structure of class files now, where they all have the following declaration, it makes sense to just start using the local calls everywhere. **_Please_** scan through and make sure none of these are going to be weirdly out of scope for some reason. All of the files have the relevant declarations written near the top.

```LUA
---- Local function declarations for increased performance
-- Strings
local strformat = string.format
-- Tables
local insert, remove, sort, wipe = table.insert, table.remove, table.sort, table.wipe
-- Math
local abs, ceil, floor, max, sqrt = math.abs, math.ceil, math.floor, math.max, math.sqrt

```

I cleaned up all of the following:
| Global Call       | Local Alias |
|-------------------|-------------|
| `table.insert`    | `insert`    |
| `table.remove`    | `remove`    |
| `table.sort`      | `sort`      |
| `table.wipe`      | `wipe`      |
| `math.abs`        | `abs`       |
| `math.ceil`       | `ceil`      |
| `math.floor`      | `floor`     |
| `math.max`        | `max`       |
| `math.sqrt`       | `sqrt`      |
| `string.format`   | `strformat` |

### Note 1
Some exceptions where the name convention like `tremove` already existed, I did not undo those and stuck with that convention within the file.

### Note 2
I also discovered a few cases where something like `local wipe` was declared twice, due to the old declaration not being spotted in the original PR that standardized the class file headers, so those got undone too.