### PR TITLE
Legion Remix Abilities

### DIFF
--- a/Hekili.toc
+++ b/Hekili.toc
@@ -1,5 +1,5 @@
 ## Interface: 110200
-## Version: @project-version@
+## Version: v11.2.0-1.0.1h
 ## Title: Hekili
 ## Author: Hekili
 ## IconTexture: Interface\AddOns\Hekili\Textures\LOGO-ORANGE.blp
@@ -26,6 +26,7 @@ TheBurningCrusade\Items.lua
 Wrath\Items.lua
 Cataclysm\Items.lua
 Legion\Items.lua
+LegionRemix\ArtifactAbilities.lua
 
 BfA\AzeritePowers.lua
 BfA\Essences.lua

--- a/LegionRemix/ArtifactAbilities.lua
+++ b/LegionRemix/ArtifactAbilities.lua
@@ -1,0 +1,79 @@
+-- LegionRemix/ArtifactAbilities.lua
+
+local addon, ns = ...
+local Hekili = _G[ addon ]
+
+local class, state = Hekili.Class, Hekili.State
+local all = Hekili.Class.specs[ 0 ]
+
+
+all:RegisterAbilities( {
+	call_of_the_forest = {
+		id = 1233577,
+		cast = 0,
+		cooldown = 90,
+		gcd = "spell",
+
+		toggle = "cooldowns",
+
+		startsCombat = true,
+		texture = 4667415
+	},
+	twisted_crusade = {
+		id = 1237711,
+		cast = 0,
+		cooldown = 90,
+		gcd = "spell",
+
+		toggle = "cooldowns",
+
+		startsCombat = true,
+		texture = 1413862
+	},
+	narans_everdisc = {
+		id = 1233775,
+		cast = 0,
+		cooldown = 60,
+		gcd = "spell",
+
+		toggle = "cooldowns",
+
+		startsCombat = true,
+		texture = 6891023
+	},
+	tempest_wrath = {
+		id = 1233181,
+		cast = 0,
+		cooldown = 60,
+		gcd = "spell",
+
+		toggle = "cooldowns",
+
+		startsCombat = true,
+		texture = 839979
+	},
+	vindicators_judgement = {
+		id = 1251045,
+		cast = 0,
+		cooldown = 90,
+		gcd = "spell",
+
+		toggle = "cooldowns",
+
+		startsCombat = true,
+		texture = 1360764
+	},
+	remix_time = {
+		id = 1236723,
+		channeled = true,
+		cast = 3,
+		cooldown = 120,
+		gcd = "spell",
+
+		toggle = "cooldowns",
+
+		startsCombat = false,
+		texture = 5228749
+		
+	}
+} )


### PR DESCRIPTION
Add the Remix Time ability and the 5 artifact abilities in a new file and include that file in TOC (and apparantly mess up line endings).

This DOES NOT alter any rotations or action lists (I neither know the correct placement/APL for them, nor how to modify those in the addon), but merely registers the abilities to the addon for use in custom priorities.