### PR TITLE
Create a new practice mode that hides during combat and reports accuracy

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -197,6 +197,11 @@ function Hekili:OnEnable()
 
     ns.ReadKeybindings()
 
+    -- Initialize Practice mode
+    if ns.Practice then
+        ns.Practice:Initialize()
+    end
+
     self.PendingSpecializationChange = true
     self:ForceUpdate( "ADDON_ENABLED" )
 
@@ -1197,6 +1202,12 @@ function Hekili:GetPredictionFromAPL( dispName, packName, listName, slot, action
                                                         slot.listName = listName
                                                         slot.action = actID
                                                         slot.actionName = state.this_action
+
+                                                        -- Track recommendation for practice mode
+                                                        if ns.Practice then
+                                                            ns.Practice:TrackRecommendation(state.this_action, GetTime() + state.delay)
+                                                        end
+
                                                         slot.actionID = -1 * item
 
                                                         slot.texture = select( 10, GetItemInfo( item ) )
@@ -1236,6 +1247,7 @@ function Hekili:GetPredictionFromAPL( dispName, packName, listName, slot, action
                                                             slot.listName = listName
                                                             slot.action = actID
                                                             slot.actionName = state.this_action
+
                                                             slot.actionID = ability.id
 
                                                             slot.caption = ability.caption or entry.caption
@@ -1392,6 +1404,36 @@ function Hekili:GetPredictionFromAPL( dispName, packName, listName, slot, action
                                                             slot.indicator = module.cycle()
                                                         end
                                                         Timer:Track( "Action Stored" )
+                                                    end
+                                                end
+
+                                                if ns.Practice and ns.Practice:IsActive() and slot.index == 1 then
+                                                    ns.Practice:DebugHook(
+                                                        "Core Slot1",
+                                                        string.format(
+                                                            "action=%s abilityKey=%s abilityID=%s delay=%.1f active=%s inCombat=%s",
+                                                            tostring(state.this_action),
+                                                            tostring(ability and ability.key),
+                                                            tostring(ability and ability.id),
+                                                            (state.delay or 0),
+                                                            tostring(ns.Practice:IsActive()),
+                                                            tostring(ns.Practice:IsInCombat())
+                                                        )
+                                                    )
+
+                                                    if state.this_action then
+                                                        local practiceAbility = ability or class.abilities[ state.this_action ]
+                                                        local practiceID = practiceAbility and practiceAbility.id or nil
+                                                        local practiceName = practiceAbility and practiceAbility.name or nil
+                                                        local practiceKey = practiceAbility and ( practiceAbility.key or practiceAbility.name ) or state.this_action
+
+                                                        if practiceKey and practiceKey ~= "wait" and practiceKey ~= "pool_resource" then
+                                                            ns.Practice:TrackRecommendation( practiceID, practiceName, GetTime() + state.delay, practiceKey )
+                                                        else
+                                                            ns.Practice:DebugHook("Core Slot1", "Skipped non-spell action" )
+                                                        end
+                                                    else
+                                                        ns.Practice:DebugHook("Core Slot1", "No state.this_action" )
                                                     end
                                                 end
 
@@ -1626,7 +1668,9 @@ function Hekili.Update()
 
         local checkstr = ""
 
-        if UI.Active and UI.alpha > 0 and rule( profile ) then
+        local practiceForce = ns.Practice and ns.Practice:ShouldForceRecommendations()
+
+        if UI.Active and ( UI.alpha > 0 or practiceForce ) and rule( profile ) then
             for i = #Stack, 1, -1 do tinsert( StackPool, tremove( Stack, i ) ) end
             for i = #Block, 1, -1 do tinsert( StackPool, tremove( Block, i ) ) end
 

--- a/Hekili.toc
+++ b/Hekili.toc
@@ -91,3 +91,4 @@ Options\Options.lua
 UI.lua
 Scripts.lua
 Core.lua
+Practice.lua

--- a/Options/ChatCommands.lua
+++ b/Options/ChatCommands.lua
@@ -48,7 +48,8 @@ function Hekili:CmdLine( input )
     -- Alias maps for argument substitutions
     local arg1Aliases = {
         prio        = "priority",
-        snap        = "snapshot"
+        snap        = "snapshot",
+        prac        = "practice"
     }
     local arg2Aliases = {
         cd          = "cooldowns",
@@ -90,6 +91,7 @@ function Hekili:CmdLine( input )
         recover  = function () self:HandleRecoverCommand() end,
         fix      = function () self:HandleFixCommand( args ) end,
         snapshot = function () self:MakeSnapshot() end,
+        practice = function () if ns.Practice then ns.Practice:ToggleMode() end end,
         skeleton = function () self:HandleSkeletonCommand( input ) end
     }
 

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -263,6 +263,15 @@ local displayTemplate = {
         fixedBrightness = false
     },
 
+    practice = {
+        enabled = false,
+        showReport = true,
+        hideDisplaysInCombat = true,
+        trackAllAbilities = true,
+        accuracyThreshold = 2.0, -- seconds tolerance for timing
+        reportDuration = 10, -- seconds to show report
+    },
+
     captions = {
         enabled = false,
         queued = false,
@@ -542,6 +551,12 @@ do
                         key = "",
                         value = false,
                         name = "Custom #2"
+                    },
+
+                    practice = {
+                        key = "ALT-SHIFT-B",
+                        value = false,
+                        name = "Practice Mode"
                     }
                 },
 
@@ -4159,6 +4174,7 @@ self:ForceUpdate( "SPEC_PACKAGE_CHANGED" )
                     toggles.potions = "Potions"
                     toggles.custom1 = "Custom 1"
                     toggles.custom2 = "Custom 2"
+                    toggles.practice = "Practice Mode"
 
                     return toggles
                 end,
@@ -4578,6 +4594,7 @@ found = true end
                     toggles.potions = "Potions"
                     toggles.custom1 = "Custom 1"
                     toggles.custom2 = "Custom 2"
+                    toggles.practice = "Practice Mode"
 
                     return toggles
                 end,
@@ -8289,6 +8306,30 @@ do
                                     order = 3
                                 }
                             }
+                        },
+
+                        practice = {
+                            type = "group",
+                            name = "Practice Mode",
+                            inline = true,
+                            order = 30.3,
+                            args = {
+                                key = {
+                                    type = "keybinding",
+                                    name = "Practice Mode",
+                                    desc = "Set a key to toggle practice mode. When enabled, shows rotation recommendations normally, but hides displays during combat and tracks accuracy.",
+                                    width = 1,
+                                    order = 1,
+                                },
+
+                                value = {
+                                    type = "toggle",
+                                    name = "Enable Practice Mode",
+                                    desc = "If checked, practice mode is active. Displays will show recommendations until combat starts, then track your accuracy.",
+                                    width = 2,
+                                    order = 2,
+                                },
+                            }
                         }
                     }
                 }
@@ -10088,6 +10129,12 @@ do
 
         elseif name == 'snapshot' then
             self:MakeSnapshot()
+            return
+
+        elseif name == 'practice' then
+            if ns.Practice then
+                ns.Practice:ToggleMode()
+            end
             return
 
         else

--- a/Practice.lua
+++ b/Practice.lua
@@ -1,0 +1,435 @@
+-- Practice.lua
+-- Practice mode functionality for Hekili
+
+local addon, ns = ...
+local Hekili = _G[ addon ]
+
+local RegisterEvent = ns.RegisterEvent
+local tableCopy = ns.tableCopy
+local GetSpellInfo = ns.GetUnpackedSpellInfo
+
+local LAST_COMMIT_TIMESTAMP = "2025-09-23 16:00:25"
+
+-- Practice Mode Module
+local Practice = {}
+ns.Practice = Practice
+
+-- Practice session data
+local practiceSession = {
+    active = false,
+    inCombat = false,
+    combatStart = 0,
+    combatEnd = 0,
+    expectedActions = {},
+    actualActions = {},
+    reportShown = false,
+    currentRecommendation = nil,
+    recommendations = {},
+    processedCasts = {},
+    unguidedCastTimes = {},
+}
+
+-- Configuration
+local function getPracticeConfig()
+    if not Hekili.DB or not Hekili.DB.profile then
+        return {
+            enabled = false,
+            showReport = true,
+            hideDisplaysInCombat = true,
+            trackAllAbilities = true,
+            accuracyThreshold = 2.0,
+            reportDuration = 10,
+        }
+    end
+
+    -- Ensure practice config exists
+    if not Hekili.DB.profile.practice then
+        Hekili.DB.profile.practice = {
+            enabled = false,
+            showReport = true,
+            hideDisplaysInCombat = true,
+            trackAllAbilities = true,
+            accuracyThreshold = 2.0,
+            reportDuration = 10,
+        }
+    end
+
+    return Hekili.DB.profile.practice
+end
+
+local function isPracticeEnabled()
+    if not Hekili.DB or not Hekili.DB.profile or not Hekili.DB.profile.toggles or not Hekili.DB.profile.toggles.practice then
+        return false
+    end
+    return Hekili.DB.profile.toggles.practice.value
+end
+
+-- Practice session management
+function Practice:StartSession()
+    practiceSession.active = true
+    practiceSession.inCombat = false
+    practiceSession.expectedActions = {}
+    practiceSession.actualActions = {}
+    practiceSession.recommendations = {}
+    practiceSession.reportShown = false
+    practiceSession.currentRecommendation = nil
+    table.wipe(practiceSession.processedCasts)
+    table.wipe(practiceSession.unguidedCastTimes)
+
+    -- Practice mode is controlled by toggle state
+
+    Hekili:Print("|cFF00FF00Practice Mode enabled.|r Recommendations will hide during combat.")
+
+    -- Also show prominent on-screen message
+    UIErrorsFrame:AddMessage(
+        "Practice Mode enabled",
+        0.0, 1.0, 0.0, -- Green color
+        1, -- UIErrorsFrame flags
+        3  -- Hold time
+    )
+end
+
+function Practice:EndSession()
+    if not practiceSession.active then return end
+
+    practiceSession.active = false
+    if practiceSession.inCombat then
+        self:ExitCombat()
+    end
+end
+
+function Practice:EnterCombat()
+    if not practiceSession.active then return end
+
+    practiceSession.inCombat = true
+    practiceSession.combatStart = GetTime()
+    practiceSession.combatEnd = 0
+    practiceSession.reportShown = false
+
+    -- Clear previous session data and start fresh for combat
+    table.wipe(practiceSession.expectedActions)
+    table.wipe(practiceSession.actualActions)
+    table.wipe(practiceSession.recommendations) -- Clear to start tracking during combat
+    practiceSession.currentRecommendation = nil
+    table.wipe(practiceSession.processedCasts)
+    table.wipe(practiceSession.unguidedCastTimes)
+
+end
+
+function Practice:ExitCombat()
+    if not practiceSession.active or not practiceSession.inCombat then return end
+
+    practiceSession.inCombat = false
+    practiceSession.combatEnd = GetTime()
+    practiceSession.currentRecommendation = nil
+
+
+    -- Calculate and show report
+    if getPracticeConfig().showReport then
+        self:ShowReport()
+    end
+end
+
+function Practice:TrackRecommendation(primary, secondary, time, actionKey)
+    if not practiceSession.active then return end
+
+    if not practiceSession.inCombat then return end
+
+    if not primary and not secondary and not actionKey then return end
+
+    local timestamp = time or GetTime()
+    local spellID, spellName
+
+    if type(primary) == "number" then
+        spellID = primary
+    elseif type(secondary) == "number" then
+        spellID = secondary
+    end
+
+    if type(primary) == "string" and not secondary then
+        spellName = GetSpellInfo(primary) or primary
+    elseif type(secondary) == "string" then
+        spellName = GetSpellInfo(secondary) or secondary
+    end
+
+    if not spellName and spellID then
+        spellName = GetSpellInfo(spellID)
+    end
+
+    if not spellName and type(actionKey) == "string" then
+        spellName = GetSpellInfo(actionKey) or actionKey
+    end
+
+    if not spellName then return end
+
+    local current = practiceSession.currentRecommendation
+    local sameSpell = current
+        and ((current.spellID and spellID and current.spellID == spellID)
+            or (current.spell and spellName and current.spell == spellName)
+            or (current.actionKey and actionKey and current.actionKey == actionKey))
+
+    if sameSpell then
+        current.time = timestamp
+        current.spellID = current.spellID or spellID
+        current.spell = current.spell or spellName
+        current.actionKey = current.actionKey or actionKey
+        return
+    end
+
+    practiceSession.currentRecommendation = {
+        spellID = spellID,
+        spell = spellName,
+        actionKey = actionKey,
+        time = timestamp,
+    }
+
+end
+
+function Practice:DebugHook()
+end
+
+-- Track player actions
+function Practice:TrackPlayerAction(spellID, castGUID, time)
+    if not practiceSession.active or not practiceSession.inCombat then return end
+
+    if castGUID and practiceSession.processedCasts[castGUID] then
+        return
+    end
+
+    local actionTime = time or GetTime()
+    local spellName = GetSpellInfo(spellID)
+
+    if not spellName then return end
+
+    if castGUID then
+        practiceSession.processedCasts[castGUID] = true
+    else
+        -- Fallback dedupe for casts without GUID (e.g., some pet/vehicle abilities)
+        local last = practiceSession.unguidedCastTimes[spellID]
+        if last and (actionTime - last) < 0.05 then
+            return
+        end
+        practiceSession.unguidedCastTimes[spellID] = actionTime
+    end
+
+    local current = practiceSession.currentRecommendation
+    if not current then
+        return
+    end
+
+    table.insert(practiceSession.actualActions, {
+        spell = spellName,
+        spellID = spellID,
+        time = actionTime,
+    })
+
+    local threshold = getPracticeConfig().accuracyThreshold or 2
+    local matched = false
+    local delta
+
+    local idMatch = current.spellID and current.spellID == spellID
+    local nameMatch = not current.spellID and current.spell == spellName
+    delta = actionTime - (current.time or actionTime)
+
+    if (idMatch or nameMatch) and math.abs(delta) <= threshold then
+        matched = true
+    end
+
+    local entry = {
+        expected = current.spell or current.actionKey,
+        expectedSpell = current.spell,
+        expectedSpellID = current.spellID,
+        expectedActionKey = current.actionKey,
+        expectedTime = current.time,
+        actualSpell = spellName,
+        actualSpellID = spellID,
+        actualTime = actionTime,
+        used = matched,
+        delta = delta,
+    }
+
+    entry.action = entry.expected or entry.actualSpell
+
+    table.insert(practiceSession.recommendations, entry)
+    practiceSession.currentRecommendation = nil
+end
+
+-- Calculate accuracy
+function Practice:CalculateAccuracy()
+    if #practiceSession.recommendations == 0 then return 0, 0, 0 end
+
+    local correct = 0
+    local total = #practiceSession.recommendations
+    local threshold = getPracticeConfig().accuracyThreshold
+
+    for _, rec in ipairs(practiceSession.recommendations) do
+        if rec.used then
+            correct = correct + 1
+        end
+    end
+
+    local accuracy = (correct / total) * 100
+    return accuracy, correct, total
+end
+
+-- Report display
+function Practice:ShowReport()
+    if practiceSession.reportShown then return end
+    practiceSession.reportShown = true
+
+    local accuracy, correct, total = self:CalculateAccuracy()
+    local combatDuration = practiceSession.combatEnd - practiceSession.combatStart
+
+    -- Create a detailed report
+    local accuracyColor = "|cFF00FF00" -- Green
+    if accuracy < 50 then
+        accuracyColor = "|cFFFF0000" -- Red
+    elseif accuracy < 80 then
+        accuracyColor = "|cFFFFAA00" -- Orange
+    end
+
+    local message = string.format(
+        "|cFFFFD100=== Practice Mode Report ===|r\n" ..
+        "|cFFFFFFFFCombat Duration:|r %.1fs\n" ..
+        "|cFFFFFFFFAccuracy:|r %s%.1f%%|r (%d/%d actions)\n" ..
+        "|cFFFFFFFFRecommendations Given:|r %d total\n" ..
+        "|cFFFFFFFFPlayer Actions:|r %d total\n" ..
+        "|cFFFFFFFFCommit Timestamp:|r %s",
+        combatDuration,
+        accuracyColor, accuracy, correct, total,
+        #practiceSession.recommendations,
+        #practiceSession.actualActions,
+        LAST_COMMIT_TIMESTAMP
+    )
+
+    -- Add performance rating
+    local rating = "Needs Practice"
+    if accuracy >= 90 then
+        rating = "|cFF00FF00Excellent!|r"
+    elseif accuracy >= 80 then
+        rating = "|cFF00AA00Good|r"
+    elseif accuracy >= 60 then
+        rating = "|cFFFFAA00Fair|r"
+    else
+        rating = "|cFFFF0000Needs Practice|r"
+    end
+
+    message = message .. "\n|cFFFFFFFFPerformance:|r " .. rating
+
+    -- Show detailed missed recommendations if accuracy is low
+    if accuracy < 80 and total > 0 then
+        local missed = {}
+        for _, rec in ipairs(practiceSession.recommendations) do
+            if not rec.used then
+                table.insert(missed, rec.action)
+            end
+        end
+
+        if #missed > 0 then
+            message = message .. "\n|cFFFFAAAAMissed Actions:|r " .. table.concat(missed, ", ", 1, math.min(5, #missed))
+            if #missed > 5 then
+                message = message .. " (+" .. (#missed - 5) .. " more)"
+            end
+        end
+    end
+
+    Hekili:Print(message)
+
+    -- Also show in UI error frame for better visibility
+    UIErrorsFrame:AddMessage(
+        string.format("Practice Mode: %.1f%% (%d/%d) | Commit: %s", accuracy, correct, total, LAST_COMMIT_TIMESTAMP),
+        1.0, 0.8, 0.0, -- Gold color
+        1, -- UIErrorsFrame flags
+        5  -- Hold time
+    )
+
+    -- Hide report after configured duration
+    local duration = getPracticeConfig().reportDuration or 10
+    C_Timer.After(duration, function()
+        -- Could add a way to hide the report if it was shown in a frame
+    end)
+end
+
+-- Check if displays should be hidden during combat
+function Practice:ShouldHideDisplays()
+    return practiceSession.active and
+           practiceSession.inCombat and
+           getPracticeConfig().hideDisplaysInCombat
+end
+
+-- Check if we should force recommendation generation
+function Practice:ShouldForceRecommendations()
+    return practiceSession.active and
+           practiceSession.inCombat and
+           isPracticeEnabled()
+end
+
+-- Integration with events
+RegisterEvent("PLAYER_REGEN_DISABLED", function()
+    Practice:EnterCombat()
+end)
+
+RegisterEvent("PLAYER_REGEN_ENABLED", function()
+    Practice:ExitCombat()
+end)
+
+RegisterEvent("UNIT_SPELLCAST_SUCCEEDED", function(event, unit, castGUID, spellID)
+    if unit == "player" then
+        Practice:TrackPlayerAction(spellID, castGUID)
+    end
+end)
+
+-- Toggle practice mode
+function Practice:ToggleMode()
+    -- Ensure toggle exists
+    if not Hekili.DB or not Hekili.DB.profile or not Hekili.DB.profile.toggles or not Hekili.DB.profile.toggles.practice then
+        Hekili:Print("|cFFFF0000[Practice] Toggle not available - DB not ready|r")
+        return
+    end
+
+    -- Toggle the setting first
+    Hekili.DB.profile.toggles.practice.value = not Hekili.DB.profile.toggles.practice.value
+
+    -- Then sync the session state to match the toggle
+    if Hekili.DB.profile.toggles.practice.value then
+        self:StartSession()
+    else
+        self:EndSession()
+        Hekili:Print("|cFFFFD100Practice Mode disabled.|r")
+
+        -- Also show prominent on-screen message
+        UIErrorsFrame:AddMessage(
+            "Practice Mode disabled",
+            1.0, 0.8, 0.0, -- Gold color
+            1, -- UIErrorsFrame flags
+            3  -- Hold time
+        )
+    end
+end
+
+-- Initialize when addon loads
+function Practice:Initialize()
+    -- Ensure configuration exists
+    getPracticeConfig()
+
+    Hekili:Print(string.format("[Practice] Last commit timestamp: %s", LAST_COMMIT_TIMESTAMP))
+
+    -- Check if practice mode should be auto-started based on toggle state
+    if isPracticeEnabled() then
+        -- Start practice mode if toggle is enabled
+        self:StartSession()
+    end
+end
+
+-- Access to session data for other modules
+function Practice:GetSessionData()
+    return practiceSession
+end
+
+function Practice:IsActive()
+    return practiceSession.active
+end
+
+function Practice:IsInCombat()
+    return practiceSession.inCombat
+end

--- a/UI.lua
+++ b/UI.lua
@@ -1679,6 +1679,13 @@ do
                 return
             end
 
+            if ns.Practice and ns.Practice:ShouldHideDisplays() then
+                self:SetAlpha( 0 )
+                self:Hide()
+                self.alpha = 0
+                return
+            end
+
             local preAlpha = self.alpha or 0
             local newAlpha = CalculateAlpha( self.id )
 
@@ -2190,6 +2197,10 @@ do
             specEnabled = false
         end
 
+        -- Check if practice mode should hide displays but force recommendations
+        local practiceForceRecs = ns.Practice and ns.Practice:ShouldForceRecommendations()
+        local practiceHideDisplays = ns.Practice and ns.Practice:ShouldHideDisplays()
+
         if profile.enabled and specEnabled then
             for i, display in pairs( profile.displays ) do
                 if display.enabled then
@@ -2212,6 +2223,18 @@ do
                     if dispActive[i] and displays[i] then
                         if not displays[i].Active then displays[i]:Activate() end
                         displays[i].NewRecommendations = true
+
+                        -- Hide display if practice mode requires it, but keep it active for recommendations
+                        if practiceHideDisplays then
+                            displays[i]:Hide()
+                        elseif displays[i]:IsShown() ~= true then
+                            displays[i]:Show()
+                        end
+                    elseif practiceForceRecs and displays[i] then
+                        -- Force activation for practice mode even if normally inactive
+                        if not displays[i].Active then displays[i]:Activate() end
+                        displays[i].NewRecommendations = true
+                        displays[i]:Hide() -- But keep it hidden
                     end
                 else
                     if displays[i] and displays[i].Active then


### PR DESCRIPTION
- [x] I confirm I am using the latest version of the addon (outdated versions may have problems that were fixed on the newest release).
- [x] I confirm I am playing on official Blizzard servers (not private servers).

- Integrated practice mode session lifecycle with per-combat resets so recommendation tracking starts clean on each pull.
- Refined counting logic to score only the active top recommendation, using cast GUID deduplication and short unguided windows to keep totals aligned with actual casts.
- Reinstated combat-time display hiding while keeping the recommendation engine running for accuracy tracking.
- 
<img width="698" height="432" alt="image" src="https://github.com/user-attachments/assets/a46ed0db-969d-4c1c-b4f6-dee32a24919b" />

<img width="255" height="120" alt="image" src="https://github.com/user-attachments/assets/88bf89b2-08ce-4159-b006-e87808d6c804" />

