### PR TITLE
Support Legion Remix Hard Mode Target Detection

### DIFF
--- a/Events.lua
+++ b/Events.lua
@@ -32,7 +32,7 @@ local GetSpellCooldown = function(spellID)
 end
 
 local GetSpellInfo = ns.GetUnpackedSpellInfo
-
+local TimerunningCheck = ns.TimerunningCheck
 local FindStringInInventoryItemTooltip = ns.FindStringInInventoryItemTooltip
 local ResetDisabledGearAndSpells = ns.ResetDisabledGearAndSpells
 local WipeCovenantCache = ns.WipeCovenantCache
@@ -1734,6 +1734,11 @@ local function CLEU_HANDLER( event, timestamp, subtype, hideCaster, sourceGUID, 
     local petSource = ( UnitExists( "pet" ) and sourceGUID == UnitGUID( "pet" ) )
     local amTarget  = ( destGUID   == state.GUID )
     local isSensePower = ( class.auras.sense_power_active and spellID == 361022 )
+
+    -- Check for Timerunning aura (1238465) on player
+    if ( amTarget or amSource ) and spellID == 1238465 and aura_events[ subtype ] then
+        TimerunningCheck()
+    end
 
     if not InCombatLockdown() and not ( amSource or petSource or amTarget ) then return end
 

--- a/Targets.lua
+++ b/Targets.lua
@@ -318,11 +318,31 @@ do
     RegisterEvent( "PLAYER_ENTERING_WORLD", CheckWarMode )
 end
 
+-- Timerunning Hardmode
+local timeRunningHwt = false
+
+do
+    local IsPlayerInTimerunningHeroicWorldTier = C_PlayerInfo.IsPlayerInTimerunningHeroicWorldTier
+
+    local function UpdateTimerunning()
+        timeRunningHwt = IsPlayerInTimerunningHeroicWorldTier()
+    end
+
+    local function TimerunningCheck()
+        timeRunningHwt = IsPlayerInTimerunningHeroicWorldTier()
+        C_Timer.After( 2, UpdateTimerunning )
+    end
+
+    ns.TimerunningCheck = TimerunningCheck
+
+    RegisterEvent( "PLAYER_ENTERING_WORLD", TimerunningCheck )
+end
 
 local function UnitInPhase( unit )
     local reason = UnitPhaseReason( unit )
     local wm = not IsInInstance() and warmode
 
+    if reason == 4 and IsPlayerInTimerunningHeroicWorldTier() then return true end
     if reason == 3 and chromieTime then return true end
     if reason == 2 and wm then return true end
     if reason == nil then return true end

--- a/Targets.lua
+++ b/Targets.lua
@@ -342,7 +342,7 @@ local function UnitInPhase( unit )
     local reason = UnitPhaseReason( unit )
     local wm = not IsInInstance() and warmode
 
-    if reason == 4 and IsPlayerInTimerunningHeroicWorldTier() then return true end
+    if reason == 4 and timeRunningHwt then return true end
     if reason == 3 and chromieTime then return true end
     if reason == 2 and wm then return true end
     if reason == nil then return true end


### PR DESCRIPTION
# Issue
11.2.5 added a new return option of `4` for `UnitPhaseReason(unit)`, and the addon would throw out any units with this return. But all mobs in Heroic World Tier (Hard mode) for legion remix return this new value.

# Solution
Support this return, by checking player world tier upon entering the world, and updating it anytime an aura event for `1238465` fires.


# Info

<img width="384" height="46" alt="image" src="https://github.com/user-attachments/assets/15d09f6d-49c4-4b2b-b218-35e729ce39c9" />

<img width="480" height="93" alt="image" src="https://github.com/user-attachments/assets/ab7d2df8-0c9a-4e76-aa6f-47cad94606f3" />


<img width="847" height="582" alt="image" src="https://github.com/user-attachments/assets/dda5fcc2-48ca-4027-9bd2-80e438567409" />
