### PR TITLE
Low Level Warning Tweak

### DIFF
--- a/Events.lua
+++ b/Events.lua
@@ -1212,14 +1212,17 @@ end
 
 local lowLevelWarned = false
 local noClassWarned = false
+-- Change here every expansion to automatically warn low-level users.
+local minimumLevel = 71
+local expansionName = "The War Within"
 
 -- Need to make caching system.
 RegisterUnitEvent( "UNIT_SPELLCAST_SUCCEEDED", "player", "target", function( event, unit, _, spellID )
     if not noClassWarned and not class.initialized then
-        Hekili:Notify( UnitClass( "player" ) .. " does not have any Hekili modules loaded (yet).\nWatch for updates.", 5 )
+        Hekili:Notify( UnitClass( "player" ) .. " does not have any Hekili modules loaded (yet).\nWatch for updates.", 10 )
         noClassWarned = true
-    elseif not lowLevelWarned and UnitLevel( "player" ) < 70 then
-        Hekili:Notify( "Hekili is designed for current content.\nUse below level 70 at your own risk.", 5 )
+    elseif not lowLevelWarned and UnitLevel( "player" ) < minimumLevel then
+        Hekili:Notify( "Hekili is designed for use in " .. expansionName .. " content.\nIt may not work as expected below level " .. minimumLevel .. ".", 10 )
         lowLevelWarned = true
     end
 


### PR DESCRIPTION
Be more clear/explicit about the intended use. Warning stops at level 71 when user unlocks hero trees.

Redo of https://github.com/Hekili/hekili/pull/5057, dropped the incomplete spec part for now.


### I changed it to level 76 for testing purposes bc my guy is level 75

<img width="758" height="596" alt="image" src="https://github.com/user-attachments/assets/0170b5fd-bda5-4cc4-985f-c49e2b578cc7" />
