### PR TITLE
Update Targets.lua

### DIFF
--- a/Targets.lua
+++ b/Targets.lua
@@ -218,6 +218,8 @@ local enemyExclusions = {
     [151579] = true,              -- Operation: Mechagon - Shield Generator
     [219588] = true,              -- Cinderbrew Meadery - Yes Man (etc.),
     [165913] = true,              -- Halls of Atonement: Ghastly Parishioner
+    [240905] = 1231726,           -- Manaforge Omega: Forgeweaver Araz - Arcane Collectord immunity during P1
+    [233817] = 1231726,           -- Manaforge Omega: Forgeweaver Araz - Forgeweaver Araz immunity during Intermission
     [237763] = 1228284,           -- Manaforge Omega: Nexus King Salad Bar - Royal Ward immunity
     [245705] = true               -- Manaforge Omega: Dimensius - Voidwarden (one should be focussed/cleaved down off miniboss, no reason to full AoE)
 }


### PR DESCRIPTION
### Summary  
Add a special case in **Targets.lua** for **Forgeweaver Araz (NPC 233817)** to correctly handle **Arcane Barrier (Spell 1231726)** and **Arcane Collector (NPC 240905)** interactions.

---

### Details  

- **NPCs / Spells**
  - **Forgeweaver Araz** — NPC ID **233817**  
    [https://www.wowhead.com/npc=233817/forgeweaver-araz](https://www.wowhead.com/npc=233817/forgeweaver-araz)
  - **Arcane Collector** — NPC ID **240905**  
    [https://www.wowhead.com/npc=240905/arcane-collector](https://www.wowhead.com/npc=240905/arcane-collector)
  - **Arcane Barrier** — Spell ID **1231726**  
    [https://www.wowhead.com/spell=1231726/arcane-barrier](https://www.wowhead.com/spell=1231726/arcane-barrier)

- **Behavioral Change**
  - Prevent targeting logic from misclassifying Araz when **Arcane Barrier (1231726)** is active.  
  - Exclude or handle **Arcane Collector (240905)** differently to avoid interference with add targeting.

---

### Motivation  
The default targeting logic breaks during **Araz’s Arcane Barrier**, causing incorrect target recommendations and inconsistent behavior.  
This update ensures accurate rotation logic and stable performance during the **Manaforge Omega – Araz** encounter.
