### PR TITLE
Long Term Queue Aura Events Solution

### DIFF
--- a/State.lua
+++ b/State.lua
@@ -6508,93 +6508,98 @@ do
         local ability
         local curr_action = self.this_action
 
+        -- Check if this is a spell-related event that needs ability validation
         if e.type ~= "AURA_EXPIRATION" and e.type ~= "AURA_PERIODIC" then
             ability = class.abilities[ e.action ]
 
-            if not ability then
+            if ability then
+                self.this_action = action
+            elseif not e.func then
+                -- Only remove if no custom function and no known ability
                 state:RemoveEvent( e )
                 return
             end
-
-            self.this_action = action
         end
 
         if Hekili.ActiveDebug then Hekili:Debug( "\nHandling %s at %.2f (%s).", action, e.time, e.type ) end
 
-        if e.type == "CAST_FINISH" then
-            self.hardcast = true
-            local cooldown = ability.cooldown
+        -- Handle spell events only if we have a valid ability
+        if ability then
+            if e.type == "CAST_FINISH" then
+                self.hardcast = true
+                local cooldown = ability.cooldown
 
-            -- Put the action on cooldown. (It's slightly premature, but addresses CD resets like Echo of the Elements.)
-            -- if ability.charges and ability.charges > 1 and ability.recharge > 0 then
-            if ability.charges and ( ability.recharge or ability.cooldown ) > 0 then
-                self.spendCharges( action, 1 )
+                -- Put the action on cooldown. (It's slightly premature, but addresses CD resets like Echo of the Elements.)
+                -- if ability.charges and ability.charges > 1 and ability.recharge > 0 then
+                if ability.charges and ( ability.recharge or ability.cooldown ) > 0 then
+                    self.spendCharges( action, 1 )
 
-            elseif action ~= "global_cooldown" then
-                self.setCooldown( action, cooldown )
-            end
+                elseif action ~= "global_cooldown" then
+                    self.setCooldown( action, cooldown )
+                end
 
-            -- Spend resources.
-            ns.spendResources( action )
+                -- Spend resources.
+                ns.spendResources( action )
 
-            local wasCycling = self.IsCycling( nil, true )
-            local expires, minTTD, maxTTD, aura
+                local wasCycling = self.IsCycling( nil, true )
+                local expires, minTTD, maxTTD, aura
 
-            if wasCycling then
-                expires, minTTD, maxTTD, aura = self.GetCycleInfo()
-            end
+                if wasCycling then
+                    expires, minTTD, maxTTD, aura = self.GetCycleInfo()
+                end
 
-            if e.target and e.target ~= self.target.unit then
-                if Hekili.ActiveDebug then Hekili:Debug( "Using ability on a different target." ) end
-                self.SetupCycle( ability )
-            end
+                if e.target and e.target ~= self.target.unit then
+                    if Hekili.ActiveDebug then Hekili:Debug( "Using ability on a different target." ) end
+                    self.SetupCycle( ability )
+                end
 
-            -- Perform the action.
-            self:RunHandler( action )
-            self.hardcast = nil
-            self.whitelist = nil
-            self.removeBuff( "casting" ) -- TODO: Revisit for Casting while Casting scenarios; check Fire Mage.
+                -- Perform the action.
+                self:RunHandler( action )
+                self.hardcast = nil
+                self.whitelist = nil
+                self.removeBuff( "casting" ) -- TODO: Revisit for Casting while Casting scenarios; check Fire Mage.
 
-            if wasCycling then
-                self.SetCycleInfo( expires, minTTD, maxTTD, aura )
-            else
-                self.ClearCycle()
-            end
+                if wasCycling then
+                    self.SetCycleInfo( expires, minTTD, maxTTD, aura )
+                else
+                    self.ClearCycle()
+                end
 
-            self:SetWhitelist( nil )
+                self:SetWhitelist( nil )
 
-            if ability.item and not ( ability.essence or ability.no_icd ) then
-                self.putTrinketsOnCD( cooldown / 6 )
-            end
+                if ability.item and not ( ability.essence or ability.no_icd ) then
+                    self.putTrinketsOnCD( cooldown / 6 )
+                end
 
-        elseif e.type == "CHANNEL_TICK" then
-            if ability.tick then ability.tick() end
+            elseif e.type == "CHANNEL_TICK" then
+                if ability.tick then ability.tick() end
 
-        elseif e.type == "CHANNEL_FINISH" then
-            if ability.finish then ability.finish() end
-            self.whitelist = nil
-            self.removeBuff( "casting" )
+            elseif e.type == "CHANNEL_FINISH" then
+                if ability.finish then ability.finish() end
+                self.whitelist = nil
+                self.removeBuff( "casting" )
 
-        elseif e.type == "PROJECTILE_IMPACT" then
-            local wasCycling = self.IsCycling( nil, true )
-            local expires, minTTD, maxTTD, aura
+            elseif e.type == "PROJECTILE_IMPACT" then
+                local wasCycling = self.IsCycling( nil, true )
+                local expires, minTTD, maxTTD, aura
 
-            if wasCycling then
-                expires, minTTD, maxTTD, aura = self.GetCycleInfo()
-            end
+                if wasCycling then
+                    expires, minTTD, maxTTD, aura = self.GetCycleInfo()
+                end
 
-            if e.target and e.target ~= self.target.unit then
-                if Hekili.ActiveDebug then Hekili:Debug( "Using ability on a different target." ) end
-                self.SetupCycle( ability )
-            end
+                if e.target and e.target ~= self.target.unit then
+                    if Hekili.ActiveDebug then Hekili:Debug( "Using ability on a different target." ) end
+                    self.SetupCycle( ability )
+                end
 
-            if ability.impact then ability.impact( e.real ) end
-            self:StartCombat()
+                if ability.impact then ability.impact( e.real ) end
+                self:StartCombat()
 
-            if wasCycling then
-                self.SetCycleInfo( expires, minTTD, maxTTD, aura )
-            else
-                self.ClearCycle()
+                if wasCycling then
+                    self.SetCycleInfo( expires, minTTD, maxTTD, aura )
+                else
+                    self.ClearCycle()
+                end
             end
         end
 

--- a/TheWarWithin/DruidBalance.lua
+++ b/TheWarWithin/DruidBalance.lua
@@ -1791,7 +1791,6 @@ spec:RegisterPet( "treants",
 spec:RegisterTotem( "treants", 103822 )
 
 local TreantMoonfires = setfenv( function()
-    if Hekili.ActiveDebug then Hekili:Debug( "Running local spec function - TreantMoonfires" ) end
     for i = 1, 3 do -- # of treants
         spec.abilities.moonfire.handler()
     end

--- a/TheWarWithin/DruidFeral.lua
+++ b/TheWarWithin/DruidFeral.lua
@@ -1382,7 +1382,6 @@ local SinfulHysteriaHandler = setfenv( function ()
 end, state )
 
 local ComboPointPeriodic = setfenv( function()
-    if Hekili.ActiveDebug then Hekili:Debug( "Running local spec function - ComboPointPeriodic" ) end
     gain( 1, "combo_points" )
 end, state )
 

--- a/TheWarWithin/DruidRestoration.lua
+++ b/TheWarWithin/DruidRestoration.lua
@@ -575,7 +575,6 @@ end )
 
 local TranquilityTickHandler = setfenv( function()
 
-    if Hekili.ActiveDebug then Hekili:Debug( "Running local spec function - TranquilityTickHandler" ) end
     addStack( "tranquility_hot" )
     if talent.dreamstate.enabled then
         for ability, _ in pairs( class.abilities ) do
@@ -586,12 +585,10 @@ local TranquilityTickHandler = setfenv( function()
 end, state )
 
 local ComboPointPeriodic = setfenv( function()
-    if Hekili.ActiveDebug then Hekili:Debug( "Running local spec function - ComboPointPeriodic" ) end
     gain( 1, "combo_points" )
 end, state )
 
 local TreantSpawnPeriodic = setfenv( function()
-    if Hekili.ActiveDebug then Hekili:Debug( "Running local spec function - TreantSpawnPeriodic" ) end
     summonPet( "treants", 15 )
     addStack( "grove_guardians" ) -- Just for tracking.
     if talent.harmony_of_the_grove.enabled then addStack( "harmony_of_the_grove" ) end

--- a/TheWarWithin/HunterBeastMastery.lua
+++ b/TheWarWithin/HunterBeastMastery.lua
@@ -1300,7 +1300,6 @@ spec:RegisterHook( "spend", function( amt, resource )
 end )
 
 local CallOfTheWildCDR = setfenv( function()
-    if Hekili.ActiveDebug then Hekili:Debug( "Running local spec function - CallOfTheWildCDR" ) end
     gainChargeTime( "kill_command", spec.abilities.kill_command.recharge/4)
     gainChargeTime( "barbed_shot", spec.abilities.barbed_shot.recharge/4)
     if talent.withering_fire.enabled then

--- a/TheWarWithin/PriestShadow.lua
+++ b/TheWarWithin/PriestShadow.lua
@@ -1040,7 +1040,6 @@ local ExpireVoidform = setfenv( function()
 end, state )
 
 local PowerSurge = setfenv( function()
-    if Hekili.ActiveDebug then Hekili:Debug( "Running local spec function - PowerSurge" ) end
     class.abilities.halo.handler()
 end, state )
 


### PR DESCRIPTION
As per feedback, make the `function state:HandleEvent( e )` less strict. It will now only remove the event if it doesn't match an ability **_and_** if there is no function supplied.

The standard spell types (`CAST_FINISH`, `CHANNEL_TICK`, `CHANNEL_FINISH`, `PROJECTILE_IMPACT`) all got bumped into a block that checks if the ability is valid, which would be skipped for an aura event like:

`state:QueueAuraEvent( "call_of_the_wild_cdr", CallOfTheWildCDR, tick, "AURA_PERIODIC" )`

Also removed the snapshot outputs. There is no need to relabel the ones I changed into `AURA_TICK`, either way is pretty descriptive since they are standardized intervals.