### PR TITLE
Trinket Toggle

### DIFF
--- a/Events.lua
+++ b/Events.lua
@@ -748,6 +748,16 @@ do
         -- 3. Does it have an on-use?  (IsItemUsable)
         -- 4. ???
 
+        local function applyTrinketToggle( ability )
+            if not ability then return end
+
+            ability.isTrinket = true
+
+            if ability.toggle == nil or ability.toggle == "cooldowns" or ability.toggle == "default" then
+                ability.toggle = "trinkets"
+            end
+        end
+
         local T1 = GetInventoryItemID( "player", 13 )
 
         state.trinket.t1.__id = 0
@@ -777,6 +787,8 @@ do
 
                 local ability = class.abilities[ tSpell ]
 
+                applyTrinketToggle( ability )
+
                 state.trinket.t1.__has_use_damage = ability and ability.proc == "damage"
 
                 local aura = ability and class.auras[ ability.self_buff or spellID ]
@@ -798,6 +810,7 @@ do
             else
                 class.abilities.trinket1 = class.abilities.actual_trinket1
                 class.specs[ 0 ].abilities.trinket1 = class.abilities.actual_trinket1
+                applyTrinketToggle( class.abilities.trinket1 )
                 state.trinket.t1.cooldown = state.cooldown.null_cooldown
             end
 
@@ -833,6 +846,8 @@ do
 
                 local ability = class.abilities[ tSpell ]
 
+                applyTrinketToggle( ability )
+
                 state.trinket.t2.__has_use_damage = ability and ability.proc == "damage"
 
                 local aura = class.auras[ ability.self_buff or spellID ]
@@ -854,6 +869,7 @@ do
             else
                 class.abilities.trinket2 = class.abilities.actual_trinket2
                 class.specs[ 0 ].abilities.trinket2 = class.abilities.actual_trinket2
+                applyTrinketToggle( class.abilities.trinket2 )
                 state.trinket.t2.cooldown = state.cooldown.null_cooldown
             end
 

--- a/Events.lua
+++ b/Events.lua
@@ -752,6 +752,7 @@ do
             if not ability then return end
 
             ability.isTrinket = true
+            ability.cooldowns = true
 
             if ability.toggle == nil or ability.toggle == "cooldowns" or ability.toggle == "default" then
                 ability.toggle = "trinkets"

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -514,6 +514,12 @@ do
                         override = false,
                     },
 
+                    trinkets = {
+                        key = "",
+                        value = true,
+                        override = true,
+                    },
+
                     interrupts = {
                         key = "ALT-SHIFT-I",
                         value = true,
@@ -4156,6 +4162,7 @@ self:ForceUpdate( "SPEC_PACKAGE_CHANGED" )
                     toggles.essences = "Minor CDs"
                     toggles.defensives = "Defensives"
                     toggles.interrupts = "Interrupts"
+                    toggles.trinkets = "Trinkets"
                     toggles.potions = "Potions"
                     toggles.custom1 = "Custom 1"
                     toggles.custom2 = "Custom 2"
@@ -4291,6 +4298,7 @@ self:ForceUpdate( "SPEC_PACKAGE_CHANGED" )
                             toggles.essences = "Minor CDs"
                             toggles.defensives = "Defensives"
                             toggles.interrupts = "Interrupts"
+                            toggles.trinkets = "Trinkets"
                             toggles.potions = "Potions"
                             toggles.custom1 = "Custom 1"
                             toggles.custom2 = "Custom 2"
@@ -4575,6 +4583,7 @@ found = true end
                     toggles.essences = "Minor CDs"
                     toggles.defensives = "Defensives"
                     toggles.interrupts = "Interrupts"
+                    toggles.trinkets = "Trinkets"
                     toggles.potions = "Potions"
                     toggles.custom1 = "Custom 1"
                     toggles.custom2 = "Custom 2"
@@ -4691,6 +4700,7 @@ found = true end
                             toggles.essences = "Minor CDs"
                             toggles.defensives = "Defensives"
                             toggles.interrupts = "Interrupts"
+                            toggles.trinkets = "Trinkets"
                             toggles.potions = "Potions"
                             toggles.custom1 = "Custom 1"
                             toggles.custom2 = "Custom 2"
@@ -7789,6 +7799,51 @@ do
                             }
                         },
 
+                        trinkets = {
+                            type = "group",
+                            name = "",
+                            inline = true,
+                            order = 7.5,
+                            args = {
+                                key = {
+                                    type = "keybinding",
+                                    name = "Trinkets",
+                                    desc = "Set a key to toggle recommendations of on-use trinkets on or off.",
+                                    order = 1,
+                                },
+
+                                value = {
+                                    type = "toggle",
+                                    name = "Enable Trinkets",
+                                    desc = "If checked, on-use trinkets that require the |cFFFFD100Trinkets|r toggle can be recommended.",
+                                    width = 2,
+                                    order = 2,
+                                },
+
+                                trinketLineBreak = {
+                                    type = "description",
+                                    name = "",
+                                    width = "full",
+                                    order = 3.1,
+                                },
+
+                                trinketIndent = {
+                                    type = "description",
+                                    name = "",
+                                    width = 1,
+                                    order = 3.2,
+                                },
+
+                                override = {
+                                    type = "toggle",
+                                    name = "Auto-Enable when |cFFFFD100Major Cooldowns|r Active",
+                                    desc = "If checked, when |cFFFFD100Major Cooldowns|r are enabled (or auto-enabled), trinkets may be recommended even if the |cFFFFD100Trinkets|r toggle is unchecked.",
+                                    width = 2,
+                                    order = 4,
+                                },
+                            },
+                        },
+
                         funnel = {
                             type = "group",
                             name = "",
@@ -10026,6 +10081,9 @@ do
                 t[ k ] = name
             elseif k == "cooldowns" then
                 name = "Major Cooldowns"
+                t[ k ] = name
+            elseif k == "trinkets" then
+                name = "Trinkets"
                 t[ k ] = name
             end
 

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -517,7 +517,7 @@ do
                     trinkets = {
                         key = "",
                         value = true,
-                        override = false,
+                        override = true,
                     },
 
                     interrupts = {

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -517,7 +517,7 @@ do
                     trinkets = {
                         key = "",
                         value = true,
-                        override = true,
+                        override = false,
                     },
 
                     interrupts = {

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Other features include:
 - Toggle controls for cooldowns, defensives, interrupts, potions:
   - You can manually control whether major abilities like 2-minute cooldowns are used by enabling or disabling toggle options.
   - These toggles can be bound to hotkeys or macros, giving you flexible control on a fight-by-fight basis.
+  - A dedicated Trinkets toggle lets you decide whether the addon should recommend on-use trinkets or leave them for manual use.
   - Rather than using the toggles, you can display these abilities in a dedicated Cooldowns display, allowing you to cast them manually when timing is ideal.
   - This system is especially powerful when paired with encounter knowledge — for example, holding cooldowns for a burn phase or add wave can result in substantial DPS gains.
 - Compatible with **ElvUI**, **Bartender**, and other UI mods

--- a/State.lua
+++ b/State.lua
@@ -7554,6 +7554,10 @@ do
             local toggle = option.toggle
             if not toggle or toggle == "default" then toggle = ability.toggle end
 
+            if toggle == "trinkets" and profile.toggles.cooldowns.separate and state.filter ~= "cooldowns" then
+                return true, "display"
+            end
+
             if ( toggle == "potion" or toggle == "essences" ) and profile.toggles[ toggle ].separate and not profile.toggles[ toggle ].value then toggle = "cooldowns" end
 
             if toggle and toggle ~= "none" and ( not self.toggle[ toggle ] or ( profile.toggles[ toggle ].separate and state.filter ~= toggle ) ) then return true, format( "toggle %s", toggle ) end

--- a/State.lua
+++ b/State.lua
@@ -3014,6 +3014,7 @@ local mt_toggle = {
         if k == "cooldowns" and ( toggle.override and state.buff.bloodlust.up or toggle.infusion and state.buff.power_infusion.up ) then return true end
         if k == "essences" and toggle.override and state.toggle.cooldowns then return true end
         if k == "potions" and toggle.override and state.toggle.cooldowns then return true end
+        if k == "trinkets" and toggle.override and state.toggle.cooldowns then return true end
 
         if toggle then return toggle.value end
     end

--- a/UI.lua
+++ b/UI.lua
@@ -574,6 +574,12 @@ do
             text = "Potions",
             func = function() Hekili:FireToggle( "potions" ); ns.UI.Minimap:RefreshDataText() end,
             checked = function () return Hekili.DB.profile.toggles.potions.value end,
+        },
+
+        {
+            text = "Trinkets",
+            func = function() Hekili:FireToggle( "trinkets" ); ns.UI.Minimap:RefreshDataText() end,
+            checked = function () return Hekili.DB.profile.toggles.trinkets.value end,
         }
     }
 


### PR DESCRIPTION
  - Added a dedicated trinkets toggle (defaults, keybind UI, minimap entry) so players can flip on-use trinket recommendations on demand.
  - Flagged equipped trinket abilities as cooldowns while tying them to the new toggle, preserving integration with the existing cooldown logic.
  - Updated filtering so trinkets move to the separate cooldown display when that option’s on, fall back to the main queue when it’s off, and disappear entirely if the toggle is disabled.
  - Kept the “auto-enable with major cooldowns” checkbox working, matching the behaviour used by potions.
  - Mentioned the new toggle in the README for visibility.