### PR TITLE
Disable All Items Setting (Per-Specialization)

### DIFF
--- a/Classes.lua
+++ b/Classes.lua
@@ -55,6 +55,7 @@ local specTemplate = {
     custom1Name = "Custom 1",
     custom2Name = "Custom 2",
     noFeignedCooldown = false,
+    disable_items = false,
 
     abilities = {
         ['**'] = {

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -8863,14 +8863,12 @@ do
                         get = GetCurrentSpec,
                         values = GetCurrentSpecList,
                     },
-
                     disable_items = {
                         type = "toggle",
                         name = "Disable Gear and Items",
-                        desc = "If checked, no usable gear or items (i.e., trinkets and weapons and armor with On Use effects) will be recommended for this |cFFFFD100Specialization|r.\n\n"
-                            .. "Individual item settings can be updated below, but will be ignored when this option is checked.\n\n"
-                            .. "This option does not apply to potions, which are controlled by |cFF00B4FFToggles > Potions|r.",
-                            order = 0.2,
+                        desc = "If checked, no equipped trinkets, weapons, or armor with |cFFFFD100Use:|r effects will be recommended for this specialization, " 
+                            .. "regardless of any other options selected below.",
+                        order = 0.2,
                         width = 1.49,
                         get = function()
                             local spec = GetCurrentSpec()

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -8866,7 +8866,7 @@ do
                     disable_items = {
                         type = "toggle",
                         name = "Disable Gear and Items",
-                        desc = "If checked, no equipped trinkets, weapons, or armor with |cFFFFD100Use:|r effects will be recommended for this specialization, " 
+                        desc = "If checked, no equipped trinkets, weapons, or armor with |cFF00FF00Use:|r effects will be recommended for this specialization, " 
                             .. "regardless of any other options selected below.",
                         order = 0.2,
                         width = 1.49,

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -5204,11 +5204,11 @@ found = true end
                                             "\nThis setting determines how much time can be used to generate recommendations.\n\n" ..
                                             "|cFFFFD100• Higher values|r allow recommendations to |cFF00FF00update more quickly|r but may risk lowering your frame rate, " ..
                                             "especially when other addons are working at the same time.\n" ..
-                                            "|cFFFFD100• Lower values|r mean recommendations may update more slowly but may |cFF00FF00preserve your frame rate|r.\n\n" .. 
-                                            
+                                            "|cFFFFD100• Lower values|r mean recommendations may update more slowly but may |cFF00FF00preserve your frame rate|r.\n\n" ..
+
                                             "Adjust this budget to balance |cFF00FF00smooth gameplay|r and |cFF00FF00responsive recommendations|r. " ..
                                             "Use the highest value that feels smooth on your system without your screen freezing or stuttering.\n\n" ..
-                                            
+
                                             "|cFF00B4FFDefault (recommended)|r: |cFFFFD10070%|r\n\n" ..
 
                                             "At |cFFFFD700" .. format( "%.1f", fps ) .. " FPS|r, a budget of |cFFFFD700" .. ( budget * 100 ) .. "%|r " ..
@@ -8858,10 +8858,28 @@ do
                         name = "Specialization",
                         desc = "These options apply to your selected specialization.",
                         order = 0.1,
-                        width = "full",
+                        width = 1.49,
                         set = SetCurrentSpec,
                         get = GetCurrentSpec,
                         values = GetCurrentSpecList,
+                    },
+
+                    disable_items = {
+                        type = "toggle",
+                        name = "Disable Gear and Items",
+                        desc = "If checked, no usable gear or items (i.e., trinkets and weapons and armor with On Use effects) will be recommended for this |cFFFFD100Specialization|r.\n\n"
+                            .. "Individual item settings can be updated below, but will be ignored when this option is checked.\n\n"
+                            .. "This option does not apply to potions, which are controlled by |cFF00B4FFToggles > Potions|r.",
+                            order = 0.2,
+                        width = 1.49,
+                        get = function()
+                            local spec = GetCurrentSpec()
+                            return Hekili.DB.profile.specs[ spec ].disable_items or false
+                        end,
+                        set = function( info, val )
+                            local spec = GetCurrentSpec()
+                            Hekili.DB.profile.specs[ spec ].disable_items = val
+                        end,
                     },
                 },
                 plugins = {

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -8866,8 +8866,10 @@ do
                     disable_items = {
                         type = "toggle",
                         name = "Disable Gear and Items",
-                        desc = "If checked, no equipped trinkets, weapons, or armor with |cFF00FF00Use:|r effects will be recommended for this specialization, " 
-                            .. "regardless of any other options selected below.",
+                        desc = function()
+                            return format( "If checked, no equipped trinkets, weapons, or armor with |cFF00FF00Use:|r effects will be recommended for |cFFFFD100%s|r, " 
+                            .. "regardless of any other options selected below.", ( GetCurrentSpec() and GetCurrentSpecList()[ GetCurrentSpec() ] or "this specialization" ) )
+                        end,
                         order = 0.2,
                         width = 1.49,
                         get = function()

--- a/State.lua
+++ b/State.lua
@@ -7541,6 +7541,13 @@ do
 
         local option = ability.item and spec.items[ spell ] or spec.abilities[ spell ]
 
+        if ability.item and ability.toggle ~= "potions" then
+            local sp = rawget( profile.specs, state.spec.id )
+            if sp and sp.disable_items then
+                return true, "preference - spec disables gear/items"
+            end
+        end
+
         if not strict then
             local toggle = option.toggle
             if not toggle or toggle == "default" then toggle = ability.toggle end


### PR DESCRIPTION
Re-do of https://github.com/Hekili/hekili/pull/4568, incorporating the feedback. Properly set up as a spec setting, behaves the same way users are accustomed to with individual item/ability settings and the dropdown.

<img width="1017" height="777" alt="image" src="https://github.com/user-attachments/assets/c660cd2b-45e7-4001-873b-e500f1350ab4" />
<img width="672" height="306" alt="image" src="https://github.com/user-attachments/assets/e831b6ab-3566-4895-89d0-02393a5bffb6" />
