### PR TITLE
Adding support for new 11.2 healing potions

### DIFF
--- a/Classes.lua
+++ b/Classes.lua
@@ -2709,7 +2709,11 @@ do
         {
             name = "cavedwellers_delight",
             items = { 212242, 212243, 212244 }
-        }
+        },
+        {
+            name = "invigorating_healing_potion",
+            items = { 244835, 244838, 244839 }
+        }        
     }
 
 ---@diagnostic disable-next-line: need-check-nil


### PR DESCRIPTION
11.2 added new healing potions:

https://www.wowhead.com/item=244835/invigorating-healing-potion
https://www.wowhead.com/item=244838/invigorating-healing-potion
https://www.wowhead.com/item=244839/invigorating-healing-potion

This should allow these new potions to be used in action lists, same as the old Algari Healing Potions.