### PR TITLE
Sub Rogue - Danse Macabre

### DIFF
--- a/TheWarWithin/RogueSubtlety.lua
+++ b/TheWarWithin/RogueSubtlety.lua
@@ -502,7 +502,6 @@ spec:RegisterCombatLogEvent( function( _, subtype, _, sourceGUID, sourceName, _,
 
         if spellID == 53 or spellID == 185438 then -- Backstab (53) or Shadowstrike (185438) consumes 1 Disorienting Strike stack.
             disorientStacks = disorientStacks - 1
-            return
         end
 
         if state.talent.danse_macabre.enabled then


### PR DESCRIPTION
This quick-return I added back in here https://github.com/Hekili/hekili/commit/96102ae36153d14b1a72158ea37b1d79392fb874#diff-5816be00651436f9ea52f4bc25e934a07c83d46ba5de21a8de228536498666feR505

I didn't realize this would prevent backstab from being counted in Danse Macabre. Fixes https://github.com/Hekili/hekili/issues/5350

@Hekili removed this line previously and I added it back, woops.